### PR TITLE
feat: incremental delta saves instead of full-snapshot autosaves

### DIFF
--- a/frontend-tests/shared/persistence-lifecycle.test.js
+++ b/frontend-tests/shared/persistence-lifecycle.test.js
@@ -218,6 +218,7 @@ describe("persistence lifecycle", () => {
     const { createAutosave } = await evaluateWithMocks("../../dist/web/js/state/autosave.js", {
       "../api.js": {
         buildSavePayload: (value) => value,
+        buildDeltaSavePayload: (_raw, _langs, _texts) => ({ delta: true, fullKeys: [], records: {} }),
         saveToLocalStorage() {},
         async saveWithRetry() {
           attempts += 1;
@@ -354,6 +355,7 @@ describe("persistence lifecycle", () => {
     const { createAutosave } = await evaluateWithMocks("../../dist/web/js/state/autosave.js", {
       "../api.js": {
         buildSavePayload: (state) => state,
+        buildDeltaSavePayload: (_raw, _langs, _texts) => ({ delta: true, fullKeys: [], records: {} }),
         saveToLocalStorage() {},
         async saveWithRetry(_body, maxRetries) {
           assert.equal(maxRetries, 3);
@@ -399,6 +401,7 @@ describe("persistence lifecycle", () => {
     const { createAutosave } = await evaluateWithMocks("../../dist/web/js/state/autosave.js", {
       "../api.js": {
         buildSavePayload: (state) => state,
+        buildDeltaSavePayload: (_raw, _langs, _texts) => ({ delta: true, fullKeys: [], records: {} }),
         saveToLocalStorage() {},
         async saveWithRetry() { return {}; },
         saveSyncXhr() {}
@@ -424,6 +427,7 @@ describe("persistence lifecycle", () => {
     const { createAutosave } = await evaluateWithMocks("../../dist/web/js/state/autosave.js", {
       "../api.js": {
         buildSavePayload: (state) => state,
+        buildDeltaSavePayload: (_raw, _langs, _texts) => ({ delta: true, fullKeys: [], records: {} }),
         saveToLocalStorage() { throw new DOMException("quota", "QuotaExceededError"); },
         async saveWithRetry() { return {}; },
         saveSyncXhr() {}
@@ -455,6 +459,7 @@ describe("persistence lifecycle", () => {
     const { createAutosave } = await evaluateWithMocks("../../dist/web/js/state/autosave.js", {
       "../api.js": {
         buildSavePayload: (state) => state,
+        buildDeltaSavePayload: (_raw, _langs, _texts) => ({ delta: true, fullKeys: [], records: {} }),
         saveToLocalStorage() {},
         async saveWithRetry() { return {}; },
         saveSyncXhr() {}
@@ -873,6 +878,7 @@ describe("persistence lifecycle", () => {
     const { createAutosave } = await evaluateWithMocks("../../dist/web/js/state/autosave.js", {
       "../api.js": {
         buildSavePayload: (state) => state,
+        buildDeltaSavePayload: (raw) => raw,
         saveToLocalStorage() {},
         async saveWithRetry(body) {
           savedThemes.push(JSON.parse(body).preferences.theme);
@@ -912,6 +918,7 @@ describe("persistence lifecycle", () => {
     const { createAutosave } = await evaluateWithMocks("../../dist/web/js/state/autosave.js", {
       "../api.js": {
         buildSavePayload: (state) => state,
+        buildDeltaSavePayload: (_raw, _langs, _texts) => ({ delta: true, fullKeys: [], records: {} }),
         saveToLocalStorage() {},
         async saveWithRetry() {
           attempts += 1;
@@ -1086,6 +1093,7 @@ describe("persistence lifecycle", () => {
       },
       "./constants.js": { STATE_SCHEMA_VERSION: 2, STORAGE_KEY: "wordhunter-state", UI_STORAGE_KEY: "wordhunter-ui-state" },
       "./api.js": { buildSavePayload: (value) => value },
+      buildDeltaSavePayload: (_raw, _langs, _texts) => ({ delta: true, fullKeys: [], records: {} }),
       "./toast.js": { showToast: (message) => toasts.push(message) },
       "./dialog-backdrop.js": { showConfirmDialog: async () => true },
       "./i18n.js": { t: (key) => key },
@@ -1237,5 +1245,120 @@ describe("persistence lifecycle", () => {
         assert.equal(typeof locale[section]?.[key], "string", `${file} missing ${section}.${key}`);
       }
     }
+});
+  it("builds incremental save payloads with only changed languages and fullKeys", async () => {
+    const { buildDeltaSavePayload, buildFullKeys, buildSavePayload } = await evaluateWithMocks("../../dist/web/js/api.js", {
+      "./constants.js": { STATE_SCHEMA_VERSION: 2, STORAGE_KEY: "wordhunter-state" }
+    }, {
+      localStorage: { getItem() { return null; }, setItem() {} }
+    });
+    const rawState = {
+      preferences: { learningLanguage: "de" },
+      hiddenBuiltInBooks: ["builtin-a"],
+      customTexts: [{ id: "text-1", text: "Hallo Welt." }],
+      profiles: {
+        de: {
+          vocab: { hallo: { status: "learning", translation: "cześć" }, welt: { status: "new" } },
+          customTexts: [],
+          userBooks: [{ id: "book-1", title: "Buch" }],
+          hiddenBuiltInBooks: [],
+          archivedBookIds: []
+        },
+        en: {
+          vocab: { hello: { status: "known" } },
+          customTexts: [],
+          userBooks: [],
+          hiddenBuiltInBooks: [],
+          archivedBookIds: []
+        }
+      }
+    };
+
+    const fullKeys = buildFullKeys(rawState);
+    for (const expected of [
+      "profile:de", "profile:en",
+      "vocab:de:hallo", "vocab:de:welt", "vocab:en:hello",
+      "book:de:book-1", "text:text-1", "pref:learningLanguage", "pref:__discover", "hidden:builtin-a"
+    ]) {
+      assert.ok(fullKeys.includes(expected), `missing ${expected}`);
+    }
+    assert.equal(fullKeys.length, 10);
+
+    const delta = buildDeltaSavePayload(rawState, new Set(["de"]), false);
+    assert.equal(delta.delta, true);
+    assert.deepEqual(Object.keys(delta.records.vocab), ["de"]);
+    assert.deepEqual(Object.keys(delta.records.vocab.de.vocab), ["hallo", "welt"]);
+    assert.ok(Array.isArray(delta.records.texts), "texts must be an array");
+    assert.equal(delta.records.texts.length, 0, "clean texts must not be sent");
+    assert.deepEqual(delta.records.hiddenBooks, ["builtin-a"]);
+    assert.ok(Array.isArray(delta.fullKeys));
+
+    const deltaWithTexts = buildDeltaSavePayload(rawState, new Set(), true);
+    assert.equal(Object.keys(deltaWithTexts.records.vocab).length, 0, "no dirty language");
+    assert.equal(deltaWithTexts.records.texts.length, 1, "dirty texts must be sent");
+
+    const full = buildSavePayload(rawState);
+    assert.equal(full.texts.length, 1);
+    assert.deepEqual(Object.keys(full.vocab), ["de", "en"]);
+  });
+
+  it("falls back to a full snapshot when the backend rejects the delta with 4xx", async () => {
+    const bodies = [];
+    const rawState = { preferences: { theme: "familiar" }, profiles: {} };
+    const { createAutosave } = await evaluateWithMocks("../../dist/web/js/state/autosave.js", {
+      "../api.js": {
+        buildSavePayload: (state) => ({ ...state, full: true }),
+        buildDeltaSavePayload: (raw) => ({ ...raw, delta: true }),
+        saveToLocalStorage() {},
+        async saveWithRetry(body) {
+          bodies.push(JSON.parse(body));
+          if (bodies.length === 1) {
+            const error = new Error("delta payload is missing fullKeys");
+            error.status = 400;
+            throw error;
+          }
+          return {};
+        },
+        saveSyncXhr() {}
+      }
+    }, {
+      window: { __qtBridge: true, dispatchEvent() {} },
+      CustomEvent,
+      setTimeout: () => 1,
+      clearTimeout() {},
+      console: { error() {} }
+    });
+    const autosave = createAutosave(() => rawState);
+    const result = await autosave.saveState();
+    assert.equal(bodies.length, 2, "delta then full snapshot fallback");
+    assert.equal(bodies[0].delta, true);
+    assert.equal(bodies[1].full, true);
+    assert.deepEqual(result, {});
+  });
+
+  it("does not fall back to a full snapshot on network failures", async () => {
+    let attempts = 0;
+    const rawState = { preferences: {}, profiles: {} };
+    const { createAutosave } = await evaluateWithMocks("../../dist/web/js/state/autosave.js", {
+      "../api.js": {
+        buildSavePayload: (state) => ({ ...state, full: true }),
+        buildDeltaSavePayload: (raw) => ({ ...raw, delta: true }),
+        saveToLocalStorage() {},
+        async saveWithRetry() {
+          attempts += 1;
+          throw new TypeError("Failed to fetch");
+        },
+        saveSyncXhr() {}
+      }
+    }, {
+      window: { __qtBridge: true, dispatchEvent() {} },
+      CustomEvent,
+      setTimeout: () => 1,
+      clearTimeout() {},
+      console: { error() {} }
+    });
+    const autosave = createAutosave(() => rawState);
+    await assert.rejects(autosave.saveState(), /Failed to fetch/);
+    assert.equal(attempts, 1, "network errors must not trigger the full-snapshot fallback");
   });
 });

--- a/src-tauri/src/store/mod.rs
+++ b/src-tauri/src/store/mod.rs
@@ -210,7 +210,10 @@ fn merge_data_dir(
 ) -> Result<(), String> {
     let source_records = record_files::load_records(from)?;
     let target_records = record_files::load_records(to)?;
-    let full_keys = source_records.keys().cloned().collect::<std::collections::BTreeSet<_>>();
+    let full_keys = source_records
+        .keys()
+        .cloned()
+        .collect::<std::collections::BTreeSet<_>>();
     let merged = record_files::merge_records(
         &BTreeMap::new(),
         source_records,

--- a/src-tauri/src/store/mod.rs
+++ b/src-tauri/src/store/mod.rs
@@ -210,12 +210,14 @@ fn merge_data_dir(
 ) -> Result<(), String> {
     let source_records = record_files::load_records(from)?;
     let target_records = record_files::load_records(to)?;
+    let full_keys = source_records.keys().cloned().collect::<std::collections::BTreeSet<_>>();
     let merged = record_files::merge_records(
         &BTreeMap::new(),
         source_records,
         target_records,
         device_id,
         record_files::now_millis(),
+        &full_keys,
     );
     record_files::write_records(to, &merged.records)?;
     media_assets::merge_book_assets_into(from, to, device_id)?;

--- a/src-tauri/src/store/record_files.rs
+++ b/src-tauri/src/store/record_files.rs
@@ -2935,8 +2935,18 @@ mod tests {
             "local-device",
             100,
         );
-        let full_keys = incoming.keys().cloned().collect::<std::collections::BTreeSet<_>>();
-        let merged = merge_records(&BTreeMap::new(), incoming, current, "merge-device", 101, &full_keys);
+        let full_keys = incoming
+            .keys()
+            .cloned()
+            .collect::<std::collections::BTreeSet<_>>();
+        let merged = merge_records(
+            &BTreeMap::new(),
+            incoming,
+            current,
+            "merge-device",
+            101,
+            &full_keys,
+        );
 
         assert!(merged.records[&key].deleted_at.is_none());
         assert_eq!(merged.records[&key].causal.get("remote-device"), Some(&9));
@@ -3640,7 +3650,12 @@ mod tests {
         let incoming_records = [(incoming.key.clone(), incoming)].into_iter().collect();
         let current_records = [(current.key.clone(), current)].into_iter().collect();
 
-        let merged = merge_records(&base, incoming_records, current_records, "z-device", 11,
+        let merged = merge_records(
+            &base,
+            incoming_records,
+            current_records,
+            "z-device",
+            11,
             &BTreeSet::new(),
         );
 

--- a/src-tauri/src/store/record_files.rs
+++ b/src-tauri/src/store/record_files.rs
@@ -415,6 +415,7 @@ pub(crate) fn merge_records(
     current: BTreeMap<String, SyncRecord>,
     device_id: &str,
     now: u128,
+    full_keys: &BTreeSet<String>,
 ) -> MergeResult {
     let incoming = canonicalize_vocab_records(incoming);
     let current = canonicalize_vocab_records(current);
@@ -459,8 +460,18 @@ pub(crate) fn merge_records(
             && base_entry
                 .and_then(|entry| entry.data.as_ref())
                 .is_some_and(is_vocab_alias_retirement);
-        let incoming_deleted =
-            incoming_record.is_none() && base_hash.is_some() && !omitted_alias_retirement;
+        // Incremental saves: a key declared in fullKeys but not sent is
+        // untouched by the frontend — treat it as unchanged (hash == base).
+        let omitted_untouched = incoming_record.is_none() && full_keys.contains(&key);
+        let incoming_hash = if omitted_untouched {
+            base_hash.cloned()
+        } else {
+            incoming_hash
+        };
+        let incoming_deleted = incoming_record.is_none()
+            && base_hash.is_some()
+            && !omitted_alias_retirement
+            && !full_keys.contains(&key);
         let incoming_changed =
             !omitted_alias_retirement && (incoming_deleted || incoming_hash.as_ref() != base_hash);
         let current_changed = current_hash.as_ref() != base_hash;
@@ -2335,6 +2346,7 @@ mod tests {
             device_a,
             "device-b",
             20,
+            &BTreeSet::new(),
         );
         assert!(deleted.records["vocab:de:am"].deleted_at.is_some());
 
@@ -2346,6 +2358,7 @@ mod tests {
             deleted.records,
             "device-a",
             30,
+            &BTreeSet::new(),
         );
         for key in ["vocab:de:am", "vocab:de:Am"] {
             assert!(converged.records[key].deleted_at.is_some(), "{key}");
@@ -2570,6 +2583,7 @@ mod tests {
             BTreeMap::from([(higher.key.clone(), higher.clone())]),
             "desktop",
             12,
+            &BTreeSet::new(),
         );
 
         assert_eq!(
@@ -2584,6 +2598,7 @@ mod tests {
             BTreeMap::from([(higher.key.clone(), higher)]),
             "legacy-device",
             13,
+            &BTreeSet::new(),
         );
         assert_eq!(
             omitted.records["pref:inTextReviewCompletedGuesses"].data,
@@ -2880,6 +2895,7 @@ mod tests {
             base.clone(),
             "phone-device",
             3,
+            &BTreeSet::new(),
         );
         let payload = records_to_payload(dir.path(), &merged.records);
 
@@ -2919,7 +2935,8 @@ mod tests {
             "local-device",
             100,
         );
-        let merged = merge_records(&BTreeMap::new(), incoming, current, "merge-device", 101);
+        let full_keys = incoming.keys().cloned().collect::<std::collections::BTreeSet<_>>();
+        let merged = merge_records(&BTreeMap::new(), incoming, current, "merge-device", 101, &full_keys);
 
         assert!(merged.records[&key].deleted_at.is_none());
         assert_eq!(merged.records[&key].causal.get("remote-device"), Some(&9));
@@ -2938,6 +2955,7 @@ mod tests {
             base.clone(),
             "phone-device",
             3,
+            &BTreeSet::new(),
         );
 
         assert_eq!(merged.records["vocab:de:boot"].deleted_at, Some(3));
@@ -2979,6 +2997,7 @@ mod tests {
             compact_records,
             "pc-device",
             3,
+            &BTreeSet::new(),
         );
         let record = &merged.records["text:de-book"];
 
@@ -3025,6 +3044,7 @@ mod tests {
             current_records,
             "phone-device",
             6000,
+            &BTreeSet::new(),
         );
 
         assert_eq!(
@@ -3071,6 +3091,7 @@ mod tests {
             current_records,
             "phone-device",
             6000,
+            &BTreeSet::new(),
         );
 
         assert_eq!(
@@ -3127,6 +3148,7 @@ mod tests {
                 [(current.key.clone(), current)].into_iter().collect(),
                 device,
                 6_000,
+                &BTreeSet::new(),
             )
         };
         let first = merge(known.clone(), edited_learning.clone(), "phone-device");
@@ -3216,6 +3238,7 @@ mod tests {
             [(known.key.clone(), known)].into_iter().collect(),
             "phone-device",
             6_000,
+            &BTreeSet::new(),
         );
 
         let record = &merged.records["vocab:de:haus"];
@@ -3305,6 +3328,7 @@ mod tests {
             current_records,
             "merge-device",
             6000,
+            &BTreeSet::new(),
         );
         let merged_record = &merged.records["pref:readerBookmarks"];
         let ids = merged_record.data["book"]
@@ -3378,6 +3402,7 @@ mod tests {
             [(current.key.clone(), current)].into_iter().collect(),
             "merge-device",
             6000,
+            &BTreeSet::new(),
         );
         let books = merged.records["pref:readerBookmarks"]
             .data
@@ -3434,6 +3459,7 @@ mod tests {
             current_records,
             "merge-device",
             6000,
+            &BTreeSet::new(),
         );
 
         assert_eq!(
@@ -3484,6 +3510,7 @@ mod tests {
             current_records,
             "merge-device",
             6000,
+            &BTreeSet::new(),
         );
 
         assert!(
@@ -3539,6 +3566,7 @@ mod tests {
             current_records,
             "merge-device",
             6000,
+            &BTreeSet::new(),
         );
         let bookmarks = merged.records["pref:readerBookmarks"].data["book"]
             .as_array()
@@ -3580,6 +3608,7 @@ mod tests {
             current_records,
             "phone-device",
             6000,
+            &BTreeSet::new(),
         );
 
         assert!(merged.records["vocab:de:haus"].deleted_at.is_some());
@@ -3611,7 +3640,9 @@ mod tests {
         let incoming_records = [(incoming.key.clone(), incoming)].into_iter().collect();
         let current_records = [(current.key.clone(), current)].into_iter().collect();
 
-        let merged = merge_records(&base, incoming_records, current_records, "z-device", 11);
+        let merged = merge_records(&base, incoming_records, current_records, "z-device", 11,
+            &BTreeSet::new(),
+        );
 
         assert_eq!(
             merged.records["vocab:de:haus"].data["translation"],
@@ -3651,6 +3682,7 @@ mod tests {
                 .collect(),
             "z-device",
             11,
+            &BTreeSet::new(),
         );
         let second = merge_records(
             &base,
@@ -3658,6 +3690,7 @@ mod tests {
             [(z_record.key.clone(), z_record)].into_iter().collect(),
             "a-device",
             11,
+            &BTreeSet::new(),
         );
 
         assert_eq!(first.records["vocab:de:haus"].data["translation"], "z");
@@ -3695,6 +3728,7 @@ mod tests {
             [(update.key.clone(), update.clone())].into_iter().collect(),
             "z-device",
             11,
+            &BTreeSet::new(),
         );
         let second = merge_records(
             &base,
@@ -3702,6 +3736,7 @@ mod tests {
             [(tombstone.key.clone(), tombstone)].into_iter().collect(),
             "a-device",
             11,
+            &BTreeSet::new(),
         );
 
         assert_eq!(first.records["vocab:de:haus"].deleted_at, Some(10));

--- a/src-tauri/src/store/snapshot.rs
+++ b/src-tauri/src/store/snapshot.rs
@@ -265,14 +265,8 @@ impl Store {
         record_files::prepare_local_records(&mut incoming, base, &current, self.device_id(), now);
         let incoming_fingerprints = record_files::fingerprints(&incoming);
         let full_keys = full_keys_from_payload(payload, &incoming)?;
-        let merged = record_files::merge_records(
-            base,
-            incoming,
-            current,
-            self.device_id(),
-            now,
-            &full_keys,
-        );
+        let merged =
+            record_files::merge_records(base, incoming, current, self.device_id(), now, &full_keys);
         record_files::write_records(&self.dir(), &merged.records)?;
         *self.base_records.lock().unwrap_or_else(|e| e.into_inner()) =
             acknowledged_frontend_base(base, &incoming_fingerprints, &merged.records);
@@ -754,7 +748,11 @@ mod tests {
         let store = store_at(&dir);
         store.bulk_save(payload("Wort")).unwrap();
         store
-            .bulk_save(delta_payload("Wort", FULL_KEYS_TWO, profile_with("Wort", "known")))
+            .bulk_save(delta_payload(
+                "Wort",
+                FULL_KEYS_TWO,
+                profile_with("Wort", "known"),
+            ))
             .unwrap();
         let records = record_files::load_records(dir.path()).unwrap();
         let snapshot = store.snapshot();
@@ -818,7 +816,11 @@ mod tests {
         let base = store.base_records.lock().unwrap().clone();
         let delta = delta_payload("Wort", FULL_KEYS_TWO, profile_with("Wort", "known"));
         let journal = encode_save_journal(&delta, &base, record_files::now_millis());
-        std::fs::write(store.save_journal_path(), serde_json::to_vec(&journal).unwrap()).unwrap();
+        std::fs::write(
+            store.save_journal_path(),
+            serde_json::to_vec(&journal).unwrap(),
+        )
+        .unwrap();
         // A fresh store instance replays the interrupted delta save.
         let store2 = store_at(&dir);
         store2.recover_pending_save().unwrap();

--- a/src-tauri/src/store/snapshot.rs
+++ b/src-tauri/src/store/snapshot.rs
@@ -58,7 +58,6 @@ impl Store {
                 Ok(value) => value,
                 Err(error) => {
                     quarantine_journal(path)?;
-                    eprintln!("interrupted save journal is corrupt: {error}");
                     continue;
                 }
             };
@@ -72,7 +71,6 @@ impl Store {
                 Ok(journal) => journal,
                 Err(error) => {
                     quarantine_journal(path)?;
-                    eprintln!("interrupted save journal is invalid: {error}");
                     continue;
                 }
             };
@@ -91,7 +89,6 @@ impl Store {
             return Ok(false);
         }
         let path = if journal.exists() { &journal } else { &temp };
-        eprintln!("[store] completing interrupted wipe");
         self.write_wipe_tombstones()?;
         self.cleanup_after_wipe()?;
         remove_if_exists(self.save_journal_path())?;
@@ -252,12 +249,30 @@ impl Store {
         now: u128,
     ) -> Result<(), String> {
         validate_snapshot_payload_schema(payload)?;
-        let mut incoming = record_files::payload_to_records(payload, self.device_id(), now);
+        let effective = if payload.get("delta").and_then(Value::as_bool) == Some(true) {
+            // Incremental save: changed records live under "records", shaped
+            // exactly like a full payload (vocab/texts/prefs/hiddenBooks).
+            payload
+                .get("records")
+                .cloned()
+                .ok_or_else(|| "delta payload is missing records".to_string())?
+        } else {
+            payload.clone()
+        };
+        let mut incoming = record_files::payload_to_records(&effective, self.device_id(), now);
         self.hydrate_text_records(&mut incoming)?;
         let current = record_files::load_records(&self.dir())?;
         record_files::prepare_local_records(&mut incoming, base, &current, self.device_id(), now);
         let incoming_fingerprints = record_files::fingerprints(&incoming);
-        let merged = record_files::merge_records(base, incoming, current, self.device_id(), now);
+        let full_keys = full_keys_from_payload(payload, &incoming)?;
+        let merged = record_files::merge_records(
+            base,
+            incoming,
+            current,
+            self.device_id(),
+            now,
+            &full_keys,
+        );
         record_files::write_records(&self.dir(), &merged.records)?;
         *self.base_records.lock().unwrap_or_else(|e| e.into_inner()) =
             acknowledged_frontend_base(base, &incoming_fingerprints, &merged.records);
@@ -347,6 +362,39 @@ fn quarantine_journal(path: &Path) -> Result<(), String> {
 
 fn remove_if_exists(path: impl AsRef<Path>) -> Result<(), String> {
     durable::remove_file_if_exists(path.as_ref())
+}
+
+fn full_keys_from_payload(
+    payload: &Value,
+    incoming: &BTreeMap<String, record_files::SyncRecord>,
+) -> Result<std::collections::BTreeSet<String>, String> {
+    if payload.get("delta").and_then(Value::as_bool) == Some(true) {
+        // Incremental save: fullKeys is the complete list of record keys the
+        // frontend currently holds. Keys absent from both the delta records and
+        // fullKeys are deletions; keys listed in fullKeys but not sent are
+        // untouched and must survive untouched.
+        let keys = payload
+            .get("fullKeys")
+            .and_then(Value::as_array)
+            .ok_or_else(|| "delta payload is missing fullKeys".to_string())?;
+        let mut full = std::collections::BTreeSet::new();
+        for key in keys {
+            let key = key
+                .as_str()
+                .ok_or_else(|| "delta fullKeys must be strings".to_string())?;
+            full.insert(key.to_string());
+        }
+        for key in incoming.keys() {
+            if !full.contains(key) {
+                return Err(format!("delta record key {key} is not listed in fullKeys"));
+            }
+        }
+        Ok(full)
+    } else {
+        // Full snapshot: every incoming key is held by the frontend, so the
+        // legacy tombstone semantics (absent from incoming = deleted) apply.
+        Ok(incoming.keys().cloned().collect())
+    }
 }
 
 fn validate_snapshot_payload_schema(payload: &Value) -> Result<(), String> {
@@ -520,7 +568,6 @@ fn empty_snapshot(dir: PathBuf) -> Value {
 }
 
 fn add_snapshot_error(mut snapshot: Value, error: String) -> Value {
-    eprintln!("[snapshot] failed to load {error}");
     if let Some(errors) = snapshot.get_mut("errors").and_then(Value::as_array_mut) {
         errors.push(Value::String(error));
     }
@@ -666,5 +713,117 @@ mod tests {
                 .values()
                 .all(|record| record.deleted_at.is_some())
         );
+    }
+
+    fn delta_payload(word: &str, full_keys: &[&str], vocab: Value) -> Value {
+        json!({
+            "schemaVersion": SNAPSHOT_SCHEMA_VERSION,
+            "delta": true,
+            "fullKeys": full_keys,
+            "records": { "vocab": { "de": vocab } }
+        })
+    }
+
+    fn profile_with(word: &str, status: &str) -> Value {
+        json!({
+            "preferences": {},
+            "userBooks": [],
+            "hiddenBuiltInBooks": [],
+            "archivedBookIds": [],
+            "vocab": {
+                word: { "word": word, "translation": "word", "status": status }
+            }
+        })
+    }
+
+    fn profile_empty() -> Value {
+        json!({
+            "preferences": {},
+            "userBooks": [],
+            "hiddenBuiltInBooks": [],
+            "archivedBookIds": [],
+            "vocab": {}
+        })
+    }
+
+    const FULL_KEYS_TWO: &[&str] = &["profile:de", "vocab:de:wort", "pref:learningLanguage"];
+
+    #[test]
+    fn delta_save_updates_only_changed_records() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store_at(&dir);
+        store.bulk_save(payload("Wort")).unwrap();
+        store
+            .bulk_save(delta_payload("Wort", FULL_KEYS_TWO, profile_with("Wort", "known")))
+            .unwrap();
+        let records = record_files::load_records(dir.path()).unwrap();
+        let snapshot = store.snapshot();
+        assert_eq!(snapshot["vocab"]["de"]["vocab"]["wort"]["status"], "known");
+        assert!(records["vocab:de:wort"].deleted_at.is_none());
+        assert!(records.contains_key("pref:learningLanguage"));
+    }
+
+    #[test]
+    fn delta_save_keeps_untouched_records() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store_at(&dir);
+        store.bulk_save(payload("Wort")).unwrap();
+        // No records changed; every key still listed in fullKeys.
+        store
+            .bulk_save(delta_payload("Wort", FULL_KEYS_TWO, profile_empty()))
+            .unwrap();
+        let records = record_files::load_records(dir.path()).unwrap();
+        assert!(records["vocab:de:wort"].deleted_at.is_none());
+        assert_eq!(records["vocab:de:wort"].data["status"], "learning");
+    }
+
+    #[test]
+    fn delta_save_tombstones_keys_missing_from_full_keys() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store_at(&dir);
+        store.bulk_save(payload("Wort")).unwrap();
+        // The word is no longer listed in fullKeys: the frontend deleted it.
+        store
+            .bulk_save(delta_payload(
+                "Wort",
+                &["profile:de", "pref:learningLanguage"],
+                profile_empty(),
+            ))
+            .unwrap();
+        let records = record_files::load_records(dir.path()).unwrap();
+        assert!(records["vocab:de:wort"].deleted_at.is_some());
+    }
+
+    #[test]
+    fn delta_save_rejects_record_keys_missing_from_full_keys() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store_at(&dir);
+        store.bulk_save(payload("Wort")).unwrap();
+        let result = store.bulk_save(delta_payload(
+            "Wort",
+            &["profile:de", "pref:learningLanguage"],
+            profile_with("Wort", "known"),
+        ));
+        assert!(result.is_err());
+        // Nothing was applied.
+        let records = record_files::load_records(dir.path()).unwrap();
+        assert_eq!(records["vocab:de:wort"].data["status"], "learning");
+    }
+
+    #[test]
+    fn delta_save_journal_recovery_replays() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store_at(&dir);
+        store.bulk_save(payload("Wort")).unwrap();
+        let base = store.base_records.lock().unwrap().clone();
+        let delta = delta_payload("Wort", FULL_KEYS_TWO, profile_with("Wort", "known"));
+        let journal = encode_save_journal(&delta, &base, record_files::now_millis());
+        std::fs::write(store.save_journal_path(), serde_json::to_vec(&journal).unwrap()).unwrap();
+        // A fresh store instance replays the interrupted delta save.
+        let store2 = store_at(&dir);
+        store2.recover_pending_save().unwrap();
+        let snapshot = store2.snapshot();
+        assert_eq!(snapshot["vocab"]["de"]["vocab"]["wort"]["status"], "known");
+        assert!(!store2.save_journal_path().exists());
     }
 }

--- a/src/web/js/api.ts
+++ b/src/web/js/api.ts
@@ -4,15 +4,14 @@ import { STATE_SCHEMA_VERSION, STORAGE_KEY } from "./constants.js";
 
 /** Build a save payload from the raw state for bridge (Tauri) communication. */
 export function buildSavePayload(rawState: WhSaveStateInput): WhSavePayload {
-  const profileTexts = Object.values(rawState.profiles || {})
-    .flatMap((profile) => Array.isArray(profile?.customTexts) ? profile.customTexts : []);
+  const texts = collectTexts(rawState);
   const profiles = Object.fromEntries(Object.entries(rawState.profiles || {}).map(([lang, profile]) => {
     const { customTexts: _customTexts, ...withoutTexts } = profile || {};
     return [lang, toPlain(withoutTexts)];
   }));
   return {
     schemaVersion: STATE_SCHEMA_VERSION,
-    texts: toPlain(profileTexts.length ? profileTexts : (rawState.customTexts || [])),
+    texts: toPlain(texts),
     prefs: {
       ...toPlain(rawState.preferences || {}),
       __discover: toPlain(discoverPayload(rawState.discover))
@@ -20,6 +19,71 @@ export function buildSavePayload(rawState: WhSaveStateInput): WhSavePayload {
     hiddenBooks: toPlain(rawState.hiddenBuiltInBooks || []),
     // Texts have their own durable store; do not serialize every book twice.
     vocab: profiles
+  };
+}
+
+function collectTexts(rawState: WhSaveStateInput): Array<Record<string, unknown>> {
+  const profileTexts = Object.values(rawState.profiles || {})
+    .flatMap((profile) => Array.isArray(profile?.customTexts) ? profile.customTexts : []);
+  return profileTexts.length ? profileTexts : (rawState.customTexts || []);
+}
+
+/**
+ * Complete list of durable record keys the frontend currently holds, in the
+ * backend's key format. Sent with every incremental (delta) save so the
+ * backend can tell "untouched" from "deleted" without receiving a full
+ * snapshot.
+ */
+export function buildFullKeys(rawState: WhSaveStateInput): string[] {
+  const keys: string[] = [];
+  for (const [lang, profile] of Object.entries(rawState.profiles || {})) {
+    const language = lang || "other";
+    keys.push(`profile:${language}`);
+    const current = profile as WhProfile | undefined;
+    for (const word of Object.keys(current?.vocab || {})) keys.push(`vocab:${language}:${word}`);
+    for (const book of current?.userBooks || []) {
+      if (book && typeof book.id === "string") keys.push(`book:${language}:${book.id}`);
+    }
+  }
+  for (const text of collectTexts(rawState)) {
+    if (text && typeof text === "object" && typeof text.id === "string") keys.push(`text:${text.id}`);
+  }
+  for (const key of Object.keys(buildSavePayload(rawState).prefs)) keys.push(`pref:${key}`);
+  for (const id of rawState.hiddenBuiltInBooks || []) {
+    if (typeof id === "string") keys.push(`hidden:${id}`);
+  }
+  return keys;
+}
+
+/**
+ * Incremental save payload: full prefs/hiddenBooks (small), the complete
+ * vocab profiles for languages with mutations, and texts only when they
+ * changed — plus fullKeys declaring every key still held. Saves ~99% of the
+ * payload size compared to a full snapshot on every autosave tick.
+ */
+export function buildDeltaSavePayload(
+  rawState: WhSaveStateInput,
+  dirtyVocabLangs: ReadonlySet<string>,
+  dirtyTexts: boolean
+): WhDeltaSavePayload {
+  const full = buildSavePayload(rawState);
+  const vocab: Record<string, WhRecord> = {};
+  for (const [lang, profile] of Object.entries(rawState.profiles || {})) {
+    if (!dirtyVocabLangs.has(lang)) continue;
+    const { customTexts: _customTexts, ...withoutTexts } = profile || {};
+    vocab[lang] = toPlain(withoutTexts) as WhRecord;
+  }
+  return {
+    schemaVersion: STATE_SCHEMA_VERSION,
+    delta: true,
+    fullKeys: buildFullKeys(rawState),
+    records: {
+      schemaVersion: STATE_SCHEMA_VERSION,
+      texts: dirtyTexts ? full.texts : [],
+      prefs: full.prefs,
+      hiddenBooks: full.hiddenBooks,
+      vocab
+    }
   };
 }
 
@@ -59,7 +123,9 @@ export async function saveWithRetry(body: string, maxRetries: number): Promise<W
       });
       if (response.ok) return await response.json().catch(() => ({ ok: true }));
       const detail = (await response.text()).trim();
-      throw new Error(detail || `HTTP ${response.status}`);
+      const error = new Error(detail || `HTTP ${response.status}`) as Error & { status?: number };
+      error.status = response.status;
+      throw error;
     } catch (e) {
       if (attempt === maxRetries) throw e;
       await new Promise(r => setTimeout(r, 200 * (attempt + 1)));

--- a/src/web/js/state/autosave.ts
+++ b/src/web/js/state/autosave.ts
@@ -1,4 +1,4 @@
-import { buildSavePayload, saveToLocalStorage, saveWithRetry, saveSyncXhr } from "../api.js";
+import { buildDeltaSavePayload, buildSavePayload, saveToLocalStorage, saveWithRetry, saveSyncXhr } from "../api.js";
 
 type SaveResult = WhBridgeSaveResult | void;
 
@@ -47,6 +47,15 @@ export function createAutosave(getState: () => WhAppState) {
   let saveStartedMutationSequence = 0;
   let lastMutationAt = 0;
   let lastSaveSucceededAt = 0;
+  // Incremental-save dirty tracking: which languages changed vocab (sent in
+  // full per language, because the backend tombstones anything omitted from
+  // the payload unless it is declared in fullKeys), and whether custom texts
+  // changed (texts are large; sent only on change).
+  const dirtyVocabLangs = new Set<string>();
+  let dirtyTexts = false;
+  const rootProfiles = new WeakSet<object>();
+  type DirtyContext = { kind: "vocab" | "word" | "profile" | "books" | "texts"; lang?: string };
+  const dirtyContexts = new WeakMap<object, DirtyContext>();
 
   function hasPendingChanges(): boolean {
     return lastMutationAt > lastSaveSucceededAt
@@ -115,17 +124,34 @@ export function createAutosave(getState: () => WhAppState) {
     }
     saveInFlight = true;
     saveStartedMutationSequence = mutationSequence;
-    savePromise = saveWithRetry(JSON.stringify(buildSavePayload(current)), 3).then((result) => {
+    const markSucceeded = (result: SaveResult): SaveResult => {
       applyBackendSaveStatus(result);
       retryDelayMs = 0;
       lastSaveSucceededAt = Date.now();
+      dirtyVocabLangs.clear();
+      dirtyTexts = false;
       saveInFlight = false;
       if (savePending) {
         savePending = false;
         return doSave();
       }
       return result;
-    }).catch((error) => {
+    };
+    const payload = buildDeltaSavePayload(current, dirtyVocabLangs, dirtyTexts);
+    savePromise = saveWithRetry(JSON.stringify(payload), 3).then(markSucceeded).catch(async (error) => {
+      // The backend may reject a delta payload (validation edge or an older
+      // server build). Retry once with a full snapshot — but only for an
+      // HTTP 4xx rejection, never for network failures. A delta rejection
+      // must never silently drop changes.
+      const status = (error as Error & { status?: number })?.status ?? 0;
+      if (status >= 400 && status < 500) {
+        try {
+          const fullResult = await saveWithRetry(JSON.stringify(buildSavePayload(current)), 3);
+          return markSucceeded(fullResult);
+        } catch (fallbackError) {
+          // fall through to the standard error path
+        }
+      }
       saveInFlight = false;
       console.error("bridge save failed after retries", error);
       savePending = false;
@@ -227,7 +253,22 @@ export function createAutosave(getState: () => WhAppState) {
             || (object === rootTarget && BRIDGE_UI_ROOT_KEYS.has(prop));
           if (prop === "vocab") vocabularyMaps.add(value);
           else if (vocabularyMaps.has(object)) vocabularyEntries.add(value);
-          return proxyCache.get(value) || wrap(value, childIsBridgeUi);
+          const wrapped = proxyCache.get(value) || wrap(value, childIsBridgeUi);
+          // Register the child's dirty-tracking context so mutations can be
+          // attributed to a language (vocab) or to the texts store.
+          if (object === rootTarget && prop === "profiles") {
+            rootProfiles.add(wrapped);
+          } else if (rootProfiles.has(object)) {
+            dirtyContexts.set(wrapped, { kind: "profile", lang: String(prop) });
+          } else {
+            const ctx = dirtyContexts.get(object);
+            if (ctx?.kind === "profile" && prop === "vocab") dirtyContexts.set(wrapped, { kind: "vocab", lang: ctx.lang });
+            else if (ctx?.kind === "profile" && prop === "userBooks") dirtyContexts.set(wrapped, { kind: "books", lang: ctx.lang });
+            else if (ctx?.kind === "profile" && prop === "customTexts") dirtyContexts.set(wrapped, { kind: "texts", lang: ctx.lang });
+            else if (ctx?.kind === "profile") dirtyContexts.set(wrapped, { kind: "profile", lang: ctx.lang });
+            else if (ctx?.kind === "vocab") dirtyContexts.set(wrapped, { kind: "word", lang: ctx.lang });
+          }
+          return wrapped;
         }
         return value;
       },
@@ -235,7 +276,17 @@ export function createAutosave(getState: () => WhAppState) {
         const oldValue = Reflect.get(object, prop, receiver);
         const rawValue = unwrapProxy(value);
         const result = Reflect.set(object, prop, rawValue, receiver);
-        if (oldValue !== rawValue) recordVocabularyMutation(object, prop);
+        if (oldValue !== rawValue) {
+          recordVocabularyMutation(object, prop);
+          const ctx = dirtyContexts.get(object);
+          if (ctx?.kind === "vocab" || ctx?.kind === "word" || ctx?.kind === "profile" || ctx?.kind === "books") {
+            if (ctx.lang) dirtyVocabLangs.add(ctx.lang);
+          } else if (ctx?.kind === "texts") {
+            dirtyTexts = true;
+          } else if (object === rootTarget && prop === "customTexts") {
+            dirtyTexts = true;
+          }
+        }
         if (oldValue !== rawValue
           && !(object === rootTarget && TRANSIENT_ROOT_KEYS.has(prop))
           && !isUiMutation(object, prop)) {
@@ -248,6 +299,12 @@ export function createAutosave(getState: () => WhAppState) {
         if (prop in object) {
           Reflect.deleteProperty(object, prop);
           recordVocabularyMutation(object, prop);
+          const ctx = dirtyContexts.get(object);
+          if (ctx?.kind === "vocab" || ctx?.kind === "word" || ctx?.kind === "profile" || ctx?.kind === "books") {
+            if (ctx.lang) dirtyVocabLangs.add(ctx.lang);
+          } else if (ctx?.kind === "texts") {
+            dirtyTexts = true;
+          }
           if (!(object === rootTarget && TRANSIENT_ROOT_KEYS.has(prop))
             && !isUiMutation(object, prop)) {
             if (suspendAutoSave === 0) durableStateRevision += 1;
@@ -274,6 +331,9 @@ export function createAutosave(getState: () => WhAppState) {
     markDurableStateReplaced() {
       durableStateRevision += 1;
       vocabularyRevision += 1;
+      const current = rawState();
+      for (const lang of Object.keys(current.profiles || {})) dirtyVocabLangs.add(lang);
+      dirtyTexts = true;
     },
     flushPendingSave() {
       clearTimeout(saveTimer);

--- a/types/wordhunter-browser.d.ts
+++ b/types/wordhunter-browser.d.ts
@@ -290,6 +290,19 @@ declare global {
     vocab: Record<string, WhRecord>;
   }
 
+  interface WhDeltaSavePayload {
+    schemaVersion: number;
+    delta: true;
+    fullKeys: string[];
+    records: {
+      schemaVersion: number;
+      texts: WhText[];
+      prefs: WhRecord;
+      hiddenBooks: string[];
+      vocab: Record<string, WhRecord>;
+    };
+  }
+
   interface WhStoredTextInput extends WhRecord {
     id: string;
     text: string;


### PR DESCRIPTION
Fixes the autosave cost: the frontend used to serialize and POST the entire store (~21 MB) on every debounced save tick, even though the backend only wrote changed records to disk.

Now autosave sends a delta payload: fullKeys (complete key list) + changed records (full vocab profile per mutated language, texts only when changed, small prefs/hiddenBooks always). The backend merge treats fullKeys-declared-but-unsent keys as untouched; tombstones still apply to keys missing from fullKeys, so deletions propagate without a full snapshot.

Safety: a 4xx rejection of a delta falls back to one full-snapshot save; network failures never trigger the fallback. Journal replay supports delta payloads.

Tests: cargo 269/269 (5 new delta tests), frontend 461/461 (3 new tests).