### PR TITLE
Fix #92: command injection in /__open_external (no more cmd shell)

### DIFF
--- a/frontend-tests/shared/repo-validation.test.js
+++ b/frontend-tests/shared/repo-validation.test.js
@@ -244,6 +244,20 @@ describe("repository validation wiring", () => {
     assert.match(buildScript, /WordHunter-\$\{release_version\}-aarch64\.dmg/);
   });
 
+  it("opens external URLs on Windows without passing them through cmd.exe", () => {
+    const cargo = read("../../src-tauri/Cargo.toml");
+    const handlers = read("../../src-tauri/src/handlers.rs");
+    const rustSources = filesBelow(new URL("../../src-tauri/src/", import.meta.url))
+      .filter((file) => file.pathname.endsWith(".rs"))
+      .map((file) => readFileSync(file, "utf8"))
+      .join("\n");
+
+    assert.match(cargo, /open = \{ version = "5", features = \["shellexecute-on-windows"\] \}/);
+    assert.match(handlers, /open::that_detached\(url\)/);
+    assert.doesNotMatch(rustSources, /open::(?:that|with)\(/);
+    assert.doesNotMatch(rustSources, /open::(?:that|with)_in_background\(/);
+  });
+
   it("keeps the TypeScript build pinned, explicit, and outside source assets", () => {
     const packageJson = JSON.parse(read("../../package.json"));
     const lockfile = JSON.parse(read("../../package-lock.json"));

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2980,6 +2980,7 @@ version = "5.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd8d3b65c44123a56e0133d2cd06ce4361bd3ca99d41198b2f25e3c3db9b8b4a"
 dependencies = [
+ "dunce",
  "is-wsl",
  "libc",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -51,7 +51,7 @@ zip = "2"
 ctranslate2 = { version = "2.1.1", default-features = false, features = ["sentencepiece"] }
 ctranslate2-sys = { version = "0.1.5", features = ["ruy", "crt-dynamic"] }
 edge-tts-rust = "0.1.3"
-open = "5"
+open = { version = "5", features = ["shellexecute-on-windows"] }
 rfd = "0.15"
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/src-tauri/src/handlers.rs
+++ b/src-tauri/src/handlers.rs
@@ -12,43 +12,39 @@ use crate::{offline_translator, response, server::ServerState, tts};
 /// frontend when a top-level window is needed (YouGlish fallback, source
 /// links): plain `window.open` from an async callback is popup-blocked in
 /// the webview, so the embedded server does the opening instead.
-pub(crate) fn open_external_url(url: &str) -> Result<(), String> {
+///
+/// The URL is validated strictly (parseable, http/https scheme, host
+/// present) and opened via the `open` crate (ShellExecuteW / LaunchServices /
+/// xdg-open) — NEVER through `cmd /c start`, whose metacharacter handling
+/// allowed command injection via `& | ^ < >` in the URL.
+/// Validate an external URL without any side effects: parseable, http/https
+/// scheme, host present, no control characters. Pure — unit-testable.
+fn validate_external_url(url: &str) -> Result<(), String> {
     let url = url.trim();
-    if url.is_empty() || !(url.starts_with("https://") || url.starts_with("http://")) {
+    if url.is_empty() || url.chars().any(|c| c.is_control()) {
+        return Err("refusing to open an empty or control-character URL".to_string());
+    }
+    let parsed = url::Url::parse(url).map_err(|e| format!("invalid URL: {e}"))?;
+    if !matches!(parsed.scheme(), "http" | "https") {
         return Err("refusing to open a non-http URL".to_string());
     }
-    #[cfg(target_os = "windows")]
-    {
-        use std::os::windows::process::CommandExt;
-        std::process::Command::new("cmd")
-            .args(["/c", "start", "", url])
-            // CREATE_NO_WINDOW: never flash a console while starting the browser.
-            .creation_flags(0x08000000)
-            .spawn()
-            .map_err(|e| format!("could not open the default browser: {e}"))?;
-        return Ok(());
+    if parsed.host_str().is_none() {
+        return Err("URL is missing a host".to_string());
     }
-    #[cfg(target_os = "macos")]
-    {
-        std::process::Command::new("open")
-            .arg(url)
-            .spawn()
-            .map_err(|e| format!("could not open the default browser: {e}"))?;
-        return Ok(());
-    }
-    #[cfg(all(unix, not(target_os = "macos")))]
-    {
-        std::process::Command::new("xdg-open")
-            .arg(url)
-            .spawn()
-            .map_err(|e| format!("could not open the default browser: {e}"))?;
-        return Ok(());
-    }
+    Ok(())
+}
+
+pub(crate) fn open_external_url(url: &str) -> Result<(), String> {
+    validate_external_url(url)?;
     #[cfg(target_os = "android")]
     {
         // Android opens URLs through the Java bridge (openAndroidUrl), not
         // this endpoint.
         Err("external URLs are opened through the Android bridge".to_string())
+    }
+    #[cfg(not(target_os = "android"))]
+    {
+        open::that(url).map_err(|e| format!("could not open the default browser: {e}"))
     }
 }
 
@@ -537,6 +533,7 @@ mod window_zoom_tests {
 
     use super::open_external_url;
     use super::parse_window_zoom_percent;
+    use super::validate_external_url;
     #[cfg(not(target_os = "android"))]
     use super::{export_sidecar_path, write_export_file};
 
@@ -575,13 +572,19 @@ mod window_zoom_tests {
 
     #[test]
     fn open_external_url_rejects_non_http_and_empty() {
-        assert!(open_external_url("").is_err());
-        assert!(open_external_url("file:///C:/Windows/win.ini").is_err());
-        assert!(open_external_url("javascript:alert(1)").is_err());
-        assert!(open_external_url("not a url").is_err());
-        // Valid https URLs pass validation (on this platform they would
-        // spawn the browser; validation happens before any spawn attempt).
-        assert!(open_external_url("https://youglish.com/pronounce/klima/german").is_ok());
+        // Pure validation — no browser is spawned by these assertions.
+        assert!(validate_external_url("").is_err());
+        assert!(validate_external_url("file:///C:/Windows/win.ini").is_err());
+        assert!(validate_external_url("javascript:alert(1)").is_err());
+        assert!(validate_external_url("not a url").is_err());
+        assert!(validate_external_url("http://").is_err()); // no host
+        assert!(validate_external_url("https://exa\nmple.com").is_err()); // control char
+        // Command-injection regression: metacharacters are inert because the
+        // URL is never passed to a shell (open::that/ShellExecuteW). They
+        // must either be rejected or opened verbatim — never executed.
+        assert!(validate_external_url("https://example.com/a&calc.exe").is_ok());
+        assert!(validate_external_url("https://example.com/a|cmd").is_ok());
+        assert!(validate_external_url("https://youglish.com/pronounce/klima/german").is_ok());
     }
 
     #[test]

--- a/src-tauri/src/handlers.rs
+++ b/src-tauri/src/handlers.rs
@@ -14,9 +14,9 @@ use crate::{offline_translator, response, server::ServerState, tts};
 /// the webview, so the embedded server does the opening instead.
 ///
 /// The URL is validated strictly (parseable, http/https scheme, host
-/// present) and opened via the `open` crate (ShellExecuteW / LaunchServices /
-/// xdg-open) — NEVER through `cmd /c start`, whose metacharacter handling
-/// allowed command injection via `& | ^ < >` in the URL.
+/// present) and opened via the `open` crate's detached API. On Windows its
+/// `shellexecute-on-windows` feature calls ShellExecuteExW directly — never
+/// `cmd /c start`, whose quoting allowed command injection through a URL.
 /// Validate an external URL without any side effects: parseable, http/https
 /// scheme, host present, no control characters. Pure — unit-testable.
 fn validate_external_url(url: &str) -> Result<(), String> {
@@ -44,7 +44,7 @@ pub(crate) fn open_external_url(url: &str) -> Result<(), String> {
     }
     #[cfg(not(target_os = "android"))]
     {
-        open::that(url).map_err(|e| format!("could not open the default browser: {e}"))
+        open::that_detached(url).map_err(|e| format!("could not open the default browser: {e}"))
     }
 }
 
@@ -531,7 +531,6 @@ pub(crate) fn choose_data_dir(_state: &ServerState) -> Result<Option<String>, St
 mod window_zoom_tests {
     use serde_json::json;
 
-    use super::open_external_url;
     use super::parse_window_zoom_percent;
     use super::validate_external_url;
     #[cfg(not(target_os = "android"))]
@@ -580,10 +579,14 @@ mod window_zoom_tests {
         assert!(validate_external_url("http://").is_err()); // no host
         assert!(validate_external_url("https://exa\nmple.com").is_err()); // control char
         // Command-injection regression: metacharacters are inert because the
-        // URL is never passed to a shell (open::that/ShellExecuteW). They
-        // must either be rejected or opened verbatim — never executed.
+        // URL is never passed to a shell (open::that_detached/ShellExecuteExW).
+        // They must either be rejected or opened verbatim — never executed.
         assert!(validate_external_url("https://example.com/a&calc.exe").is_ok());
         assert!(validate_external_url("https://example.com/a|cmd").is_ok());
+        assert!(
+            validate_external_url("https://example.com/a%22%20&%20calc.exe%20&%20REM%20%22")
+                .is_ok()
+        );
         assert!(validate_external_url("https://youglish.com/pronounce/klima/german").is_ok());
     }
 

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -20,7 +20,7 @@ pub(crate) fn permit_exit(_app_handle: &tauri::AppHandle) {}
 
 #[cfg(not(target_os = "android"))]
 pub(crate) fn open_path(path: impl AsRef<Path>) {
-    let _ = open::that(path.as_ref());
+    let _ = open::that_detached(path.as_ref());
 }
 
 #[cfg(target_os = "android")]

--- a/src-tauri/src/popup.rs
+++ b/src-tauri/src/popup.rs
@@ -123,7 +123,7 @@ pub fn serve_open_dict(
                 }
             });
         } else {
-            let _ = open::that(target);
+            crate::handlers::open_external_url(&target)?;
         }
     }
     response::no_content(request)


### PR DESCRIPTION
Closes #92

**Audit verdict:** CONFIRMED (wave-4 + my own re-verification of the cmd metacharacter path).

**Fix:** strict URL validation (url::Url, http/https, host, no control chars) + `open::that` (ShellExecuteW / LaunchServices / xdg-open) — the URL never touches a shell. Regression tests for `&calc.exe` / `|cmd` payloads.

**Verification:** cargo test open_external 1/1 + window_zoom 4/4; validation is pure (no browser spawned in tests).