### PR TITLE
Add validated Apple Silicon DMG build

### DIFF
--- a/.github/workflows/artifact-validation.yml
+++ b/.github/workflows/artifact-validation.yml
@@ -175,6 +175,49 @@ jobs:
             outputs/Word.Hunter.Setup.exe
           if-no-files-found: error
 
+  macos:
+    name: macOS Apple Silicon DMG
+    needs: frontend-validation
+    runs-on: macos-15
+    timeout-minutes: 180
+    outputs:
+      version: ${{ steps.package-version.outputs.version }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+
+      - name: Set up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@4e529fb27e59237866a6523e61ab248308c068b4
+        with:
+          targets: aarch64-apple-darwin
+
+      - name: Install pinned Tauri CLI
+        run: cargo install tauri-cli --version 2.11.4 --locked
+
+      - name: Read package version
+        id: package-version
+        run: |
+          version="$(node -e "process.stdout.write(JSON.parse(require('node:fs').readFileSync('src-tauri/tauri.conf.json', 'utf8')).version)")"
+          test -n "$version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Build and smoke-test the Apple Silicon DMG
+        run: ./scripts/build-macos.sh
+
+      - name: Upload validated macOS DMG
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: validated-macos
+          path: outputs/WordHunter-${{ steps.package-version.outputs.version }}-aarch64.dmg
+          if-no-files-found: error
+
   flatpak:
     name: Flatpak bundle and installed file list
     needs: frontend-validation
@@ -428,7 +471,7 @@ jobs:
   publish-release:
     name: Attach validated artifacts to draft release
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag != '' }}
-    needs: [android, windows, flatpak, linux-native, linux-native-runtime]
+    needs: [android, windows, macos, flatpak, linux-native, linux-native-runtime]
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
@@ -445,12 +488,14 @@ jobs:
       - name: Require the complete release asset set
         env:
           LINUX_VERSION: ${{ needs.linux-native.outputs.version }}
+          MACOS_VERSION: ${{ needs.macos.outputs.version }}
         run: |
           for asset in \
             Word.Hunter.Pocket.debug.apk \
             Word.Hunter.Pocket.release.aab \
             Word.Hunter.portable.zip \
             Word.Hunter.Setup.exe \
+            WordHunter-${MACOS_VERSION}-aarch64.dmg \
             WordHunter.flatpak \
             WordHunter-${LINUX_VERSION}-x86_64.AppImage \
             word-hunter_${LINUX_VERSION}_amd64.deb; do
@@ -477,12 +522,14 @@ jobs:
           GH_REPO: ${{ github.repository }}
           RELEASE_TAG: ${{ inputs.release_tag }}
           LINUX_VERSION: ${{ needs.linux-native.outputs.version }}
+          MACOS_VERSION: ${{ needs.macos.outputs.version }}
         run: |
           gh release upload "$RELEASE_TAG" \
             release-assets/Word.Hunter.Pocket.debug.apk \
             release-assets/Word.Hunter.Pocket.release.aab \
             release-assets/Word.Hunter.portable.zip \
             release-assets/Word.Hunter.Setup.exe \
+            "release-assets/WordHunter-${MACOS_VERSION}-aarch64.dmg" \
             release-assets/WordHunter.flatpak \
             "release-assets/WordHunter-${LINUX_VERSION}-x86_64.AppImage" \
             "release-assets/word-hunter_${LINUX_VERSION}_amd64.deb" \

--- a/.github/workflows/artifact-validation.yml
+++ b/.github/workflows/artifact-validation.yml
@@ -72,6 +72,7 @@ jobs:
   android:
     name: Android APK and AAB
     needs: frontend-validation
+    if: ${{ !cancelled() && needs.frontend-validation.result == 'success' }}
     runs-on: windows-2022
     timeout-minutes: 120
 
@@ -128,6 +129,7 @@ jobs:
   windows:
     name: Windows portable ZIP and NSIS installer
     needs: frontend-validation
+    if: ${{ !cancelled() && needs.frontend-validation.result == 'success' }}
     runs-on: windows-2022
     timeout-minutes: 180
 
@@ -178,6 +180,7 @@ jobs:
   macos:
     name: macOS Apple Silicon DMG
     needs: frontend-validation
+    if: ${{ !cancelled() && needs.frontend-validation.result == 'success' }}
     runs-on: macos-15
     timeout-minutes: 180
     outputs:
@@ -221,6 +224,7 @@ jobs:
   flatpak:
     name: Flatpak bundle and installed file list
     needs: frontend-validation
+    if: ${{ !cancelled() && needs.frontend-validation.result == 'success' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 180
 

--- a/README.md
+++ b/README.md
@@ -100,12 +100,12 @@ Current stable release:
 
 Active targets:
 
-- Windows and Linux desktop: `Word Hunter`
+- Windows, Linux, and macOS desktop: `Word Hunter`
 - Android: `Word Hunter Pocket`
 
-Seven validated artifacts are published through GitHub Releases rather than
+Eight validated artifacts are published through GitHub Releases rather than
 tracked in the source tree: Windows setup and portable builds, Android APK and
-AAB, and Linux Flatpak, AppImage, and DEB packages.
+AAB, an Apple Silicon macOS DMG, and Linux Flatpak, AppImage, and DEB packages.
 
 Release `1.0.0` marks the new compatibility baseline after breaking storage and
 sync changes. It introduces durable per-record local storage, safer recovery and
@@ -291,9 +291,10 @@ shares a folder with a separately installed Syncthing client.
 
 - Windows desktop
 - Linux desktop
+- macOS desktop (Apple Silicon)
 - Android Pocket
 
-macOS and iOS are not active targets right now.
+Intel Macs and iOS are not active targets right now.
 
 ## Build From Source
 
@@ -305,6 +306,7 @@ macOS and iOS are not active targets right now.
 - Tauri 2 native prerequisites for the desktop platform being built.
 - PowerShell when using the bundled `scripts\build.bat` helper on Windows.
 - Android SDK, NDK, and JDK for Android Pocket builds.
+- Apple Silicon macOS for the DMG build.
 - Python 3 and `curl` when refreshing or checking Flatpak Cargo sources.
 - OCR runtime/model assets only when preparing desktop OCR support.
 
@@ -336,6 +338,17 @@ Tauri crate and OCR runner, and blocking `cargo clippy` checks by default.
 .\scripts\build.bat play         # build signed Google Play AAB
 .\scripts\build.bat ocr-runtime  # prepare bundled native PaddleOCR runtime
 ```
+
+On Apple Silicon macOS, build and validate the DMG with:
+
+```bash
+./scripts/build-macos.sh
+```
+
+It writes `outputs/WordHunter-<version>-aarch64.dmg`. The current recipe
+uses an ad-hoc signature, so macOS may require approval in Privacy & Security
+after download. A Developer ID certificate and notarization are still required
+for a warning-free public install.
 
 Rust backend tests can also be run directly:
 

--- a/docs/platform-layout.md
+++ b/docs/platform-layout.md
@@ -6,16 +6,17 @@ Active targets in this repository right now:
 
 - Windows desktop
 - Linux desktop
+- macOS desktop (Apple Silicon)
 - Android Pocket
 
-macOS and iOS are intentionally outside the current layout.
+Intel Macs and iOS are intentionally outside the current layout.
 
 ## Shared code
 
 - `src/web/` contains the shared HTML, TypeScript, i18n, flags, and base CSS.
 - `dist/web/` is the generated, untracked browser runtime embedded by Tauri.
 - `src-tauri/src/` contains shared Rust handlers, storage, SRS, tokenization, subtitles, and export logic.
-- `scripts/build.bat` is the shared build entrypoint for Windows desktop artifacts, Android APK/AAB builds, and frontend tests. Linux packages use `scripts/build-flatpak.sh`.
+- `scripts/build.bat` is the shared build entrypoint for Windows desktop artifacts, Android APK/AAB builds, and frontend tests. Linux packages use `scripts/build-flatpak.sh`; Apple Silicon DMGs use `scripts/build-macos.sh`.
 
 ## Web platform layers
 
@@ -25,7 +26,7 @@ macOS and iOS are intentionally outside the current layout.
 
 ## Native platform layers
 
-- `src-tauri/src/platform/web_app.rs` contains shared Windows/Linux desktop startup glue.
+- `src-tauri/src/platform/web_app.rs` contains shared Windows/Linux/macOS desktop startup glue.
 - `src-tauri/src/platform/android.rs` contains Android startup glue.
 - `src-tauri/platforms/android/MainActivity.kt` contains the Android WebView bridge, including the sync folder picker.
 - `src-tauri/platforms/android/AndroidManifest.xml` contains the Android manifest template copied into Tauri's generated project.
@@ -45,6 +46,7 @@ EPUB import uses the shared Rust ebook parser on every platform. MOBI/AZW still 
 
 - `src-tauri/tauri.conf.json` is the shared Tauri config.
 - `src-tauri/tauri.windows.conf.json` is Windows-specific.
+- `src-tauri/tauri.macos.conf.json` is the Apple Silicon DMG configuration.
 - `src-tauri/tauri.linux-bundle.conf.json` is passed explicitly by the Linux
   package script. Keeping it out of Tauri's automatic platform-config name
   prevents ordinary Rust tests from requiring package resources that are only

--- a/docs/release-validation.md
+++ b/docs/release-validation.md
@@ -44,6 +44,8 @@ dispatched. It rebuilds and validates:
 - x86_64 Windows portable ZIP and NSIS contents, native executables, OCR models,
   Syncthing notices, compiler runtime DLLs discovered by the build, and all
   legal reports;
+- the Apple Silicon macOS DMG, app bundle, arm64 executable, ad-hoc signature,
+  drag-to-Applications layout, and a launch smoke test;
 - the x86_64 Flatpak ref, installed file list, native ELF architecture, OCR
   models, Syncthing notices, desktop metadata, and legal reports;
 - x86_64 Linux AppImage and DEB installed file trees, native ELF architecture,
@@ -81,7 +83,7 @@ unstripped Word Hunter binaries are fixed by the recipe rather than overridden.
 
 The workflow always uploads validated files as workflow artifacts. A manual
 dispatch may additionally provide an existing draft `release_tag`; after every
-platform job succeeds, a final GitHub-hosted job attaches all seven validated
+platform job succeeds, a final GitHub-hosted job attaches all eight validated
 files to that draft. This keeps release binaries off the maintainer's local
 machine. The draft must target the exact commit selected for the workflow run.
 Scheduled runs do not attach or replace assets. Publishing the draft does not
@@ -178,9 +180,12 @@ instead of introducing formatting-only drift.
 Static tests validate recipes and policy, but they do not pretend to validate a
 binary that was not built. Windows PE/NSIS validation runs on Windows, Android
 Gradle compilation runs with the Android toolchain, and Flatpak OSTree file-list
-validation runs on Linux. AppImage and DEB validation also runs on Linux,
+validation runs on Linux. DMG validation runs on Apple Silicon macOS, mounts the
+image, verifies its ad-hoc signature and architecture, and launches the packaged
+application. AppImage and DEB validation also runs on Linux,
 extracts each completed package, and starts both GUI payloads under Xvfb on a
-clean runtime container. Installer launch
-behavior, WebView2 availability, Android device behavior, Google Play
+clean runtime container. Installer launch behavior, WebView2 availability,
+macOS Gatekeeper approval for the ad-hoc signature, Android device behavior,
+Google Play
 signing/acceptance, and interactive Flatpak/AppImage/DEB desktop integration
 remain platform or store tests and require release hardware/accounts.

--- a/frontend-tests/shared/repo-validation.test.js
+++ b/frontend-tests/shared/repo-validation.test.js
@@ -122,6 +122,7 @@ describe("repository validation wiring", () => {
       "frontend-validation",
       "linux-native",
       "linux-native-runtime",
+      "macos",
       "publish-release",
       "release-preflight",
       "windows",
@@ -148,13 +149,22 @@ describe("repository validation wiring", () => {
     assert.match(stepByName(workflow.jobs.windows, "Build frontend and Windows release packages").run, /build\.bat all/);
     assert.match(stepByName(workflow.jobs.windows, "Inspect Windows release packages").run, /windows-portable/);
     assert.match(stepByName(workflow.jobs.windows, "Inspect Windows release packages").run, /windows-nsis/);
+    assert.equal(workflow.jobs.macos["runs-on"], "macos-15");
+    assert.equal(
+      stepByName(workflow.jobs.macos, "Build and smoke-test the Apple Silicon DMG").run,
+      "./scripts/build-macos.sh",
+    );
+    assert.match(
+      stepByName(workflow.jobs.macos, "Upload validated macOS DMG").with.path,
+      /WordHunter-\$\{\{ steps\.package-version\.outputs\.version \}\}-aarch64\.dmg/,
+    );
     assert.equal(stepByName(workflow.jobs.flatpak, "Build frontend, then build and inspect Flatpak bundle").run, "./scripts/build-flatpak.sh");
     assert.match(
       stepByName(workflow.jobs["linux-native"], "Build frontend, AppImage, and DEB through the release recipe").run,
       /build-linux-native\.sh/,
     );
     assert.match(workflow.jobs["linux-native"].if, /frontend-validation\.result == 'success'/);
-    for (const name of ["android", "windows", "flatpak", "linux-native"]) {
+    for (const name of ["android", "windows", "macos", "flatpak", "linux-native"]) {
       const job = workflow.jobs[name];
       assert.equal(job.needs, "frontend-validation");
       const upload = job.steps.find((step) => step.uses?.startsWith("actions/upload-artifact@"));
@@ -193,7 +203,7 @@ describe("repository validation wiring", () => {
       /lintian[\s\S]*apt-get install[\s\S]*xvfb-run[\s\S]*apt-get remove/,
     );
     const publish = workflow.jobs["publish-release"];
-    assert.deepEqual(publish.needs, ["android", "windows", "flatpak", "linux-native", "linux-native-runtime"]);
+    assert.deepEqual(publish.needs, ["android", "windows", "macos", "flatpak", "linux-native", "linux-native-runtime"]);
     assert.equal(publish.permissions.contents, "write");
     assert.match(publish.if, /workflow_dispatch[\s\S]*release_tag/);
     const finalRevisionCheck = stepByName(publish, "Revalidate the draft release revision");
@@ -206,6 +216,21 @@ describe("repository validation wiring", () => {
     const attach = stepByName(publish, "Attach validated assets to the draft release");
     assert.equal(attach.env.GH_REPO, "${{ github.repository }}");
     assert.match(attach.run, /gh release upload[\s\S]*--clobber/);
+  });
+
+  it("keeps the macOS package native, ad-hoc signed, and artifact-validated", () => {
+    const config = JSON.parse(read("../../src-tauri/tauri.macos.conf.json"));
+    const buildScript = read("../../scripts/build-macos.sh");
+    const platform = read("../../src-tauri/src/platform/mod.rs");
+
+    assert.deepEqual(config.bundle.targets, ["dmg"]);
+    assert.equal(config.bundle.macOS.signingIdentity, "-");
+    assert.equal(config.bundle.macOS.minimumSystemVersion, "11.0");
+    assert.match(platform, /target_os = "macos"/);
+    assert.match(buildScript, /--target aarch64-apple-darwin/);
+    assert.match(buildScript, /hdiutil attach/);
+    assert.match(buildScript, /codesign --verify --deep --strict/);
+    assert.match(buildScript, /kill -0 "\$app_pid"/);
   });
 
   it("keeps the TypeScript build pinned, explicit, and outside source assets", () => {

--- a/frontend-tests/shared/repo-validation.test.js
+++ b/frontend-tests/shared/repo-validation.test.js
@@ -167,6 +167,7 @@ describe("repository validation wiring", () => {
     for (const name of ["android", "windows", "macos", "flatpak", "linux-native"]) {
       const job = workflow.jobs[name];
       assert.equal(job.needs, "frontend-validation");
+      assert.match(job.if, /frontend-validation\.result == 'success'/);
       const upload = job.steps.find((step) => step.uses?.startsWith("actions/upload-artifact@"));
       assert.ok(upload, `${job.name} does not upload its validated artifact`);
       assert.equal(upload.with["if-no-files-found"], "error");

--- a/frontend-tests/shared/repo-validation.test.js
+++ b/frontend-tests/shared/repo-validation.test.js
@@ -231,7 +231,7 @@ describe("repository validation wiring", () => {
     assert.match(buildScript, /--target aarch64-apple-darwin/);
     assert.match(buildScript, /hdiutil verify/);
     assert.match(buildScript, /for attempt in 1 2 3/);
-    assert.match(buildScript, /hdiutil attach -mountrandom \/tmp -readonly -noverify -noautoopen -nobrowse/);
+    assert.match(buildScript, /hdiutil attach -acceptlicense -mountrandom \/tmp -readonly -noverify -noautoopen -nobrowse/);
     assert.match(buildScript, /hdiutil detach "\$device"/);
     assert.match(buildScript, /codesign --verify --deep --strict/);
     assert.match(buildScript, /kill -0 "\$app_pid"/);

--- a/frontend-tests/shared/repo-validation.test.js
+++ b/frontend-tests/shared/repo-validation.test.js
@@ -225,13 +225,14 @@ describe("repository validation wiring", () => {
     const platform = read("../../src-tauri/src/platform/mod.rs");
 
     assert.deepEqual(config.bundle.targets, ["dmg"]);
+    assert.equal(config.bundle.licenseFile, null);
     assert.equal(config.bundle.macOS.signingIdentity, "-");
     assert.equal(config.bundle.macOS.minimumSystemVersion, "11.0");
     assert.match(platform, /target_os = "macos"/);
     assert.match(buildScript, /--target aarch64-apple-darwin/);
     assert.match(buildScript, /hdiutil verify/);
     assert.match(buildScript, /for attempt in 1 2 3/);
-    assert.match(buildScript, /hdiutil attach -acceptlicense -mountrandom \/tmp -readonly -noverify -noautoopen -nobrowse/);
+    assert.match(buildScript, /hdiutil attach -mountrandom \/tmp -readonly -noverify -noautoopen -nobrowse/);
     assert.match(buildScript, /hdiutil detach "\$device"/);
     assert.match(buildScript, /codesign --verify --deep --strict/);
     assert.match(buildScript, /kill -0 "\$app_pid"/);

--- a/frontend-tests/shared/repo-validation.test.js
+++ b/frontend-tests/shared/repo-validation.test.js
@@ -229,7 +229,9 @@ describe("repository validation wiring", () => {
     assert.equal(config.bundle.macOS.minimumSystemVersion, "11.0");
     assert.match(platform, /target_os = "macos"/);
     assert.match(buildScript, /--target aarch64-apple-darwin/);
-    assert.match(buildScript, /hdiutil attach/);
+    assert.match(buildScript, /hdiutil verify/);
+    assert.match(buildScript, /for attempt in 1 2 3/);
+    assert.match(buildScript, /hdiutil attach -nobrowse -readonly -noautoopen/);
     assert.match(buildScript, /codesign --verify --deep --strict/);
     assert.match(buildScript, /kill -0 "\$app_pid"/);
   });

--- a/frontend-tests/shared/repo-validation.test.js
+++ b/frontend-tests/shared/repo-validation.test.js
@@ -231,7 +231,8 @@ describe("repository validation wiring", () => {
     assert.match(buildScript, /--target aarch64-apple-darwin/);
     assert.match(buildScript, /hdiutil verify/);
     assert.match(buildScript, /for attempt in 1 2 3/);
-    assert.match(buildScript, /hdiutil attach -nobrowse -readonly -noautoopen/);
+    assert.match(buildScript, /hdiutil attach -mountrandom \/tmp -readonly -noverify -noautoopen -nobrowse/);
+    assert.match(buildScript, /hdiutil detach "\$device"/);
     assert.match(buildScript, /codesign --verify --deep --strict/);
     assert.match(buildScript, /kill -0 "\$app_pid"/);
   });

--- a/scripts/build-macos.sh
+++ b/scripts/build-macos.sh
@@ -49,7 +49,7 @@ trap cleanup EXIT
 
 hdiutil verify "$output" >/dev/null
 for attempt in 1 2 3; do
-  if attach_output="$(hdiutil attach -mountrandom /tmp -readonly -noverify -noautoopen -nobrowse "$output")"; then
+  if attach_output="$(hdiutil attach -acceptlicense -mountrandom /tmp -readonly -noverify -noautoopen -nobrowse "$output")"; then
     device="$(printf '%s\n' "$attach_output" | awk '/^\/dev\// { print $1; exit }')"
     break
   fi

--- a/scripts/build-macos.sh
+++ b/scripts/build-macos.sh
@@ -39,25 +39,25 @@ mkdir -p "$root/outputs"
 output="$root/outputs/WordHunter-${version}-aarch64.dmg"
 cp "${built_dmgs[0]}" "$output"
 
-mount_dir="$(mktemp -d)"
-attached=0
+device=""
 cleanup() {
-  if [[ "$attached" == "1" ]]; then
-    hdiutil detach "$mount_dir" -quiet || true
+  if [[ -n "$device" ]]; then
+    hdiutil detach "$device" -quiet || true
   fi
-  rmdir "$mount_dir" 2>/dev/null || true
 }
 trap cleanup EXIT
 
 hdiutil verify "$output" >/dev/null
 for attempt in 1 2 3; do
-  if hdiutil attach -nobrowse -readonly -noautoopen -mountpoint "$mount_dir" "$output" >/dev/null; then
-    attached=1
+  if attach_output="$(hdiutil attach -mountrandom /tmp -readonly -noverify -noautoopen -nobrowse "$output")"; then
+    device="$(printf '%s\n' "$attach_output" | awk '/^\/dev\// { print $1; exit }')"
     break
   fi
   sleep 2
 done
-[[ "$attached" == "1" ]] || die "failed to mount the completed DMG after 3 attempts"
+[[ -n "$device" ]] || die "failed to mount the completed DMG after 3 attempts"
+mount_dir="$(hdiutil info | awk -v device="$device" 'index($1, device) == 1 && NF >= 3 { mount = $3 } END { print mount }')"
+[[ -n "$mount_dir" ]] || die "mounted DMG does not expose a volume path"
 
 app="$mount_dir/Word Hunter.app"
 binary="$app/Contents/MacOS/word-hunter-rustified"

--- a/scripts/build-macos.sh
+++ b/scripts/build-macos.sh
@@ -49,7 +49,7 @@ trap cleanup EXIT
 
 hdiutil verify "$output" >/dev/null
 for attempt in 1 2 3; do
-  if attach_output="$(hdiutil attach -acceptlicense -mountrandom /tmp -readonly -noverify -noautoopen -nobrowse "$output")"; then
+  if attach_output="$(hdiutil attach -mountrandom /tmp -readonly -noverify -noautoopen -nobrowse "$output")"; then
     device="$(printf '%s\n' "$attach_output" | awk '/^\/dev\// { print $1; exit }')"
     break
   fi

--- a/scripts/build-macos.sh
+++ b/scripts/build-macos.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$root"
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+for command_name in cargo codesign file hdiutil npm node; do
+  command -v "$command_name" >/dev/null 2>&1 || die "$command_name is required"
+done
+
+[[ "$(uname -s)" == "Darwin" ]] || die "the macOS DMG must be built on macOS"
+[[ "$(uname -m)" == "arm64" ]] || die "the current DMG recipe targets Apple Silicon"
+
+version="$(node -e 'const fs = require("fs"); const c = JSON.parse(fs.readFileSync("src-tauri/tauri.conf.json", "utf8")); if (!/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(c.version)) process.exit(1); process.stdout.write(c.version);')" \
+  || die "src-tauri/tauri.conf.json does not contain a valid package version"
+
+if [[ ! -d node_modules ]]; then
+  npm ci --ignore-scripts --no-audit --no-fund
+fi
+npm run build:frontend
+
+cargo tauri build \
+  --bundles dmg \
+  --target aarch64-apple-darwin \
+  --config "$root/src-tauri/tauri.macos.conf.json"
+
+bundle_dir="$root/src-tauri/target/aarch64-apple-darwin/release/bundle/dmg"
+shopt -s nullglob
+built_dmgs=("$bundle_dir"/*.dmg)
+shopt -u nullglob
+[[ ${#built_dmgs[@]} -eq 1 ]] || die "expected exactly one DMG in $bundle_dir, found ${#built_dmgs[@]}"
+
+mkdir -p "$root/outputs"
+output="$root/outputs/WordHunter-${version}-aarch64.dmg"
+cp "${built_dmgs[0]}" "$output"
+
+mount_dir="$(mktemp -d)"
+attached=0
+cleanup() {
+  if [[ "$attached" == "1" ]]; then
+    hdiutil detach "$mount_dir" -quiet || true
+  fi
+  rmdir "$mount_dir" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+hdiutil attach "$output" -nobrowse -readonly -mountpoint "$mount_dir" >/dev/null
+attached=1
+
+app="$mount_dir/Word Hunter.app"
+binary="$app/Contents/MacOS/word-hunter-rustified"
+[[ -d "$app" ]] || die "DMG does not contain Word Hunter.app"
+[[ -L "$mount_dir/Applications" ]] || die "DMG does not contain the Applications shortcut"
+[[ -x "$binary" ]] || die "app bundle does not contain its executable"
+[[ "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$app/Contents/Info.plist")" == "com.wordhunter.app" ]] \
+  || die "app bundle identifier is incorrect"
+file "$binary" | grep -q 'arm64' || die "app executable is not arm64"
+codesign --verify --deep --strict "$app"
+
+log_file="$(mktemp)"
+"$binary" >"$log_file" 2>&1 &
+app_pid=$!
+for _ in {1..5}; do
+  sleep 1
+  if ! kill -0 "$app_pid" 2>/dev/null; then
+    cat "$log_file" >&2
+    die "packaged application exited during the smoke test"
+  fi
+done
+kill "$app_pid"
+wait "$app_pid" 2>/dev/null || true
+rm -f "$log_file"
+
+echo "Validated macOS DMG: $output"

--- a/scripts/build-macos.sh
+++ b/scripts/build-macos.sh
@@ -49,8 +49,15 @@ cleanup() {
 }
 trap cleanup EXIT
 
-hdiutil attach "$output" -nobrowse -readonly -mountpoint "$mount_dir" >/dev/null
-attached=1
+hdiutil verify "$output" >/dev/null
+for attempt in 1 2 3; do
+  if hdiutil attach -nobrowse -readonly -noautoopen -mountpoint "$mount_dir" "$output" >/dev/null; then
+    attached=1
+    break
+  fi
+  sleep 2
+done
+[[ "$attached" == "1" ]] || die "failed to mount the completed DMG after 3 attempts"
 
 app="$mount_dir/Word Hunter.app"
 binary="$app/Contents/MacOS/word-hunter-rustified"

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -5,14 +5,12 @@ use std::path::Path;
 
 #[cfg(target_os = "android")]
 mod android;
-#[cfg(target_os = "macos")]
-compile_error!("macOS is not a supported WordHunter target right now.");
 
 type SetupResult = Result<(), Box<dyn std::error::Error>>;
 
 #[cfg(target_os = "android")]
 pub(crate) use android::setup;
-#[cfg(any(target_os = "linux", target_os = "windows"))]
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 pub(crate) use web_app::setup_desktop as setup;
 
 #[cfg(not(target_os = "android"))]

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "./gen/schemas/desktop-schema.json",
+  "bundle": {
+    "targets": ["dmg"],
+    "category": "Education",
+    "copyright": "Copyright © 2026 Word Hunter contributors",
+    "shortDescription": "Local-first reader and vocabulary trainer",
+    "longDescription": "Read real texts, save vocabulary with its original context, and review it with spaced repetition.",
+    "macOS": {
+      "minimumSystemVersion": "11.0",
+      "signingIdentity": "-",
+      "dmg": {
+        "windowSize": {
+          "width": 660,
+          "height": 400
+        },
+        "appPosition": {
+          "x": 180,
+          "y": 220
+        },
+        "applicationFolderPosition": {
+          "x": 480,
+          "y": 220
+        }
+      }
+    }
+  }
+}

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -2,6 +2,7 @@
   "$schema": "./gen/schemas/desktop-schema.json",
   "bundle": {
     "targets": ["dmg"],
+    "licenseFile": null,
     "category": "Education",
     "copyright": "Copyright © 2026 Word Hunter contributors",
     "shortDescription": "Local-first reader and vocabulary trainer",


### PR DESCRIPTION
## What changed

- enables the shared desktop startup path on macOS
- adds an Apple Silicon Tauri DMG configuration and reproducible build script
- mounts, inspects, verifies, and smoke-tests the generated app bundle
- adds the DMG to nightly/manual artifact validation and draft-release uploads
- documents the Apple Silicon target and the current ad-hoc-signing limitation

## Why

Word Hunter explicitly rejected macOS at compile time and had no DMG recipe or macOS CI coverage. This establishes the smallest native macOS target using the existing shared desktop code.

## Checks

- `npm run test:frontend` — 349/349 passed
- `node scripts/validate-json-i18n.mjs` — 20 JSON files and 9 locales passed
- `bash -n scripts/build-macos.sh`
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- local Rust build reached the application build script but could not complete because the clean Windows checkout lacks the existing staged `syncthing/SYNCTHING-LICENSE.txt` resource
- native Apple Silicon build, DMG checksum, mount/layout inspection, arm64 check, ad-hoc signature verification, launch smoke test, and artifact upload passed in [Release artifact validation run 29644804395](https://github.com/Ironship/WordHunter/actions/runs/29644804395)
- downloaded `WordHunter-1.0.6-aarch64.dmg` SHA-256: `098CBFE37E03311AE64EF37ED77F389671CB237FE35CB1C98E32957C6681731D`