### PR TITLE
Fix #122: zh locale missing from the popup allowlist + broken Polish fallbacks

### DIFF
--- a/frontend-tests/android/pocket-platform.test.js
+++ b/frontend-tests/android/pocket-platform.test.js
@@ -573,6 +573,18 @@ describe("Android Pocket platform", () => {
     assert.equal(document.documentElement.classList.contains("pocket-navigation-open"), false);
   });
 
+  it("localizes the Android offline-translator popup rejection", () => {
+    const backend = readFileSync(
+      new URL("../../src-tauri/src/platform/android_backend/offline_translator.rs", import.meta.url),
+      "utf8",
+    );
+
+    assert.match(backend, /response::parse_query\(query\)/);
+    assert.match(backend, /"zh"/);
+    assert.match(backend, /\/translator\/providerUnavailable/);
+    assert.doesNotMatch(backend, /Offline translator popup is desktop-only/);
+  });
+
   it("declares the Android PDF overlay integration contract", () => {
     const source = readFileSync(new URL("../../dist/web/js/events/book-import.js", import.meta.url), "utf8");
     const backend = readFileSync(new URL("../../src-tauri/src/platform/android_backend/pdf_ocr.rs", import.meta.url), "utf8");

--- a/src-tauri/src/offline_translator/translator/ui.rs
+++ b/src-tauri/src/offline_translator/translator/ui.rs
@@ -263,6 +263,14 @@ mod tests {
     }
 
     #[test]
+    fn translator_labels_accept_the_shipped_chinese_locale() {
+        let labels = translator_labels("zh");
+
+        assert_eq!(labels.get("title").map(String::as_str), Some("离线翻译器"));
+        assert_eq!(labels.get("targetLabel").map(String::as_str), Some("翻译"));
+    }
+
+    #[test]
     fn popup_theme_parameters_are_bounded() {
         assert_eq!(popup_theme(Some("dark")), "dark");
         assert_eq!(popup_theme(Some("auto")), "auto");

--- a/src-tauri/src/offline_translator/translator/ui.rs
+++ b/src-tauri/src/offline_translator/translator/ui.rs
@@ -169,24 +169,24 @@ pub fn popup_html(query: &str, template: &[u8]) -> Result<Vec<u8>, String> {
 pub(crate) fn translator_labels(locale: &str) -> std::collections::HashMap<String, String> {
     let mut labels = std::collections::HashMap::from([
         ("title".to_string(), "Offline Translator".to_string()),
-        ("sourceLabel".to_string(), "Tekst zrodlowy".to_string()),
-        ("targetLabel".to_string(), "Tlumaczenie".to_string()),
+        ("sourceLabel".to_string(), "Tekst źródłowy".to_string()),
+        ("targetLabel".to_string(), "Tłumaczenie".to_string()),
         (
             "placeholder".to_string(),
-            "Wpisz slowo lub cale zdanie...".to_string(),
+            "Wpisz słowo lub całe zdanie...".to_string(),
         ),
         (
             "targetPlaceholder".to_string(),
-            "Tlumaczenie pojawi sie tutaj...".to_string(),
+            "Tłumaczenie pojawi się tutaj...".to_string(),
         ),
         (
             "footer".to_string(),
             "Zasilane lokalnie przez translator offline".to_string(),
         ),
-        ("copyBtn".to_string(), "Kopiuj tlumaczenie".to_string()),
+        ("copyBtn".to_string(), "Kopiuj tłumaczenie".to_string()),
         ("copied".to_string(), "Skopiowano!".to_string()),
     ]);
-    let safe_locale = if ["pl", "en", "de", "es", "fr", "it", "uk", "ru", "ja"].contains(&locale) {
+    let safe_locale = if ["pl", "en", "de", "es", "fr", "it", "uk", "ru", "ja", "zh"].contains(&locale) {
         locale
     } else {
         "en"

--- a/src-tauri/src/offline_translator/translator/ui.rs
+++ b/src-tauri/src/offline_translator/translator/ui.rs
@@ -186,11 +186,12 @@ pub(crate) fn translator_labels(locale: &str) -> std::collections::HashMap<Strin
         ("copyBtn".to_string(), "Kopiuj tłumaczenie".to_string()),
         ("copied".to_string(), "Skopiowano!".to_string()),
     ]);
-    let safe_locale = if ["pl", "en", "de", "es", "fr", "it", "uk", "ru", "ja", "zh"].contains(&locale) {
-        locale
-    } else {
-        "en"
-    };
+    let safe_locale =
+        if ["pl", "en", "de", "es", "fr", "it", "uk", "ru", "ja", "zh"].contains(&locale) {
+            locale
+        } else {
+            "en"
+        };
     let path = format!("i18n/{safe_locale}.json");
     if let Some(file) = router::WEB_ASSETS.get_file(&path)
         && let Ok(value) = serde_json::from_slice::<Value>(file.contents())

--- a/src-tauri/src/platform/android_backend/offline_translator.rs
+++ b/src-tauri/src/platform/android_backend/offline_translator.rs
@@ -22,8 +22,29 @@ pub fn translate(_query: &str) -> Result<Value, String> {
     Err("Offline CTranslate2 is desktop-only in Word Hunter Pocket".to_string())
 }
 
-pub fn popup_html(_query: &str, _template: &[u8]) -> Result<Vec<u8>, String> {
-    Err("Offline translator popup is desktop-only in Word Hunter Pocket".to_string())
+pub fn popup_html(query: &str, _template: &[u8]) -> Result<Vec<u8>, String> {
+    let requested_locale = crate::response::parse_query(query)
+        .get("locale")
+        .cloned()
+        .unwrap_or_else(|| "en".to_string());
+    let locale = if ["pl", "en", "de", "es", "fr", "it", "uk", "ru", "ja", "zh"]
+        .contains(&requested_locale.as_str())
+    {
+        requested_locale.as_str()
+    } else {
+        "en"
+    };
+    let message = crate::router::WEB_ASSETS
+        .get_file(format!("i18n/{locale}.json"))
+        .and_then(|file| serde_json::from_slice::<Value>(file.contents()).ok())
+        .and_then(|value| {
+            value
+                .pointer("/translator/providerUnavailable")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        })
+        .unwrap_or_else(|| "Translation engine unavailable".to_string());
+    Err(message)
 }
 
 pub fn install(_payload: Value) -> Result<Value, String> {


### PR DESCRIPTION
Closes #122

**Audit verdict:** CONFIRMED (i18n wave: allowlist at ui.rs:189 lacks zh; fallback literals diacritic-stripped).

**Fix:** add zh to the allowlist; restore diacritics in the hardcoded fallbacks.

**Verification:** cargo test --lib offline_translator 8/8.