### PR TITLE
Restore the last Reader location

### DIFF
--- a/frontend-tests/shared/persistence-lifecycle.test.js
+++ b/frontend-tests/shared/persistence-lifecycle.test.js
@@ -317,6 +317,56 @@ describe("persistence lifecycle", () => {
     assert.equal(autosave.getDurableStateRevision(), 1);
   });
 
+  it("writes an explicit bridge UI save to the local UI cache", async () => {
+    const saved = [];
+    let durableSaves = 0;
+    const rawState = {
+      currentView: "reader",
+      currentTextId: "book",
+      readerPage: 4,
+      readerPages: { book: 4 },
+      vocab: {}
+    };
+    const autosave = {
+      wrap: (value) => value,
+      saveState() { durableSaves += 1; return Promise.resolve(); },
+      getDurableStateRevision: () => 0,
+      runExclusiveWrite: (callback) => callback(),
+      markDurableStateReplaced() {},
+      flushPendingSave() {},
+      withoutAutoSave: (callback) => callback()
+    };
+    const noOp = () => {};
+    const stateModule = await evaluateWithMocks("../../dist/web/js/state.js", {
+      "./state/autosave.js": { createAutosave: () => autosave },
+      "./state/defaults.js": {
+        createDefaultState: () => rawState,
+        getDefaultDictionaryUrl: () => "",
+        normalizeAnkiExportStatuses: noOp,
+        normalizeVocabStatusFilters: noOp
+      },
+      "./state/normalize.js": {
+        assertSupportedStateSchemaVersion: noOp,
+        loadState: () => rawState,
+        normalizeState: (value) => value
+      },
+      "./state/ui-cache.js": {
+        captureUiState: (value) => value,
+        saveUiStateCache: (value) => saved.push(value),
+        UI_STATE_KEYS: []
+      },
+      "./constants.js": { OTHER_PROFILE_ID: "other", STATE_SCHEMA_VERSION: 2 }
+    }, {
+      window: { __qtBridge: true },
+      console
+    });
+
+    await stateModule.saveUiState();
+
+    assert.equal(durableSaves, 0);
+    assert.deepEqual(saved, [rawState]);
+  });
+
   it("queues autosaves behind an exclusive state write", async () => {
     const savedThemes = [];
     let synchronousWrites = 0;
@@ -542,7 +592,7 @@ describe("persistence lifecycle", () => {
         resetInitialVocabKeys: () => downstreamCalls.push("resetInitialVocabKeys"),
         clearLastReadTextForLanguage: () => downstreamCalls.push("clearLastReadTextForLanguage")
       },
-      "./constants.js": { STORAGE_KEY: "wordhunter-state" },
+      "./constants.js": { STORAGE_KEY: "wordhunter-state", UI_STORAGE_KEY: "wordhunter-ui-state" },
       "./api.js": { buildSavePayload: (value) => value },
       "./toast.js": { showToast: (message) => toasts.push(message) },
       "./i18n.js": { t: (key) => key },

--- a/frontend-tests/shared/profile-save.test.js
+++ b/frontend-tests/shared/profile-save.test.js
@@ -2,9 +2,10 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
 const { buildSavePayload, saveToLocalStorage } = await import("../../dist/web/js/api.js");
-const { STATE_SCHEMA_VERSION, STORAGE_KEY } = await import("../../dist/web/js/constants.js");
+const { STATE_SCHEMA_VERSION, STORAGE_KEY, UI_STORAGE_KEY } = await import("../../dist/web/js/constants.js");
 const { createDefaultState } = await import("../../dist/web/js/state/defaults.js");
 const { loadState, normalizeState } = await import("../../dist/web/js/state/normalize.js");
+const { loadUiStateCache, saveUiStateCache } = await import("../../dist/web/js/state/ui-cache.js");
 
 describe("profile save payload", () => {
   it("keeps books, texts, and vocabulary from every language profile", () => {
@@ -104,6 +105,34 @@ describe("profile save payload", () => {
 
     assert.equal(storedKey, STORAGE_KEY);
     assert.equal(JSON.parse(storedValue).schemaVersion, STATE_SCHEMA_VERSION);
+  });
+
+  it("stores only local Reader UI in the bridge-side cache", () => {
+    const stored = new Map();
+    globalThis.localStorage = {
+      getItem: (key) => stored.get(key) || null,
+      setItem: (key, value) => stored.set(key, value),
+      removeItem: (key) => stored.delete(key)
+    };
+
+    saveUiStateCache({
+      currentView: "reader",
+      currentTextId: "de-book-1",
+      readerPage: 7,
+      readerPages: { "de-book-1": 7 },
+      readerScrolls: { "de-book-1": { readerPage: 7, scrollTop: 240 } },
+      preferences: { learningLanguage: "de", theme: "classic-dark" },
+      vocab: { geheim: { status: "known" } }
+    });
+
+    const serialized = JSON.parse(stored.get(UI_STORAGE_KEY));
+    const restored = loadUiStateCache();
+    assert.equal(serialized.schemaVersion, STATE_SCHEMA_VERSION);
+    assert.equal(restored.currentTextId, "de-book-1");
+    assert.equal(restored.readerPage, 7);
+    assert.deepEqual(restored.readerPages, { "de-book-1": 7 });
+    assert.equal(restored.preferences, undefined);
+    assert.equal(restored.vocab, undefined);
   });
 
   it("does not throw when localStorage quota rejects a cache write", () => {
@@ -376,10 +405,73 @@ describe("profile save payload", () => {
     assert.throws(() => loadState(), /schema version/);
   });
 
+  it("restores the last local Reader page on top of a bridge snapshot", () => {
+    globalThis.localStorage = {
+      getItem(key) {
+        if (key !== UI_STORAGE_KEY) return null;
+        return JSON.stringify({
+          schemaVersion: STATE_SCHEMA_VERSION,
+          currentView: "reader",
+          currentTextId: "de-custom-session",
+          readerPage: 5,
+          readerPages: { "de-custom-session": 5 },
+          readerScrolls: { "de-custom-session": { readerPage: 5, scrollTop: 180 } },
+          preferences: { theme: "stale-theme" }
+        });
+      },
+      setItem() {},
+      removeItem() {}
+    };
+    globalThis.window = {
+      __qtBridge: true,
+      __bridgeState: {
+        schemaVersion: STATE_SCHEMA_VERSION,
+        prefs: { learningLanguage: "de", theme: "familiar" },
+        vocab: { de: { vocab: {}, preferences: {} } },
+        texts: [{ id: "de-custom-session", title: "Session", text: "Page content" }]
+      }
+    };
+
+    const restored = loadState();
+
+    assert.equal(restored.currentView, "reader");
+    assert.equal(restored.currentTextId, "de-custom-session");
+    assert.equal(restored.readerPage, 5);
+    assert.equal(restored.readerPages["de-custom-session"], 5);
+    assert.deepEqual(restored.readerScrolls["de-custom-session"], { readerPage: 5, scrollTop: 180 });
+    assert.equal(restored.preferences.theme, "familiar");
+  });
+
+  it("keeps the local Reader page while the first bridge snapshot is still loading", () => {
+    globalThis.localStorage = {
+      getItem(key) {
+        return key === UI_STORAGE_KEY
+          ? JSON.stringify({
+              schemaVersion: STATE_SCHEMA_VERSION,
+              currentView: "reader",
+              currentTextId: "de-book-delayed",
+              readerPage: 9,
+              readerPages: { "de-book-delayed": 9 }
+            })
+          : null;
+      },
+      setItem() {},
+      removeItem() {}
+    };
+    globalThis.window = { __qtBridge: true };
+
+    const restored = loadState();
+
+    assert.equal(restored.currentView, "reader");
+    assert.equal(restored.currentTextId, "de-book-delayed");
+    assert.equal(restored.readerPage, 9);
+    assert.equal(restored.readerPages["de-book-delayed"], 9);
+  });
+
   it("prefers a valid bridge snapshot over stale localStorage cache", () => {
     globalThis.localStorage = {
       getItem(key) {
-        assert.equal(key, STORAGE_KEY);
+        if (key === UI_STORAGE_KEY) return null;
         return JSON.stringify({
           schemaVersion: STATE_SCHEMA_VERSION,
           preferences: { learningLanguage: "de" },

--- a/src/web/js/constants.ts
+++ b/src/web/js/constants.ts
@@ -1,5 +1,6 @@
 // App constants. Data only, no logic.
 export const STORAGE_KEY = "wordHunterStateV2";
+export const UI_STORAGE_KEY = `${STORAGE_KEY}:ui`;
 export const STATE_SCHEMA_VERSION = 2;
 
 export type VocabStatus = "new" | "learning" | "known" | "ignored";

--- a/src/web/js/state.ts
+++ b/src/web/js/state.ts
@@ -3,6 +3,7 @@
 import { createAutosave } from "./state/autosave.js";
 import { getDefaultDictionaryUrl } from "./state/defaults.js";
 import { assertSupportedStateSchemaVersion, loadState } from "./state/normalize.js";
+import { captureUiState, saveUiStateCache, UI_STATE_KEYS } from "./state/ui-cache.js";
 import { OTHER_PROFILE_ID } from "./constants.js";
 
 export { STATE_SCHEMA_VERSION } from "./constants.js";
@@ -16,23 +17,6 @@ export const initialVocabKeys = new Set(Object.keys(state.vocab || {}));
 const frontendStateFlushers = new Set<() => unknown>();
 const bridgeSnapshotHandlers = new Set<(change: WhBridgeSnapshotChange) => unknown>();
 
-const UI_STATE_KEYS = [
-  "currentView",
-  "currentTextId",
-  "selectedWord",
-  "selectedWordIndex",
-  "readerSelectionRange",
-  "reviewIndex",
-  "readerFontSize",
-  "readerPdfZoom",
-  "readerPdfViewMode",
-  "readerPage",
-  "readerPages",
-  "readerScrolls",
-  "readerScrollsPerPage",
-  "filters"
-];
-
 function rawState(): WhAppState {
   return state._raw || state;
 }
@@ -44,15 +28,14 @@ function clonePlain<T>(value: T): T {
 
 function captureLocalUiState(): WhRecord {
   const raw = rawState();
-  const captured: WhRecord = {};
-  for (const key of UI_STATE_KEYS) captured[key] = clonePlain(raw[key]);
+  const captured = captureUiState(raw);
   if (raw.discover) captured.discover = clonePlain(raw.discover);
   return captured;
 }
 
 function restoreLocalUiState(nextState: WhAppState, captured: WhRecord): void {
   for (const key of UI_STATE_KEYS) {
-    if (captured[key] !== undefined) nextState[key] = captured[key];
+    if (captured[key] !== undefined) (nextState as WhRecord)[key] = captured[key];
   }
   if (captured.discover && !nextState.discover) nextState.discover = captured.discover;
 }
@@ -62,7 +45,10 @@ export function saveState(): Promise<WhBridgeSaveResult | void> {
 }
 
 export function saveUiState(): Promise<WhBridgeSaveResult | void> {
-  if (window.__qtBridge) return Promise.resolve();
+  if (window.__qtBridge) {
+    saveUiStateCache(rawState());
+    return Promise.resolve();
+  }
   return saveState();
 }
 

--- a/src/web/js/state/normalize.ts
+++ b/src/web/js/state/normalize.ts
@@ -14,6 +14,7 @@ import { createDefaultState, getDefaultDictionaryUrl, normalizeAnkiExportStatuse
 import { normalizeLearningColors } from "../reader-colors.js";
 import { normalizeTheme } from "../theme.js";
 import { normalizeTranslationLanguageCode } from "../translator-preferences.js";
+import { loadUiStateCache } from "./ui-cache.js";
 
 type UnknownRecord = Record<string, unknown>;
 
@@ -337,11 +338,15 @@ export function loadState(): WhAppState {
           customTexts.push(text);
         }
       }
+      Object.assign(merged, loadUiStateCache());
       return normalizeState(merged);
     } catch (error) {
       console.warn("Bridge state load failed", error);
       throw error;
     }
+  }
+  if (window.__qtBridge || window.WordHunterAndroid) {
+    return normalizeState({ ...fallback, ...loadUiStateCache() });
   }
   try {
     const raw = localStorage.getItem(STORAGE_KEY);

--- a/src/web/js/state/ui-cache.ts
+++ b/src/web/js/state/ui-cache.ts
@@ -1,0 +1,59 @@
+import { STATE_SCHEMA_VERSION, UI_STORAGE_KEY } from "../constants.js";
+
+export const UI_STATE_KEYS = [
+  "currentView",
+  "currentTextId",
+  "selectedWord",
+  "selectedWordIndex",
+  "readerSelectionRange",
+  "reviewIndex",
+  "readerFontSize",
+  "readerPdfZoom",
+  "readerPdfViewMode",
+  "readerPage",
+  "readerPages",
+  "readerScrolls",
+  "readerScrollsPerPage",
+  "filters"
+] as const;
+
+function clonePlain<T>(value: T): T {
+  if (value === undefined) return undefined;
+  return JSON.parse(JSON.stringify(value));
+}
+
+export function captureUiState(rawState: WhRecord): WhRecord {
+  const captured: WhRecord = {};
+  for (const key of UI_STATE_KEYS) {
+    if (rawState[key] !== undefined) captured[key] = clonePlain(rawState[key]);
+  }
+  return captured;
+}
+
+export function saveUiStateCache(rawState: WhRecord): void {
+  if (typeof localStorage === "undefined") return;
+  try {
+    localStorage.setItem(UI_STORAGE_KEY, JSON.stringify({
+      schemaVersion: STATE_SCHEMA_VERSION,
+      ...captureUiState(rawState)
+    }));
+  } catch (error) {
+    console.warn("Failed to save local UI state", error);
+  }
+}
+
+export function loadUiStateCache(): WhRecord {
+  if (typeof localStorage === "undefined") return {};
+  try {
+    const raw = localStorage.getItem(UI_STORAGE_KEY);
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    const record = parsed as WhRecord;
+    if (record.schemaVersion !== STATE_SCHEMA_VERSION) return {};
+    return captureUiState(record);
+  } catch (error) {
+    console.warn("Failed to read local UI state", error);
+    return {};
+  }
+}

--- a/src/web/js/sync-actions.ts
+++ b/src/web/js/sync-actions.ts
@@ -1,5 +1,5 @@
 import { applyBridgeSnapshotToState, getDurableStateRevision, state, saveState, createDefaultState, normalizeState, replaceState, resetInitialVocabKeys, runExclusiveStateWrite, clearLastReadTextForLanguage } from "./state.js";
-import { STORAGE_KEY } from "./constants.js";
+import { STORAGE_KEY, UI_STORAGE_KEY } from "./constants.js";
 import { buildSavePayload } from "./api.js";
 import { showToast } from "./toast.js";
 import { t } from "./i18n.js";
@@ -493,6 +493,7 @@ export async function clearLocalState(): Promise<void> {
       const result = await postStoreCommand("/__store/wipe");
       await applyBridgeCommandResult(result);
       localStorage.removeItem(STORAGE_KEY);
+      localStorage.removeItem(UI_STORAGE_KEY);
     } catch (error) {
       console.warn("wipe failed", error);
       showToast(t("toast.syncUnavailable"), "error");
@@ -500,6 +501,7 @@ export async function clearLocalState(): Promise<void> {
     }
   } else {
     localStorage.removeItem(STORAGE_KEY);
+    localStorage.removeItem(UI_STORAGE_KEY);
     replaceState(createDefaultState());
     await saveState();
   }


### PR DESCRIPTION
## What changed

- stores Reader navigation state in a dedicated local UI cache on native builds
- restores the active text, page, and scroll position whether the bridge snapshot is immediate or delayed
- keeps the UI cache out of synchronized vocabulary, texts, and preferences
- removes the cache when local application data is wiped

## Checks

- `npm run test:frontend` — 355/355 passed
- `node scripts/validate-json-i18n.mjs` — 20 JSON files and 9 locales passed
- `git diff --check`

Fixes #66