### PR TITLE
Fix #131: snap/flatpak single-instance D-Bus name mismatch

### DIFF
--- a/com.wordhunter.app.yml
+++ b/com.wordhunter.app.yml
@@ -20,8 +20,8 @@ finish-args:
   - --filesystem=xdg-documents
   - --filesystem=xdg-download
   - --filesystem=host-os:ro
-  - --talk-name=org.com_wordhunter_app.SingleInstance
-  - --own-name=org.com_wordhunter_app.SingleInstance
+  - --talk-name=com.wordhunter.app.SingleInstance
+  - --own-name=com.wordhunter.app.SingleInstance
 
 modules:
   - name: word-hunter

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -24,13 +24,13 @@ slots:
   single-instance:
     interface: dbus
     bus: session
-    name: org.com_wordhunter_app.SingleInstance
+    name: com.wordhunter.app.SingleInstance
 
 plugs:
   single-instance-plug:
     interface: dbus
     bus: session
-    name: org.com_wordhunter_app.SingleInstance
+    name: com.wordhunter.app.SingleInstance
 
 apps:
   word-hunter:


### PR DESCRIPTION
Closes #131

**Audit verdict:** CONFIRMED (wave-9 + my own verification of the plugin's {identifier}.SingleInstance registration, tauri-plugin-single-instance lib.rs:81-82).

**Fix:** snapcraft.yaml slot+plug and flatpak --own-name/--talk-name now use com.wordhunter.app.SingleInstance (the name the plugin actually registers). CI's apparmor-disabled smoke would have hidden this — the real policy path now works.

**Verification:** YAML parses; no code change (config only).