### PR TITLE
Fix #103: proxy domain allowlist bypassable via redirects

### DIFF
--- a/src-tauri/src/http.rs
+++ b/src-tauri/src/http.rs
@@ -57,11 +57,25 @@ fn download_agent_with_timeouts(
 mod tests {
     use std::error::Error;
     use std::io::{self, Read, Write};
-    use std::net::TcpListener;
+    use std::net::{TcpListener, TcpStream};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
     use std::thread;
-    use std::time::Duration;
+    use std::time::{Duration, Instant};
 
-    use super::{agent_with_timeouts, download_agent_with_timeouts};
+    use super::{agent_with_timeouts, download_agent_with_timeouts, no_redirect_agent};
+
+    fn read_request_headers(stream: &mut TcpStream) {
+        let mut request = Vec::new();
+        let mut buffer = [0_u8; 1024];
+        while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+            let read = stream.read(&mut buffer).unwrap();
+            if read == 0 {
+                break;
+            }
+            request.extend_from_slice(&buffer[..read]);
+        }
+    }
 
     #[test]
     fn http_agent_builder_enforces_read_timeout() {
@@ -87,6 +101,58 @@ mod tests {
             .expect("timeout should retain its io::Error source");
         assert_eq!(io_error.kind(), io::ErrorKind::TimedOut);
         server.join().unwrap();
+    }
+
+    #[test]
+    fn proxy_agent_returns_redirect_without_contacting_its_target() {
+        let target_listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let target_address = target_listener.local_addr().unwrap();
+        target_listener.set_nonblocking(true).unwrap();
+        let target_contacted = Arc::new(AtomicBool::new(false));
+        let target_flag = Arc::clone(&target_contacted);
+        let target_server = thread::spawn(move || {
+            let deadline = Instant::now() + Duration::from_millis(300);
+            while Instant::now() < deadline {
+                match target_listener.accept() {
+                    Ok((mut stream, _)) => {
+                        target_flag.store(true, Ordering::SeqCst);
+                        read_request_headers(&mut stream);
+                        stream
+                            .write_all(b"HTTP/1.1 200 OK\x0d\x0aContent-Length: 0\x0d\x0a\x0d\x0a")
+                            .unwrap();
+                        stream.flush().unwrap();
+                        return;
+                    }
+                    Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                        thread::sleep(Duration::from_millis(5));
+                    }
+                    Err(error) => panic!("target listener failed: {error}"),
+                }
+            }
+        });
+
+        let redirect_listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let redirect_address = redirect_listener.local_addr().unwrap();
+        let redirect_server = thread::spawn(move || {
+            let (mut stream, _) = redirect_listener.accept().unwrap();
+            read_request_headers(&mut stream);
+            write!(
+                stream,
+                "HTTP/1.1 302 Found\x0d\x0aLocation: http://{target_address}/blocked\x0d\x0aContent-Length: 0\x0d\x0a\x0d\x0a"
+            )
+            .unwrap();
+            stream.flush().unwrap();
+        });
+
+        let response = no_redirect_agent()
+            .get(&format!("http://{redirect_address}/allowed"))
+            .call()
+            .expect("redirect response should be returned to the proxy");
+
+        assert_eq!(response.status(), 302);
+        redirect_server.join().unwrap();
+        target_server.join().unwrap();
+        assert!(!target_contacted.load(Ordering::SeqCst));
     }
 
     #[test]

--- a/src-tauri/src/http.rs
+++ b/src-tauri/src/http.rs
@@ -23,6 +23,17 @@ pub(crate) fn download_agent() -> &'static ureq::Agent {
     &DOWNLOAD_AGENT
 }
 
+/// Agent that never follows redirects — used where the domain allowlist is
+/// checked on the initial URL only (the proxy endpoint): a redirect could
+/// silently reach an arbitrary host.
+pub(crate) fn no_redirect_agent() -> ureq::Agent {
+    ureq::AgentBuilder::new()
+        .timeout_connect(CONNECT_TIMEOUT)
+        .timeout_read(READ_TIMEOUT)
+        .redirects(0)
+        .build()
+}
+
 fn agent_with_timeouts(connect_timeout: Duration, read_timeout: Duration) -> ureq::Agent {
     ureq::AgentBuilder::new()
         .timeout_connect(connect_timeout)

--- a/src-tauri/src/proxy.rs
+++ b/src-tauri/src/proxy.rs
@@ -6,6 +6,58 @@ use crate::response;
 
 pub const USER_AGENT: &str = concat!("WordHunter/", env!("CARGO_PKG_VERSION"), " (Tauri)");
 const MAX_PROXY_BODY: u64 = 10_485_760;
+const MAX_PROXY_REDIRECTS: usize = 5;
+
+#[derive(Debug)]
+enum ProxyFetchError {
+    Forbidden,
+    Other(String),
+}
+
+fn validate_proxy_url(target: &Url) -> Result<(), ProxyFetchError> {
+    if !matches!(target.scheme(), "http" | "https") {
+        return Err(ProxyFetchError::Forbidden);
+    }
+    let host = target.host_str().unwrap_or_default();
+    let allowed = matches!(host, "gutenberg.org" | "www.gutenberg.org" | "gutendex.com")
+        || cfg!(test) && host == "127.0.0.1";
+    if !allowed {
+        return Err(ProxyFetchError::Forbidden);
+    }
+    Ok(())
+}
+
+fn fetch_proxy_target(mut target: Url) -> Result<ureq::Response, ProxyFetchError> {
+    for redirect_count in 0..=MAX_PROXY_REDIRECTS {
+        validate_proxy_url(&target)?;
+        let response = crate::http::no_redirect_agent()
+            .get(target.as_str())
+            .set("User-Agent", USER_AGENT)
+            .call()
+            .map_err(|error| ProxyFetchError::Other(error.to_string()))?;
+        if !matches!(response.status(), 301 | 302 | 303 | 307 | 308) {
+            if (300..400).contains(&response.status()) {
+                return Err(ProxyFetchError::Other(format!(
+                    "unsupported upstream redirect status {}",
+                    response.status()
+                )));
+            }
+            return Ok(response);
+        }
+        if redirect_count == MAX_PROXY_REDIRECTS {
+            return Err(ProxyFetchError::Other(
+                "upstream redirect limit exceeded".to_string(),
+            ));
+        }
+        let location = response.header("Location").ok_or_else(|| {
+            ProxyFetchError::Other("upstream redirect is missing Location".to_string())
+        })?;
+        target = target.join(location).map_err(|error| {
+            ProxyFetchError::Other(format!("invalid upstream redirect: {error}"))
+        })?;
+    }
+    unreachable!("bounded redirect loop must return")
+}
 
 /// Proxy endpoint — fetch remote resources for allowed domains only.
 /// Currently permits gutenberg.org and gutendex.com.
@@ -15,17 +67,13 @@ pub fn serve_proxy(request: Request, query: &str) -> Result<(), String> {
         return response::error_response(request, 400, "bad url");
     };
     let parsed = Url::parse(target).map_err(|e| e.to_string())?;
-    let host = parsed.host_str().unwrap_or_default();
-    if !matches!(host, "gutenberg.org" | "www.gutenberg.org" | "gutendex.com") {
-        return response::error_response(request, 403, "domain not allowed");
-    }
-    let resp = crate::http::no_redirect_agent()
-        .get(target)
-        // The allowlist is checked on the initial URL only; following
-        // redirects could silently proxy an arbitrary host. Disable them.
-        .set("User-Agent", USER_AGENT)
-        .call()
-        .map_err(|e| e.to_string())?;
+    let resp = match fetch_proxy_target(parsed) {
+        Ok(response) => response,
+        Err(ProxyFetchError::Forbidden) => {
+            return response::error_response(request, 403, "domain not allowed");
+        }
+        Err(ProxyFetchError::Other(error)) => return Err(error),
+    };
     let content_type = resp
         .header("Content-Type")
         .unwrap_or("text/plain; charset=utf-8")
@@ -37,4 +85,76 @@ pub fn serve_proxy(request: Request, query: &str) -> Result<(), String> {
         return response::error_response(request, 413, "response too large");
     }
     response::respond(request, 200, body, &content_type, false)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Read, Write};
+    use std::net::{TcpListener, TcpStream};
+    use std::thread;
+
+    use url::Url;
+
+    use super::{ProxyFetchError, fetch_proxy_target, validate_proxy_url};
+
+    fn read_request(stream: &mut TcpStream) {
+        let mut request = Vec::new();
+        let mut chunk = [0u8; 1024];
+        while !request
+            .windows(4)
+            .any(|window| window == b"\x0d\x0a\x0d\x0a")
+        {
+            let count = stream.read(&mut chunk).expect("request should be readable");
+            if count == 0 {
+                break;
+            }
+            request.extend_from_slice(&chunk[..count]);
+        }
+    }
+
+    #[test]
+    fn follows_an_allowed_redirect_after_validating_the_next_hop() {
+        let target = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let target_port = target.local_addr().unwrap().port();
+        let target_thread = thread::spawn(move || {
+            let (mut stream, _) = target.accept().unwrap();
+            read_request(&mut stream);
+            stream
+                .write_all(b"HTTP/1.1 200 OK\x0d\x0aContent-Type: text/plain\x0d\x0aContent-Length: 9\x0d\x0aConnection: close\x0d\x0a\x0d\x0abook text")
+                .unwrap();
+            stream.flush().unwrap();
+        });
+
+        let source = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let source_port = source.local_addr().unwrap().port();
+        let source_thread = thread::spawn(move || {
+            let (mut stream, _) = source.accept().unwrap();
+            read_request(&mut stream);
+            write!(
+                stream,
+                "HTTP/1.1 302 Found\x0d\x0aLocation: http://127.0.0.1:{target_port}/book.txt\x0d\x0aContent-Length: 0\x0d\x0aConnection: close\x0d\x0a\x0d\x0a"
+            )
+            .unwrap();
+            stream.flush().unwrap();
+        });
+
+        let initial = Url::parse(&format!("http://127.0.0.1:{source_port}/start")).unwrap();
+        let response = fetch_proxy_target(initial).expect("allowed redirect should resolve");
+        assert_eq!(response.status(), 200);
+        assert_eq!(response.into_string().unwrap(), "book text");
+        source_thread.join().unwrap();
+        target_thread.join().unwrap();
+    }
+
+    #[test]
+    fn rejects_redirect_targets_outside_the_proxy_allowlist() {
+        let current = Url::parse("https://www.gutenberg.org/ebooks/1.txt.utf-8").unwrap();
+        let redirected = current.join("https://example.com/private").unwrap();
+
+        assert!(matches!(
+            validate_proxy_url(&redirected),
+            Err(ProxyFetchError::Forbidden)
+        ));
+        assert!(validate_proxy_url(&current).is_ok());
+    }
 }

--- a/src-tauri/src/proxy.rs
+++ b/src-tauri/src/proxy.rs
@@ -19,8 +19,10 @@ pub fn serve_proxy(request: Request, query: &str) -> Result<(), String> {
     if !matches!(host, "gutenberg.org" | "www.gutenberg.org" | "gutendex.com") {
         return response::error_response(request, 403, "domain not allowed");
     }
-    let resp = crate::http::agent()
+    let resp = crate::http::no_redirect_agent()
         .get(target)
+        // The allowlist is checked on the initial URL only; following
+        // redirects could silently proxy an arbitrary host. Disable them.
         .set("User-Agent", USER_AGENT)
         .call()
         .map_err(|e| e.to_string())?;


### PR DESCRIPTION
Closes #103

## What changed
- gives the proxy a no-auto-redirect HTTP agent
- manually follows at most five standard redirect hops
- parses relative `Location` values and revalidates HTTP(S) plus the exact host allowlist before every next network request
- preserves Gutenberg text imports that legitimately redirect within the allowed domain
- leaves normal/download HTTP agents unchanged

## TDD and verification
- original redirect bypass regression: normal agent follows and contacts the target (expected RED); proxy agent does not
- functionality regression: allowed validated redirect reaches the final text response
- disallowed redirect target is rejected before contact
- current-base Rust library suite: 291/291
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check`; Flatpak sources; third-party licenses; `git diff --check`
