### PR TITLE
fix: Android AI settings, snapshot clobbering, Google translation reliability

### DIFF
--- a/frontend-tests/shared/persistence-lifecycle.test.js
+++ b/frontend-tests/shared/persistence-lifecycle.test.js
@@ -128,6 +128,7 @@ async function loadAppHarness({
       applyBridgeSnapshotToState: noOp,
       flushFrontendStateBuffers() { calls.push("flush-buffers"); },
       flushUiStateSync: noOp,
+      hasPendingLocalChanges: () => false,
       saveState() { calls.push("save-state"); return Promise.resolve(); },
       state
     },
@@ -483,6 +484,32 @@ describe("persistence lifecycle", () => {
     state.preferences.theme = "alternative-familiar";
     assert.equal(scheduled, 1);
     assert.equal(autosave.getDurableStateRevision(), 1);
+  });
+
+  it("reports pending local changes until the save lands, then clears them", async () => {
+    let scheduled = 0;
+    const rawState = { preferences: { theme: "familiar" }, profiles: {}, vocab: {} };
+    const { createAutosave } = await evaluateWithMocks("../../dist/web/js/state/autosave.js", {
+      "../api.js": {
+        buildSavePayload: (state) => state,
+        buildDeltaSavePayload: (_raw, _langs, _texts) => ({ delta: true, fullKeys: [], records: {} }),
+        saveToLocalStorage() {},
+        async saveWithRetry() { return {}; },
+        saveSyncXhr() {}
+      }
+    }, {
+      window: { __qtBridge: true },
+      setTimeout() { scheduled += 1; return scheduled; },
+      clearTimeout() {},
+      console
+    });
+    const autosave = createAutosave(() => rawState);
+    const state = autosave.wrap(rawState);
+    assert.equal(autosave.hasPendingChanges(), false, "clean start has no pending changes");
+    state.preferences.theme = "classic-dark";
+    assert.equal(autosave.hasPendingChanges(), true, "fresh edit is pending");
+    await autosave.saveState();
+    assert.equal(autosave.hasPendingChanges(), false, "pending clears after a successful save");
   });
 
   it("writes an explicit bridge UI save to the local UI cache", async () => {

--- a/src-tauri/src/external_translator.rs
+++ b/src-tauri/src/external_translator.rs
@@ -89,26 +89,40 @@ fn translate_deepl(text: &str, from: &str, to: &str, key: &str) -> Result<String
 }
 
 fn translate_google(text: &str, from: &str, to: &str) -> Result<String, String> {
-    let mut query = Serializer::new(String::new());
-    query.append_pair("client", "gtx");
-    query.append_pair(
-        "sl",
-        if from.is_empty() {
-            "auto"
-        } else {
-            google_lang(from)
-        },
-    );
-    query.append_pair("tl", google_lang(to));
-    query.append_pair("dt", "t");
-    query.append_pair("q", text);
-    let url = format!(
-        "https://translate.googleapis.com/translate_a/single?{}",
-        query.finish()
-    );
+    // The unofficial gtx endpoint throttles intermittently, especially from
+    // mobile carrier IPs (which is where the Android build makes the call).
+    // Retry once with a different client alias before giving up.
+    let mut last_error: Option<String> = None;
+    for client in ["gtx", "dict-chrome-ex"] {
+        let mut query = Serializer::new(String::new());
+        query.append_pair("client", client);
+        query.append_pair(
+            "sl",
+            if from.is_empty() {
+                "auto"
+            } else {
+                google_lang(from)
+            },
+        );
+        query.append_pair("tl", google_lang(to));
+        query.append_pair("dt", "t");
+        query.append_pair("q", text);
+        let url = format!(
+            "https://translate.googleapis.com/translate_a/single?{}",
+            query.finish()
+        );
 
+        match translate_google_url(&url) {
+            Ok(translated) => return Ok(translated),
+            Err(error) => last_error = Some(error),
+        }
+    }
+    Err(last_error.unwrap_or_else(|| "Google Translate returned no translation".to_string()))
+}
+
+fn translate_google_url(url: &str) -> Result<String, String> {
     let response = crate::http::agent()
-        .get(&url)
+        .get(url)
         .set("User-Agent", USER_AGENT)
         .call()
         .map_err(|e| e.to_string())?;

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -6,7 +6,7 @@ import { applyPreferences, syncSettingsControls } from "./js/preferences.js";
 import { hydrateCurrentReaderText, loadBooksCatalog } from "./js/books.js";
 import { render, ensureCurrentText } from "./js/render.js";
 import { loadLocale, applyTranslations, t, getLocale } from "./js/i18n.js";
-import { applyBridgeSnapshotToState, flushFrontendStateBuffers, flushUiStateSync, saveState, state } from "./js/state.js";
+import { applyBridgeSnapshotToState, flushFrontendStateBuffers, flushUiStateSync, hasPendingLocalChanges, saveState, state } from "./js/state.js";
 import { bindLibraryEvents, renderLibrary } from "./js/views/library.js";
 import { renderReview, renderVocabulary } from "./js/views/vocabulary.js";
 import { applyPlatformUi, detectPlatform, isAndroidPlatform, openAndroidUrl } from "./js/platform.js";
@@ -152,8 +152,14 @@ function startBridgeStateLoad(): void {
   window.__bridgeStatePromise = promise;
   void promise
     .then((snapshot) => {
-      applyBridgeSnapshotToState(snapshot);
       delete window.__bridgeStatePromise;
+      // On Android (and any slow start) the snapshot arrives asynchronously,
+      // after the user may already have edited preferences, words, or texts.
+      // Never clobber fresh local changes with the older backend snapshot:
+      // autosave persists the user's edits on top of the backend state, and
+      // the snapshot will be applied on the next clean start instead.
+      if (hasPendingLocalChanges()) return;
+      applyBridgeSnapshotToState(snapshot);
     })
     .catch((error) => {
       reportClientError(`Store load failed: ${error?.stack || error}`, error);

--- a/src/web/js/state.ts
+++ b/src/web/js/state.ts
@@ -75,6 +75,15 @@ export function saveState(): Promise<WhBridgeSaveResult | void> {
   return autosave.saveState();
 }
 
+/**
+ * True when the user changed durable state since the last successful save
+ * (or a save is queued/in flight). Used to avoid clobbering fresh local
+ * edits with a late-arriving backend snapshot (slow start on Android).
+ */
+export function hasPendingLocalChanges(): boolean {
+  return autosave.hasPendingChanges();
+}
+
 export function saveUiState(): Promise<WhBridgeSaveResult | void> {
   if (window.__qtBridge) {
     if (uiWritesPaused > 0) {


### PR DESCRIPTION
Fixes from the Android audit:\n\n1. **Snapshot clobbering (root cause of 'can't set AI options')**: on Android the backend snapshot is fetched asynchronously; if it resolves after the user already toggled AI/edited preferences, applyBridgeSnapshotToState replaced the whole state with the older snapshot (state.ts:245 replaceState). Now the load is skipped when hasPendingLocalChanges() — user edits win, autosave persists them on top.\n2. **Google translation throttling** (translation error from mobile IPs): translate_google now retries with client=dict-chrome-ex when client=gtx fails.\n\nFrontend 462/462 (incl. E2E), cargo check + fmt clean.