### PR TITLE
fix: AI toggle sync + translation error reasons

### DIFF
--- a/src/web/js/events/settings.ts
+++ b/src/web/js/events/settings.ts
@@ -475,14 +475,16 @@ export function bindSettingsEvents() {
       const target = event.currentTarget as HTMLInputElement;
       updatePreferenceValue("aiExplanationsEnabled", target.checked);
       syncSettingsControls();
-      if (target.checked) {
-        const items = normalizeSelectedWordPanelItems(state.preferences.selectedWordPanelItems);
-        const aiItem = items.find((item) => item.id === "ai");
-        if (aiItem && !aiItem.visible) {
-          aiItem.visible = true;
-          saveSelectedWordPanelItems(items);
-          showToast(t("settings.aiPanelItemShown"));
-        }
+      // Keep the word-panel "ai" item in sync with the toggle in both
+      // directions: enabling shows the button, disabling hides it. A
+      // pre-existing mismatch (ai visible but feature off, or vice versa)
+      // must not leave the panel button out of sync with the setting.
+      const items = normalizeSelectedWordPanelItems(state.preferences.selectedWordPanelItems);
+      const aiItem = items.find((item) => item.id === "ai");
+      if (aiItem && aiItem.visible !== target.checked) {
+        aiItem.visible = target.checked;
+        saveSelectedWordPanelItems(items);
+        if (target.checked) showToast(t("settings.aiPanelItemShown"));
       }
     });
   }

--- a/src/web/js/reader/word-panel.ts
+++ b/src/web/js/reader/word-panel.ts
@@ -264,7 +264,10 @@ function bindContextTranslation(word: string, context: string): void {
     } catch (error) {
       if (generation !== contextTranslationGeneration || state.selectedWord !== word) return;
       console.warn("Context translation failed", error);
-      output.textContent = t("translator.error");
+      // Surface the backend reason (e.g. provider throttled, missing key)
+      // so transient vs. configuration errors are distinguishable on device.
+      const reason = error instanceof Error && error.message ? ` — ${error.message}` : "";
+      output.textContent = `${t("translator.error")}${reason}`;
     } finally {
       releaseBusy();
     }


### PR DESCRIPTION
Follow-up from the Android audit (#89):\n\n- **AI toggle ↔ panel item sync**: enabling AI explanations shows the panel button, disabling hides it (previously disabling left the button visible); any pre-existing mismatch is repaired.\n- **Translation errors**: the context-translation failure text now includes the backend reason (throttled provider / missing key), making on-device diagnosis possible.\n\nFocused suites 63/63, build clean.