### PR TITLE
fix: defer Android snapshot to /__store/load to avoid write-lock deadlock

### DIFF
--- a/frontend-tests/shared/persistence-lifecycle.test.js
+++ b/frontend-tests/shared/persistence-lifecycle.test.js
@@ -955,7 +955,7 @@ describe("persistence lifecycle", () => {
     assert.match(bootLogo, /animation:\s*boot-logo-pulse 1\.15s ease-in-out infinite !important/);
     assert.doesNotMatch(styles, /content: "Word Hunter"/);
     assert.ok(app.includes('fetchWithTimeout("/__store/load"'));
-    assert.match(handlers, /bootstrap_script\([\s\S]*Some/);
+    assert.match(handlers, /bootstrap_script\([\s\S]*(Some|None)/);
     assert.match(handlers, /storeLoadController[\s\S]*12000/);
     assert.match(boot, /wordHunterBootTimeout = window\.setTimeout/);
     assert.match(boot, /Startup timed out before the application became ready/);

--- a/src-tauri/src/handlers.rs
+++ b/src-tauri/src/handlers.rs
@@ -42,7 +42,10 @@ pub(crate) fn serve_index(request: Request, state: &ServerState) -> Result<(), S
     let mut html = String::from_utf8(index.contents().to_vec()).map_err(|e| e.to_string())?;
     let bootstrap = bootstrap_script(
         &state.token,
+        #[cfg(not(target_os = "android"))]
         Some(&state.store.snapshot()),
+        #[cfg(target_os = "android")]
+        None,
         crate::pdf_ocr::image_ocr_available(&state.app_handle),
     );
     if let Some(pos) = html.find("<head>") {


### PR DESCRIPTION
## Root cause

`serve_index` calls `state.store.snapshot()` synchronously on every request. On Android, a background recovery thread holds the `write_lock` during `recover_android_startup_guarded()`. When the WebView loads `index.html`, `snapshot()` blocks waiting for the lock, preventing the HTML from being served. The WebView times out before the page loads.

## Fix

On Android, pass `None` for the bootstrap snapshot so `serve_index` returns HTML immediately. The frontend fetches `/__store/load` with the existing 12-second AbortController timeout, which naturally waits for the background recovery to release the lock.

Desktop keeps the inline snapshot (`Some`) for faster cold start.

## Changes

- `src-tauri/src/handlers.rs` — `serve_index` uses `#[cfg(target_os = "android")]` to pass `None`
- `frontend-tests/shared/persistence-lifecycle.test.js` — updated assertion to accept both `Some` and `None`

## Testing

- Desktop: inline snapshot path (unchanged)
- Android: deferred fetch path with 12s timeout (restores RC2 behavior)