### PR TITLE
fix: stream AI explanations through the markdown renderer

### DIFF
--- a/frontend-tests/shared/focused-regressions.test.js
+++ b/frontend-tests/shared/focused-regressions.test.js
@@ -1557,6 +1557,57 @@ describe("focused frontend regressions", () => {
     assert.deepEqual(calls, [], "transient phrase ranges must never auto-trigger an AI explanation");
   });
 
+  it("streams AI explanations through the markdown renderer (no raw ** markers)", async () => {
+    const wordPanel = {
+      rendered: "",
+      current: null,
+      set innerHTML(value) {
+        this.rendered = value;
+        this.current = { button: eventTarget(), output: { hidden: true, textContent: "", innerHTML: "" } };
+      },
+      get innerHTML() { return this.rendered; },
+      querySelector(selector) {
+        if (selector === "[data-ai-explain]") return this.current?.button || null;
+        if (selector === "[data-ai-explanation]") return this.current?.output || null;
+        return null;
+      },
+      querySelectorAll() { return []; }
+    };
+    const state = {
+      selectedWord: "an",
+      selectedWordIndex: 0,
+      vocab: { an: { status: "new", translation: "", note: "", examples: ["Ich komme an."] } },
+      preferences: { selectedWordPanelItems: [{ id: "ai", visible: true }] }
+    };
+    const module = await evaluateWordPanel({
+      state,
+      wordPanel,
+      getSentenceForWord() { return "Ich komme an."; },
+      aiExplanationConfigured: () => true,
+      explainWord: async (_request, onDelta) => {
+        onDelta("To jest **pogrubienie** i *kursywa*.");
+        // Let the streamed state be observable before the final result lands.
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        return { explanation: "final", cached: false };
+      },
+      formatAiExplanation: (text) => `FMT:${text}`
+    });
+    module.renderWordPanel({ id: "text-1", text: "Ich komme an." });
+    wordPanel.current.button.dispatch("click", { stopPropagation() {} });
+    await flushAsync();
+    assert.equal(
+      wordPanel.current.output.innerHTML,
+      "FMT:To jest **pogrubienie** i *kursywa*.",
+      "stream deltas must be rendered through formatAiExplanation, not as raw text"
+    );
+    await flushAsync();
+    assert.equal(
+      wordPanel.current.output.innerHTML,
+      "FMT:final",
+      "the final formatted explanation still replaces the streamed preview"
+    );
+  });
+
   it("retires the in-text review explanation after three completed guesses", async () => {
     let html = "";
     let answerButton = null;
@@ -1659,6 +1710,7 @@ async function evaluateWordPanel({
   explainWord = async () => ({ explanation: "", cached: false }),
   hasWordExplanation = () => false,
   markWordExplained = () => {},
+  formatAiExplanation = (text) => String(text ?? ""),
   updateWordField = () => {}
 }) {
   return evaluateWithMocks("dist/web/js/reader/word-panel.js", {
@@ -1712,7 +1764,7 @@ async function evaluateWordPanel({
       aiExplanationConfigured,
       aiExplanationLanguagePair: () => ({ from: "de", to: "en" }),
       collectPdfOcrImageContext: async () => null,
-      formatAiExplanation: (text) => String(text ?? ""),
+      formatAiExplanation,
       explainWord,
       hasWordExplanation,
       markWordExplained

--- a/src/web/js/reader/word-panel.ts
+++ b/src/web/js/reader/word-panel.ts
@@ -414,9 +414,10 @@ async function runAiExplanation(
       (text) => {
         if (generation !== aiExplainGeneration || state.selectedWord !== word) return;
         if (!output) return;
-        // Progressive render: plain text with line breaks while streaming,
-        // then the final formatted version below.
-        output.innerHTML = escapeHtml(text).replace(/\n/g, "<br>");
+        // Stream through the markdown renderer so bold/italic/lists are
+        // visible immediately and a stalled stream never leaves raw "**"
+        // markers on screen. formatAiExplanation escapes first.
+        output.innerHTML = formatAiExplanation(text);
       }
     );
     if (generation !== aiExplainGeneration || state.selectedWord !== word) return;

--- a/src/web/js/views/translator.ts
+++ b/src/web/js/views/translator.ts
@@ -432,7 +432,10 @@ export function bindTranslatorEvents(): void {
           { word: source.slice(0, 300), context: source, from: pair.fromCode, to: pair.toCode },
           (text) => {
             if (generation !== translatorAiExplainGeneration) return;
-            output.innerHTML = escapeHtml(text).replace(/\n/g, "<br>");
+            // Stream through the markdown renderer so bold/italic/lists are
+            // visible immediately and a stalled stream never leaves raw
+            // "**" markers on screen. formatAiExplanation escapes first.
+            output.innerHTML = formatAiExplanation(text);
           }
         );
         if (generation !== translatorAiExplainGeneration) return;


### PR DESCRIPTION
Streaming AI explanations used escapeHtml+<br>, so **bold** markers were visible (and stayed) while streaming, with flat line layout. Now streams through formatAiExplanation (which escapes first) in both the translator view and the reader word panel. Adds a regression test asserting stream deltas go through the markdown renderer.