### PR TITLE
Fix #101: snap updated to 1.0.10 (was 2 releases stale, CI asserted the stale version)

### DIFF
--- a/.github/workflows/snap-validation.yml
+++ b/.github/workflows/snap-validation.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - snap/**
       - packaging/snap/**
+      - src-tauri/tauri.conf.json
       - .github/workflows/snap-validation.yml
   push:
     branches:
@@ -13,6 +14,7 @@ on:
     paths:
       - snap/**
       - packaging/snap/**
+      - src-tauri/tauri.conf.json
       - .github/workflows/snap-validation.yml
 
 permissions:
@@ -33,6 +35,33 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
+
+      - name: Read and validate the application version
+        id: app_version
+        run: |
+          set -Eeuo pipefail
+          version="$(node -p "require('./src-tauri/tauri.conf.json').version")"
+          test -n "$version"
+          grep -Fx "version: '$version'" snap/snapcraft.yaml
+          grep -Fq "/WordHunter${version}/word-hunter_${version}_amd64.deb" snap/snapcraft.yaml
+          echo "version=$version" >>"$GITHUB_OUTPUT"
+
+      - name: Verify the release asset checksum
+        env:
+          APP_VERSION: ${{ steps.app_version.outputs.version }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -Eeuo pipefail
+          asset_name="word-hunter_${APP_VERSION}_amd64.deb"
+          expected="$(sed -nE 's/^    source-checksum: sha256\/([0-9a-f]{64})$/sha256:\1/p' snap/snapcraft.yaml)"
+          test -n "$expected"
+          actual="$(curl --fail --location --retry 3 \
+            --header 'Accept: application/vnd.github+json' \
+            --header "Authorization: Bearer ${GITHUB_TOKEN}" \
+            "https://api.github.com/repos/Ironship/WordHunter/releases/tags/WordHunter${APP_VERSION}" \
+            | node -e 'let input=""; process.stdin.on("data", chunk => input += chunk); process.stdin.on("end", () => { const name=process.argv[1]; const asset=JSON.parse(input).assets.find(item => item.name === name); if (!asset?.digest) process.exit(1); process.stdout.write(asset.digest); });' \
+              "$asset_name")"
+          test "$actual" = "$expected"
 
       - name: Build Snap
         id: snapcraft
@@ -61,6 +90,7 @@ jobs:
       - name: Inspect Snap payload
         env:
           SNAP_PATH: ${{ steps.snapcraft.outputs.snap }}
+          APP_VERSION: ${{ steps.app_version.outputs.version }}
         run: |
           set -Eeuo pipefail
           trap 'echo "Snap payload inspection failed at line $LINENO: $BASH_COMMAND" >&2' ERR
@@ -97,7 +127,8 @@ jobs:
           grep -Fq '<launchable type="desktop-id">word-hunter.desktop</launchable>' \
             "$root/usr/share/metainfo/com.wordhunter.app.metainfo.xml"
           grep -Fx 'name: word-hunter' "$root/meta/snap.yaml"
-          grep -Eq "^version: ['\"]?1\\.0\\.10['\"]?$" "$root/meta/snap.yaml"
+          actual_version="$(sed -nE "s/^version: ['\"]?([^'\"]+)['\"]?$/\1/p" "$root/meta/snap.yaml")"
+          test "$actual_version" = "$APP_VERSION"
           grep -Fx 'base: core24' "$root/meta/snap.yaml"
           grep -Fx 'confinement: strict' "$root/meta/snap.yaml"
           grep -Fq 'default-provider: gnome-46-2404' "$root/meta/snap.yaml"

--- a/.github/workflows/snap-validation.yml
+++ b/.github/workflows/snap-validation.yml
@@ -97,7 +97,7 @@ jobs:
           grep -Fq '<launchable type="desktop-id">word-hunter.desktop</launchable>' \
             "$root/usr/share/metainfo/com.wordhunter.app.metainfo.xml"
           grep -Fx 'name: word-hunter' "$root/meta/snap.yaml"
-          grep -Eq "^version: ['\"]?1\\.0\\.8['\"]?$" "$root/meta/snap.yaml"
+          grep -Eq "^version: ['\"]?1\\.0\\.10['\"]?$" "$root/meta/snap.yaml"
           grep -Fx 'base: core24' "$root/meta/snap.yaml"
           grep -Fx 'confinement: strict' "$root/meta/snap.yaml"
           grep -Fq 'default-provider: gnome-46-2404' "$root/meta/snap.yaml"

--- a/frontend-tests/shared/repo-validation.test.js
+++ b/frontend-tests/shared/repo-validation.test.js
@@ -317,6 +317,22 @@ describe("repository validation wiring", () => {
     assert.match(rustBuild, /frontend_source_hash/);
   });
 
+  it("derives Snap validation from the application version and verifies the release digest", () => {
+    const config = JSON.parse(read("../../src-tauri/tauri.conf.json"));
+    const snapcraft = read("../../snap/snapcraft.yaml");
+    const workflow = read("../../.github/workflows/snap-validation.yml");
+
+    assert.match(snapcraft, new RegExp(`^version: ['\"]${config.version}['\"]$`, "m"));
+    assert.match(
+      snapcraft,
+      new RegExp(`/WordHunter${config.version}/word-hunter_${config.version}_amd64\\.deb`),
+    );
+    assert.match(workflow, /require\('\.\/src-tauri\/tauri\.conf\.json'\)\.version/);
+    assert.match(workflow, /steps\.app_version\.outputs\.version/);
+    assert.match(workflow, /api\.github\.com\/repos\/Ironship\/WordHunter\/releases\/tags/);
+    assert.match(workflow, /asset\?\.digest/);
+  });
+
   it("keeps reviewable docs tracked while generated runtime payloads stay ignored", () => {
     const gitignore = read("../../.gitignore");
     const docs = read("../../docs/release-validation.md");

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: word-hunter
 base: core24
-version: '1.0.8'
+version: '1.0.10'
 summary: Local-first reader and vocabulary trainer
 description: |
   Read real texts, save vocabulary with its original context, and review it
@@ -57,9 +57,9 @@ apps:
 parts:
   word-hunter:
     plugin: dump
-    source: https://github.com/Ironship/WordHunter/releases/download/WordHunter1.0.8/word-hunter_1.0.8_amd64.deb
+    source: https://github.com/Ironship/WordHunter/releases/download/WordHunter1.0.10/word-hunter_1.0.10_amd64.deb
     source-type: deb
-    source-checksum: sha256/3e222116ef84359f0081328c2ab98dac194c4409c9a367ffff2331a600753a01
+    source-checksum: sha256/9cef8fe726a8fb3b0aa9ae52293d8d1c1510c457ae72f4dd698c8ef3e2065d29
     stage-packages:
       - dbus-daemon
       - dbus-session-bus-common


### PR DESCRIPTION
Closes #101

**Audit verdict:** CONFIRMED (waves 2-C/3-C/9; snapcraft.yaml:3,60 pinned 1.0.8; snap-validation.yml:100 asserted it — a correct bump would have failed CI).

**Fix:** version 1.0.10, source WordHunter1.0.10 .deb (verified live asset, sha256 computed from the downloaded file), CI assert updated.

**Verification:** snapcraft YAML parses; checksum computed from the actual release asset.