### PR TITLE
fix: buffer backend saves until the snapshot is applied

### DIFF
--- a/frontend-tests/shared/persistence-lifecycle.test.js
+++ b/frontend-tests/shared/persistence-lifecycle.test.js
@@ -128,7 +128,6 @@ async function loadAppHarness({
       applyBridgeSnapshotToState: noOp,
       flushFrontendStateBuffers() { calls.push("flush-buffers"); },
       flushUiStateSync: noOp,
-      hasPendingLocalChanges: () => false,
       saveState() { calls.push("save-state"); return Promise.resolve(); },
       state
     },
@@ -510,6 +509,58 @@ describe("persistence lifecycle", () => {
     assert.equal(autosave.hasPendingChanges(), true, "fresh edit is pending");
     await autosave.saveState();
     assert.equal(autosave.hasPendingChanges(), false, "pending clears after a successful save");
+  });
+
+  it("buffers saves to localStorage until the backend snapshot is applied", async () => {
+    const localStorageSaves = [];
+    const backendSaves = [];
+    const rawState = { preferences: { theme: "familiar" }, profiles: {}, vocab: {} };
+    const { createAutosave } = await evaluateWithMocks("../../dist/web/js/state/autosave.js", {
+      "../api.js": {
+        buildSavePayload: (state) => state,
+        buildDeltaSavePayload: (_raw, _langs, _texts) => ({ delta: true, fullKeys: [], records: {} }),
+        saveToLocalStorage: (payload) => { localStorageSaves.push(payload); },
+        async saveWithRetry(body) { backendSaves.push(body); return {}; },
+        saveSyncXhr() {}
+      }
+    }, {
+      window: { __qtBridge: true, __bridgeState: null },
+      setTimeout() { return 1; },
+      clearTimeout() {},
+      console
+    });
+    const autosave = createAutosave(() => rawState);
+    const state = autosave.wrap(rawState);
+    state.preferences.theme = "classic-dark";
+    await autosave.saveState();
+    assert.equal(localStorageSaves.length, 1, "edit buffered to localStorage before the snapshot lands");
+    assert.equal(backendSaves.length, 0, "nothing sent to the backend before the snapshot lands");
+  });
+
+  it("sends to the backend once the snapshot has been applied", async () => {
+    const localStorageSaves = [];
+    const backendSaves = [];
+    const rawState = { preferences: { theme: "familiar" }, profiles: {}, vocab: {} };
+    const { createAutosave } = await evaluateWithMocks("../../dist/web/js/state/autosave.js", {
+      "../api.js": {
+        buildSavePayload: (state) => state,
+        buildDeltaSavePayload: (_raw, _langs, _texts) => ({ delta: true, fullKeys: [], records: {} }),
+        saveToLocalStorage: (payload) => { localStorageSaves.push(payload); },
+        async saveWithRetry(body) { backendSaves.push(body); return {}; },
+        saveSyncXhr() {}
+      }
+    }, {
+      window: { __qtBridge: true, __bridgeState: {} },
+      setTimeout() { return 1; },
+      clearTimeout() {},
+      console
+    });
+    const autosave = createAutosave(() => rawState);
+    const state = autosave.wrap(rawState);
+    state.preferences.theme = "classic-dark";
+    await autosave.saveState();
+    assert.equal(localStorageSaves.length, 0, "no localStorage buffering once the snapshot is applied");
+    assert.equal(backendSaves.length, 1, "edit sent to the backend once the snapshot is applied");
   });
 
   it("writes an explicit bridge UI save to the local UI cache", async () => {

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -6,7 +6,7 @@ import { applyPreferences, syncSettingsControls } from "./js/preferences.js";
 import { hydrateCurrentReaderText, loadBooksCatalog } from "./js/books.js";
 import { render, ensureCurrentText } from "./js/render.js";
 import { loadLocale, applyTranslations, t, getLocale } from "./js/i18n.js";
-import { applyBridgeSnapshotToState, flushFrontendStateBuffers, flushUiStateSync, hasPendingLocalChanges, saveState, state } from "./js/state.js";
+import { applyBridgeSnapshotToState, flushFrontendStateBuffers, flushUiStateSync, saveState, state } from "./js/state.js";
 import { bindLibraryEvents, renderLibrary } from "./js/views/library.js";
 import { renderReview, renderVocabulary } from "./js/views/vocabulary.js";
 import { applyPlatformUi, detectPlatform, isAndroidPlatform, openAndroidUrl } from "./js/platform.js";
@@ -152,14 +152,8 @@ function startBridgeStateLoad(): void {
   window.__bridgeStatePromise = promise;
   void promise
     .then((snapshot) => {
-      delete window.__bridgeStatePromise;
-      // On Android (and any slow start) the snapshot arrives asynchronously,
-      // after the user may already have edited preferences, words, or texts.
-      // Never clobber fresh local changes with the older backend snapshot:
-      // autosave persists the user's edits on top of the backend state, and
-      // the snapshot will be applied on the next clean start instead.
-      if (hasPendingLocalChanges()) return;
       applyBridgeSnapshotToState(snapshot);
+      delete window.__bridgeStatePromise;
     })
     .catch((error) => {
       reportClientError(`Store load failed: ${error?.stack || error}`, error);

--- a/src/web/js/state.ts
+++ b/src/web/js/state.ts
@@ -75,15 +75,6 @@ export function saveState(): Promise<WhBridgeSaveResult | void> {
   return autosave.saveState();
 }
 
-/**
- * True when the user changed durable state since the last successful save
- * (or a save is queued/in flight). Used to avoid clobbering fresh local
- * edits with a late-arriving backend snapshot (slow start on Android).
- */
-export function hasPendingLocalChanges(): boolean {
-  return autosave.hasPendingChanges();
-}
-
 export function saveUiState(): Promise<WhBridgeSaveResult | void> {
   if (window.__qtBridge) {
     if (uiWritesPaused > 0) {

--- a/src/web/js/state/autosave.ts
+++ b/src/web/js/state/autosave.ts
@@ -122,6 +122,22 @@ export function createAutosave(getState: () => WhAppState) {
         return Promise.reject(error);
       }
     }
+    if (window.__bridgeState === null) {
+      // The backend snapshot has not been applied yet: on Android it is
+      // fetched asynchronously after boot. Sending a delta/full payload now
+      // would tombstone the store with an effectively empty state. Buffer
+      // locally; once the snapshot lands, markDurableStateReplaced flags
+      // everything dirty and the next save pushes the full state through.
+      // (In tests __bridgeState is undefined, which deliberately bypasses
+      // this guard; at runtime the bootstrap always sets it to null first.)
+      try {
+        saveToLocalStorage(current);
+        lastSaveSucceededAt = Date.now();
+        return Promise.resolve();
+      } catch (error) {
+        return Promise.reject(error);
+      }
+    }
     saveInFlight = true;
     saveStartedMutationSequence = mutationSequence;
     const markSucceeded = (result: SaveResult): SaveResult => {
@@ -349,7 +365,8 @@ export function createAutosave(getState: () => WhAppState) {
       if (!hasPendingChanges()) return;
       const current = rawState();
       syncProfilePreferences();
-      if (window.__qtBridge) saveSyncXhr(JSON.stringify(buildSavePayload(current)));
+      if (window.__qtBridge && window.__bridgeState === null) saveToLocalStorage(current);
+      else if (window.__qtBridge) saveSyncXhr(JSON.stringify(buildSavePayload(current)));
       else saveToLocalStorage(current);
     },
     hasPendingChanges,


### PR DESCRIPTION
Senior-review follow-up replacing the #89 snapshot guard with a safe mechanism:\n\n- **Problem found**: the #89 guard skipped the snapshot when `hasPendingLocalChanges()` — but boot-time normalizations (theme alias, Android provider coercion) mutate state at startup, so the guard would skip the load *and* the next save would send an empty delta → tombstones the whole store.\n- **Fix**: while `window.__bridgeState === null` (snapshot not yet applied), saves buffer to localStorage only — for both autosave and the shutdown flush. After the snapshot lands, everything is dirty and the full state syncs to the backend.\n- Frontend 464/464 (incl. E2E), build clean.