### PR TITLE
Keep Reader selection visible

### DIFF
--- a/frontend-tests/android/pocket-bridges.test.js
+++ b/frontend-tests/android/pocket-bridges.test.js
@@ -71,11 +71,15 @@ describe("Android Pocket bridges", () => {
       }
     };
     const tokenClasses = [new Set(), new Set(), new Set()];
-    const tokens = [
-      { textContent: "Hallo", dataset: {}, classList: { add: (name) => tokenClasses[0].add(name), remove: (name) => tokenClasses[0].delete(name) } },
-      { textContent: "Welt", dataset: {}, classList: { add: (name) => tokenClasses[1].add(name), remove: (name) => tokenClasses[1].delete(name) } },
-      { textContent: "Welt", dataset: {}, classList: { add: (name) => tokenClasses[2].add(name), remove: (name) => tokenClasses[2].delete(name) } }
-    ];
+    const scrolls = [];
+    let container;
+    const tokens = ["Hallo", "Welt", "Welt"].map((textContent, index) => ({
+      textContent,
+      dataset: {},
+      classList: { add: (name) => tokenClasses[index].add(name), remove: (name) => tokenClasses[index].delete(name) },
+      closest: () => container,
+      getBoundingClientRect: () => ({ top: 20 + index * 120, bottom: 40 + index * 120, height: 20 })
+    }));
     globalThis.localStorage = { getItem: () => null, setItem: () => {} };
     globalThis.document = {
       querySelectorAll(selector) {
@@ -91,7 +95,16 @@ describe("Android Pocket bridges", () => {
 
     const { speakText } = await import("../../dist/web/js/tts.js");
     let finished = false;
-    const container = { classList: { add() {} }, querySelectorAll: () => tokens };
+    container = {
+      classList: { add() {} },
+      querySelectorAll: () => tokens,
+      contains: (token) => tokens.includes(token),
+      clientHeight: 100,
+      scrollHeight: 500,
+      scrollTop: 0,
+      getBoundingClientRect: () => ({ top: 0, bottom: 100, height: 100 }),
+      scrollTo(options) { scrolls.push(options); this.scrollTop = options.top; }
+    };
     speakText("Hallo. Welt.", container, () => { finished = true; });
 
     assert.equal(calls.length, 1);
@@ -109,6 +122,7 @@ describe("Android Pocket bridges", () => {
     listeners["wordhunter:android-tts"]({ detail: { id: calls[1].id, status: "range", start: 0, end: 4 } });
     assert.equal(tokenClasses[0].has("tts-current-word"), false);
     assert.equal(tokenClasses[1].has("tts-current-word"), true);
+    assert.deepEqual(scrolls, [{ top: 100, behavior: "auto" }]);
 
     listeners["wordhunter:android-tts"]({ detail: { id: calls[1].id, status: "done" } });
     assert.equal(finished, true);

--- a/frontend-tests/shared/focused-regressions.test.js
+++ b/frontend-tests/shared/focused-regressions.test.js
@@ -346,6 +346,41 @@ describe("focused frontend regressions", () => {
     assert.match(vocabActions, /focusWordIndex = String\(state\.selectedWordIndex\)/);
   });
 
+  it("follows the exact selected Reader occurrence", async () => {
+    const first = { dataset: { word: "beta", wordIndex: "3" }, classList: classList() };
+    const selected = { dataset: { word: "beta", wordIndex: "17" }, classList: classList() };
+    const followed = [];
+    const readerText = {
+      childNodes: [],
+      querySelector: () => null,
+      querySelectorAll: () => [first, selected]
+    };
+    const state = {
+      currentTextId: "book-1",
+      readerSelectionRange: null,
+      selectedWord: "beta",
+      selectedWordIndex: 17
+    };
+    const selection = await evaluateWithMocks("dist/web/js/reader/selection.js", {
+      "../state.js": { state, saveUiState() {} },
+      "../dom.js": { els: { readerText } },
+      "../tokenizer_v2.js": { normalizeWord: (word) => word },
+      "./renderer.js": { getTextById: () => ({ id: "book-1" }) },
+      "./word-panel.js": { renderWordPanel() {} },
+      "./visibility.js": { keepReaderTokenVisible: (token) => followed.push(token) },
+      "../views/shell.js": { renderShell() {} }
+    }, {
+      Node: { TEXT_NODE: 3 },
+      HTMLElement: class {}
+    });
+
+    selection.updateReaderSelection();
+
+    assert.equal(first.classList.contains("selected"), true);
+    assert.equal(selected.classList.contains("selected"), true);
+    assert.deepEqual(followed, [selected]);
+  });
+
   it("selects the next word immediately while a ghost card animates out", async () => {
     class FakeElement {
       constructor(classes = []) {

--- a/frontend-tests/shared/render-performance.test.js
+++ b/frontend-tests/shared/render-performance.test.js
@@ -59,6 +59,42 @@ async function evaluateWithMocks(file, importValues, globals = {}, dynamicImport
 }
 
 describe("render performance guards", () => {
+  it("keeps a Reader token above the open Pocket word sheet", async () => {
+    const scrolls = [];
+    const container = {
+      clientHeight: 500,
+      scrollHeight: 1500,
+      scrollTop: 100,
+      contains: (element) => element === token,
+      getBoundingClientRect: () => ({ top: 100, bottom: 600, height: 500 }),
+      scrollTo(options) {
+        scrolls.push(options);
+        this.scrollTop = options.top;
+      }
+    };
+    const token = {
+      closest: () => container,
+      getBoundingClientRect: () => ({ top: 450, bottom: 470, height: 20 })
+    };
+    const panel = { getBoundingClientRect: () => ({ top: 400, bottom: 700, height: 300 }) };
+    const classes = new Set(["pocket-mode", "pocket-word-panel-open"]);
+    const document = {
+      documentElement: { classList: { contains: (name) => classes.has(name) } },
+      getElementById: () => container,
+      querySelector: () => panel
+    };
+    const { keepReaderTokenVisible } = await evaluateWithMocks("../../dist/web/js/reader/visibility.js", {}, { document });
+
+    assert.equal(keepReaderTokenVisible(token), true);
+    assert.equal(scrolls.length, 1);
+    assert.equal(scrolls[0].top, 310);
+    assert.equal(scrolls[0].behavior, "auto");
+
+    token.getBoundingClientRect = () => ({ top: 220, bottom: 240, height: 20 });
+    assert.equal(keepReaderTokenVisible(token), false);
+    assert.equal(scrolls.length, 1);
+  });
+
   it("persists imprecise reader scrolls without hit-testing the document", async () => {
     let elementFromPointCalls = 0;
     let persistedWrites = 0;

--- a/src/web/js/reader/selection.ts
+++ b/src/web/js/reader/selection.ts
@@ -6,6 +6,7 @@ import { els } from "../dom.js";
 import { normalizeWord } from "../tokenizer_v2.js";
 import { getTextById } from "./renderer.js";
 import { renderWordPanel } from "./word-panel.js";
+import { keepReaderTokenVisible } from "./visibility.js";
 import { renderShell } from "../views/shell.js";
 
 interface ReaderRangeBounds {
@@ -160,6 +161,10 @@ export function updateReaderSelection(options: UpdateReaderSelectionOptions = {}
       token.classList.remove("selected");
     }
   });
+  const activeToken = useRange
+    ? tokens[rangeBounds.focus]
+    : tokens.find((token) => Number(token.dataset.wordIndex) === state.selectedWordIndex);
+  keepReaderTokenVisible(activeToken);
 
   const sentenceButton = (els.readerText as HTMLElement).querySelector<HTMLButtonElement>("[data-pdf-correct-sentence]");
   if (sentenceButton) {

--- a/src/web/js/reader/visibility.ts
+++ b/src/web/js/reader/visibility.ts
@@ -1,0 +1,38 @@
+const TOKEN_EDGE_MARGIN = 12;
+
+function elementRect(element: Element | null | undefined): DOMRect | null {
+  return element && typeof element.getBoundingClientRect === "function"
+    ? element.getBoundingClientRect()
+    : null;
+}
+
+export function keepReaderTokenVisible(token: Element | null | undefined): boolean {
+  if (!token) return false;
+  const container = (token.closest?.("#reader-text") || document.getElementById?.("reader-text")) as HTMLElement | null;
+  if (!container?.contains?.(token)) return false;
+
+  const tokenRect = elementRect(token);
+  const containerRect = elementRect(container);
+  if (!tokenRect || !containerRect || containerRect.height <= 0) return false;
+
+  let visibleBottom = containerRect.bottom;
+  const rootClasses = document.documentElement?.classList;
+  if (rootClasses?.contains("pocket-mode") && rootClasses.contains("pocket-word-panel-open")) {
+    const panelRect = elementRect(document.querySelector?.("#reader-view .reader-sidebar-wrapper"));
+    if (panelRect && panelRect.top > containerRect.top && panelRect.top < visibleBottom) {
+      visibleBottom = panelRect.top;
+    }
+  }
+
+  const visibleTop = containerRect.top;
+  if (tokenRect.top >= visibleTop + TOKEN_EDGE_MARGIN
+    && tokenRect.bottom <= visibleBottom - TOKEN_EDGE_MARGIN) return false;
+
+  const visibleHeight = Math.max(1, visibleBottom - visibleTop);
+  const tokenCenter = tokenRect.top - containerRect.top + container.scrollTop + tokenRect.height / 2;
+  const maxScroll = Math.max(0, container.scrollHeight - container.clientHeight);
+  const top = Math.max(0, Math.min(maxScroll, Math.round(tokenCenter - visibleHeight / 2)));
+  if (typeof container.scrollTo === "function") container.scrollTo({ top, behavior: "auto" });
+  else container.scrollTop = top;
+  return true;
+}

--- a/src/web/js/tts.ts
+++ b/src/web/js/tts.ts
@@ -1,6 +1,7 @@
 import { state } from "./state.js";
 import { normalizeWord } from "./tokenizer_v2.js";
 import { effectiveLearningLanguage } from "./translator-preferences.js";
+import { keepReaderTokenVisible } from "./reader/visibility.js";
 
 let speaking = false;
 let currentAudio: HTMLAudioElement | null = null;
@@ -469,7 +470,10 @@ function setCurrentTtsWordToken(token: Element): void {
   if (currentTtsWordToken === token) return;
   if (currentTtsWordToken) currentTtsWordToken.classList.remove(TTS_WORD_CLASS);
   currentTtsWordToken = token;
-  if (currentTtsWordToken) currentTtsWordToken.classList.add(TTS_WORD_CLASS);
+  if (currentTtsWordToken) {
+    currentTtsWordToken.classList.add(TTS_WORD_CLASS);
+    keepReaderTokenVisible(currentTtsWordToken);
+  }
 }
 
 function findTtsTokenStart(tokens: TtsWordTracker["tokens"], words: string[]): number {


### PR DESCRIPTION
## What changed

- keeps the exact selected Reader token inside the visible scroll area
- treats the open Pocket word sheet as the bottom edge of the readable viewport
- follows per-word TTS highlighting on both desktop and Pocket
- covers repeated-word selection, Pocket overlay visibility, and Android TTS scrolling with regressions

## Checks

- `npm run test:frontend` — 351/351 passed
- `node scripts/validate-json-i18n.mjs` — 20 JSON files and 9 locales passed
- `git diff --check`

Fixes #65