### PR TITLE
Fix #123: translator Ctrl+E badge destroyed at boot

### DIFF
--- a/frontend-tests/shared/keyboard-shortcuts.test.js
+++ b/frontend-tests/shared/keyboard-shortcuts.test.js
@@ -78,6 +78,16 @@ function resetState(view = "reader") {
 }
 
 describe("keyboard shortcut dispatch", () => {
+  it("keeps the translator Ctrl+E badge outside the translated label", () => {
+    const html = readFileSync(new URL("../../src/web/index.html", import.meta.url), "utf8");
+    const button = html.match(/<button[^>]+id="translator-ai-explain"[^>]*>([^]*?)<\/button>/)?.[0] || "";
+
+    assert.notEqual(button, "");
+    assert.doesNotMatch(button.match(/^<button[^>]*>/)?.[0] || "", /data-i18n=/);
+    assert.match(button, /<span data-i18n="reader\.aiExplain">[^<]+<\/span>/);
+    assert.match(button, /<span class="shortcut-badge">Ctrl\+E<\/span>/);
+  });
+
   it("routes Ctrl+1..4 to the active image results before Reader grading", () => {
     resetState("reader");
     let selected = 0;

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -435,7 +435,7 @@
               </label>
             </div>
             <div class="translator-actions">
-              <button class="secondary-button button-xs" type="button" id="translator-ai-explain" data-i18n="reader.aiExplain" hidden>Explain with AI <span class="shortcut-badge">Ctrl+E</span></button>
+              <button class="secondary-button button-xs" type="button" id="translator-ai-explain" hidden><span data-i18n="reader.aiExplain">Explain with AI</span> <span class="shortcut-badge">Ctrl+E</span></button>
               <p class="muted-copy" id="translator-status" role="status" aria-live="polite" aria-atomic="true" data-i18n="translator.ready">Gotowy do tłumaczenia.</p>
               <div class="translator-progress" id="translator-progress"><div class="translator-progress-fill"></div></div>
             </div>


### PR DESCRIPTION
Closes #123

**Audit verdict:** CONFIRMED (i18n wave + wave-4 style check: applyTranslations sets textContent on the button, wiping the badge; navigation.ts:20 only clicks).

**Fix:** move `data-i18n="reader.aiExplain"` to the inner span (same pattern as graphs-ai-explain).