### PR TITLE
Fix #124: stale CSS cache-buster (old stylesheet for up to a year)

### DIFF
--- a/src/web/index.html
+++ b/src/web/index.html
@@ -14,8 +14,8 @@
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"></noscript>
   <link rel="icon" type="image/svg+xml" href="favicon.svg">
   <link rel="alternate icon" type="image/png" href="favicon.png">
-  <link rel="stylesheet" href="theme.css?v=20260714-desktop-dark">
-  <link rel="stylesheet" href="styles.css?v=20260715-panel-controls">
+  <link rel="stylesheet" href="theme.css?v=20260808-ux-fixes">
+  <link rel="stylesheet" href="styles.css?v=20260808-ux-fixes">
   <link rel="stylesheet" href="platforms/android-pocket.css?v=20260715-panel-controls">
 </head>
 <body>

--- a/src/web/templates/translator-popup.html
+++ b/src/web/templates/translator-popup.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{title}}</title>
     <script type="module" src="/translator-popup.js"></script>
-    <link rel="stylesheet" href="/theme.css?v=20260713-theme-audit">
+    <link rel="stylesheet" href="/theme.css?v=20260808-ux-fixes">
     <style>
         :root {
             --popup-accent: #297a5b;


### PR DESCRIPTION
Closes #124

**Audit verdict:** CONFIRMED (wave-3 audit + independent verification: `git show ac3d7ef` changed styles.css without bumping `?v=`; static assets are cached 1 year).

**Fix:** bump styles.css/theme.css to one shared `?v=20260808-ux-fixes` in index.html AND translator-popup.html (also fixes the dual theme.css cache-key hazard). Full centralization (auto-generated `?v=` from build hash) is tracked separately in #128.

**Note:** this is a manual bump — the durable fix is #128's build-generated cache-buster.