### PR TITLE
Fix #99: state.preferences null-deref aborts snapshot apply

### DIFF
--- a/frontend-tests/shared/persistence-lifecycle.test.js
+++ b/frontend-tests/shared/persistence-lifecycle.test.js
@@ -590,6 +590,7 @@ describe("persistence lifecycle", () => {
       "./state/autosave.js": { createAutosave: () => autosave },
       "./state/defaults.js": {
         createDefaultState: () => rawState,
+        createDefaultPreferences: () => ({}),
         getDefaultDictionaryUrl: () => "",
         normalizeAnkiExportStatuses: noOp,
         normalizeVocabStatusFilters: noOp
@@ -664,6 +665,7 @@ describe("persistence lifecycle", () => {
       "./state/autosave.js": { createAutosave: () => autosave },
       "./state/defaults.js": {
         createDefaultState: () => rawState,
+        createDefaultPreferences: () => ({}),
         getDefaultDictionaryUrl: () => "",
         normalizeAnkiExportStatuses: noOp,
         normalizeVocabStatusFilters: noOp
@@ -740,6 +742,7 @@ describe("persistence lifecycle", () => {
       "./state/autosave.js": { createAutosave: () => autosave },
       "./state/defaults.js": {
         createDefaultState: () => rawState,
+        createDefaultPreferences: () => ({}),
         getDefaultDictionaryUrl: () => "",
         normalizeAnkiExportStatuses: noOp,
         normalizeVocabStatusFilters: noOp
@@ -812,6 +815,7 @@ describe("persistence lifecycle", () => {
       "./state/autosave.js": { createAutosave: () => autosave },
       "./state/defaults.js": {
         createDefaultState: () => rawState,
+        createDefaultPreferences: () => ({}),
         getDefaultDictionaryUrl: () => "",
         normalizeAnkiExportStatuses: noOp,
         normalizeVocabStatusFilters: noOp
@@ -862,6 +866,7 @@ describe("persistence lifecycle", () => {
       "./state/autosave.js": { createAutosave: () => autosave },
       "./state/defaults.js": {
         createDefaultState: () => rawState,
+        createDefaultPreferences: () => ({}),
         getDefaultDictionaryUrl: () => "",
         normalizeAnkiExportStatuses: noOp,
         normalizeVocabStatusFilters: noOp
@@ -915,6 +920,7 @@ describe("persistence lifecycle", () => {
       "./state/autosave.js": { createAutosave: () => autosave },
       "./state/defaults.js": {
         createDefaultState: () => rawState,
+        createDefaultPreferences: () => ({}),
         getDefaultDictionaryUrl: () => "",
         normalizeAnkiExportStatuses: noOp,
         normalizeVocabStatusFilters: noOp

--- a/frontend-tests/shared/persistence-lifecycle.test.js
+++ b/frontend-tests/shared/persistence-lifecycle.test.js
@@ -642,6 +642,67 @@ describe("persistence lifecycle", () => {
     assert.equal(durableSaves, 1);
   });
 
+  it("applies a bridge snapshot when the current state's preferences are null", async () => {
+    const currentState = {
+      preferences: null,
+      customTexts: [],
+      discover: null,
+      profiles: {},
+      vocab: {}
+    };
+    const nextState = {
+      preferences: { inTextReviewCompletedGuesses: 1 },
+      customTexts: [],
+      profiles: {},
+      vocab: {}
+    };
+    const autosave = {
+      wrap: (value) => value,
+      saveState: () => Promise.resolve(),
+      getDurableStateRevision: () => 0,
+      runExclusiveWrite: (callback) => callback(),
+      markDurableStateReplaced() {},
+      flushPendingSave() {},
+      hasPendingChanges: () => false,
+      withoutAutoSave: (callback) => callback()
+    };
+    const noOp = () => {};
+    let loadCount = 0;
+    const stateModule = await evaluateWithMocks("../../dist/web/js/state.js", {
+      "./state/autosave.js": { createAutosave: () => autosave },
+      "./state/defaults.js": {
+        createDefaultState: () => currentState,
+        createDefaultPreferences: () => ({ inTextReviewCompletedGuesses: 0 }),
+        getDefaultDictionaryUrl: () => "",
+        normalizeAnkiExportStatuses: noOp,
+        normalizeVocabStatusFilters: noOp
+      },
+      "./state/normalize.js": {
+        assertSupportedStateSchemaVersion: noOp,
+        loadState: () => loadCount++ === 0 ? currentState : nextState,
+        normalizeState: (value) => value
+      },
+      "./state/ui-cache.js": {
+        captureUiState: () => ({}),
+        saveUiStateCache: noOp,
+        UI_STATE_KEYS: []
+      },
+      "./store-bridge.js": { postStoreJson: async () => ({}) },
+      "./request.js": { fetchWithTimeout: async () => ({ ok: true, json: async () => ({}) }) },
+      "./constants.js": {
+        OTHER_PROFILE_ID: "other",
+        STATE_SCHEMA_VERSION: 2,
+        IN_TEXT_REVIEW_PROMPT_COMPLETION_LIMIT: 3
+      }
+    }, {
+      window: { __qtBridge: true, __bridgeState: null, WH_TOKEN: "test-token" },
+      console
+    });
+
+    assert.doesNotThrow(() => stateModule.applyBridgeSnapshotToState({ schemaVersion: 2, prefs: {} }));
+    assert.equal(stateModule.state.preferences.inTextReviewCompletedGuesses, 1);
+  });
+
   it("drains old UI saves and defers new UI saves around an exclusive import or wipe", async () => {
     const postedPages = [];
     const keepalivePages = [];

--- a/src/web/js/state.ts
+++ b/src/web/js/state.ts
@@ -238,8 +238,14 @@ export function applyBridgeSnapshotToState(
   }
   window.__bridgeState = snapshot;
   const nextState = loadState();
+  const previousPreferences = state.preferences && typeof state.preferences === "object"
+    ? state.preferences
+    : createDefaultPreferences();
+  if (!nextState.preferences || typeof nextState.preferences !== "object") {
+    nextState.preferences = createDefaultPreferences();
+  }
   nextState.preferences.inTextReviewCompletedGuesses = Math.max(
-    Math.min(IN_TEXT_REVIEW_PROMPT_COMPLETION_LIMIT, Math.max(0, Math.trunc(Number(state.preferences.inTextReviewCompletedGuesses) || 0))),
+    Math.min(IN_TEXT_REVIEW_PROMPT_COMPLETION_LIMIT, Math.max(0, Math.trunc(Number(previousPreferences.inTextReviewCompletedGuesses) || 0))),
     nextState.preferences.inTextReviewCompletedGuesses
   );
   if (localUi) restoreLocalUiState(nextState, localUi);

--- a/src/web/js/state.ts
+++ b/src/web/js/state.ts
@@ -1,6 +1,7 @@
 // @ts-check
 
 import { createAutosave } from "./state/autosave.js";
+import { createDefaultPreferences } from "./state/defaults.js";
 import { getDefaultDictionaryUrl } from "./state/defaults.js";
 import { assertSupportedStateSchemaVersion, loadState } from "./state/normalize.js";
 import { captureUiState, saveUiStateCache, UI_STATE_KEYS } from "./state/ui-cache.js";
@@ -274,6 +275,7 @@ export function getLastReadTextId(lang = state.preferences?.learningLanguage): s
 
 export function setLastReadTextId(id: string, lang = state.preferences?.learningLanguage): void {
   if (!id || !lang) return;
+  if (!state.preferences || typeof state.preferences !== "object") state.preferences = createDefaultPreferences();
   if (!state.preferences.lastReadTextIds || typeof state.preferences.lastReadTextIds !== "object") state.preferences.lastReadTextIds = {};
   state.preferences.lastReadTextIds[lang] = id;
 }
@@ -293,6 +295,11 @@ export function clearLastReadTextForLanguage(lang = state.preferences?.learningL
 export function replaceState(nextState: WhAppState, { save = true }: { save?: boolean } = {}): void {
   autosave.withoutAutoSave(() => {
     Object.keys(state).forEach((key) => delete state[key]);
+    // A snapshot without a preferences object (legacy/corrupt save) must not
+    // null-deref every later state.preferences.* access.
+    if (!nextState.preferences || typeof nextState.preferences !== "object") {
+      nextState.preferences = createDefaultPreferences();
+    }
     Object.assign(state, nextState);
   });
   resetInitialVocabKeys();
@@ -303,6 +310,7 @@ export function replaceState(nextState: WhAppState, { save = true }: { save?: bo
 }
 
 export function switchLearningLanguage(lang: string): void {
+  if (!state.preferences || typeof state.preferences !== "object") state.preferences = createDefaultPreferences();
   const previousLang = state.preferences?.learningLanguage;
   const previousProfile = state.profiles?.[previousLang];
   if (previousProfile) {

--- a/src/web/js/state/defaults.ts
+++ b/src/web/js/state/defaults.ts
@@ -37,50 +37,8 @@ export function getDefaultDictionaryUrl(lang: string): string {
   return urls[lang] || urls.en;
 }
 
-export function createDefaultState(): WhAppState {
-  const defaultProfile: WhProfile = {
-    vocab: {},
-    customTexts: [],
-    userBooks: [],
-    hiddenBuiltInBooks: [],
-    archivedBookIds: [],
-    preferences: { dictionaryUrl: getDefaultDictionaryUrl("de"), dictionaryMode: "internal" }
-  };
+export function createDefaultPreferences(): WhPreferences {
   return {
-    schemaVersion: STATE_SCHEMA_VERSION,
-    currentView: "library",
-    currentTextId: null,
-    selectedWord: null,
-    selectedWordIndex: null,
-    readerSelectionRange: null,
-    customTexts: defaultProfile.customTexts,
-    userBooks: defaultProfile.userBooks,
-    hiddenBuiltInBooks: defaultProfile.hiddenBuiltInBooks,
-    archivedBookIds: defaultProfile.archivedBookIds,
-    vocab: defaultProfile.vocab,
-    profiles: { de: defaultProfile },
-    reviewIndex: 0,
-    readerFontSize: 18,
-    readerPdfZoom: 1,
-    readerPdfViewMode: "overlay",
-    readerPage: 1,
-    readerPages: {},
-    readerScrolls: {},
-    readerScrollsPerPage: {},
-    dataDirectory: "",
-    recoveryStatus: null,
-    filters: {
-      libraryQuery: "",
-      libraryLevel: "all",
-      librarySort: "title",
-      librarySortReverse: false,
-      libraryArchive: "active",
-      vocabQuery: "",
-      vocabStatuses: ["learning", "known"],
-      vocabTextId: "all"
-    },
-    discover: { query: "", source: "gutenberg", sort: "popular", level: "", page: 1 },
-    preferences: {
       theme: DEFAULT_THEME,
       locale: "en",
       languageOnboardingDone: false,
@@ -99,7 +57,7 @@ export function createDefaultState(): WhAppState {
       cardStatsMode: "percentages",
       showCovers: true,
       learningLanguage: "de",
-      dictionaryUrl: defaultProfile.preferences.dictionaryUrl,
+      dictionaryUrl: getDefaultDictionaryUrl("de"),
       dictionaryMode: "internal",
       readerTextAlign: "left",
       readerMaxWidth: "wide",
@@ -149,6 +107,52 @@ export function createDefaultState(): WhAppState {
       reviewGraphType: "heatmap",
       graphRange: "recent",
       readerBookmarks: {}
-    }
+  };
+}
+
+export function createDefaultState(): WhAppState {
+  const defaultProfile: WhProfile = {
+    vocab: {},
+    customTexts: [],
+    userBooks: [],
+    hiddenBuiltInBooks: [],
+    archivedBookIds: [],
+    preferences: { dictionaryUrl: getDefaultDictionaryUrl("de"), dictionaryMode: "internal" }
+  };
+  return {
+    schemaVersion: STATE_SCHEMA_VERSION,
+    currentView: "library",
+    currentTextId: null,
+    selectedWord: null,
+    selectedWordIndex: null,
+    readerSelectionRange: null,
+    customTexts: defaultProfile.customTexts,
+    userBooks: defaultProfile.userBooks,
+    hiddenBuiltInBooks: defaultProfile.hiddenBuiltInBooks,
+    archivedBookIds: defaultProfile.archivedBookIds,
+    vocab: defaultProfile.vocab,
+    profiles: { de: defaultProfile },
+    reviewIndex: 0,
+    readerFontSize: 18,
+    readerPdfZoom: 1,
+    readerPdfViewMode: "overlay",
+    readerPage: 1,
+    readerPages: {},
+    readerScrolls: {},
+    readerScrollsPerPage: {},
+    dataDirectory: "",
+    recoveryStatus: null,
+    filters: {
+      libraryQuery: "",
+      libraryLevel: "all",
+      librarySort: "title",
+      librarySortReverse: false,
+      libraryArchive: "active",
+      vocabQuery: "",
+      vocabStatuses: ["learning", "known"],
+      vocabTextId: "all"
+    },
+    discover: { query: "", source: "gutenberg", sort: "popular", level: "", page: 1 },
+    preferences: createDefaultPreferences(),
   };
 }


### PR DESCRIPTION
Closes #99

**Audit verdict:** CONFIRMED (wave 2-A: replaceState/switchLearningLanguage deref without guard).

**Fix:** normalize via the new createDefaultPreferences() factory in replaceState + switchLearningLanguage + setLastReadTextId.

**Verification:** check:frontend 0; full frontend suite 389/389.