### PR TITLE
Fix #126: graph dates use browser locale instead of app locale

### DIFF
--- a/frontend-tests/shared/vocab-progress.test.js
+++ b/frontend-tests/shared/vocab-progress.test.js
@@ -12,6 +12,7 @@ const {
   getCefrThresholds,
   getCurrentLevel
 } = await import("../../dist/web/js/graphs/charts.js");
+const { loadLocale } = await import("../../dist/web/js/i18n.js");
 
 describe("vocabulary CEFR progress", () => {
   it("uses language-specific thresholds", () => {
@@ -47,6 +48,15 @@ describe("vocabulary CEFR progress", () => {
     const span = 900 * 24 * 60 * 60 * 1000;
 
     assert.equal(formatVocabProgressDate(Date.parse("2024-01-05T00:00:00.000Z"), span, "en-US"), "Jan 2024");
+  });
+
+  it("uses the selected app locale when no explicit graph locale is supplied", async () => {
+    globalThis.document = { documentElement: { lang: "" } };
+    globalThis.fetch = async () => ({ ok: true, json: async () => ({}) });
+    await loadLocale("es");
+    const span = 900 * 24 * 60 * 60 * 1000;
+
+    assert.equal(formatVocabProgressDate(Date.parse("2024-01-05T00:00:00.000Z"), span), "ene 2024");
   });
 
   it("keeps old cards in all-time added-over-time bins", () => {

--- a/src/web/js/graphs/charts.ts
+++ b/src/web/js/graphs/charts.ts
@@ -2,7 +2,7 @@
  * Individual chart render functions for the graphs view.
  */
 import { state } from "../state.js";
-import { t as rawT } from "../i18n.js";
+import { getLocale, t as rawT } from "../i18n.js";
 import { effectiveLearningLanguage } from "../translator-preferences.js";
 import {
   C, text, muted, blue, green, red, amber, panelBg, grid, labelMuted,
@@ -125,11 +125,11 @@ export function formatVocabProgressDate(time: number, span: number, locale?: Int
   const options: Intl.DateTimeFormatOptions = span >= MS_PER_DAY * 365
     ? { month: "short", year: "numeric" }
     : { month: "short", day: "numeric" };
-  return new Date(time).toLocaleDateString(locale, options);
+  return new Date(time).toLocaleDateString(locale ?? getLocale(), options);
 }
 
 function monthLabel(date: Date): string {
-  return date.toLocaleDateString(undefined, { month: "short" });
+  return date.toLocaleDateString(getLocale(), { month: "short" });
 }
 
 function monthKey(date: Date): string {
@@ -765,7 +765,7 @@ export function renderVocabProgress(_chartEntries?: readonly VocabEntry[], _opti
         }
         const potentialVal = potentialSeries[potentialIdx].val;
         const dateStr = new Date(series[idx].t)
-          .toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" });
+          .toLocaleDateString(getLocale(), { month: "short", day: "numeric", year: "numeric" });
         const level = getCurrentLevel(val, thresholds);
         const nextVal = thresholds.find(t => t > val);
         const toNext = nextVal ? nextVal - val : 0;


### PR DESCRIPTION
Closes #126

**Audit verdict:** CONFIRMED (i18n wave: charts.ts:731/768 + monthLabel used undefined locale).

**Fix:** getLocale() in month labels, axis ticks (formatVocabProgressDate default) and the tooltip.

**Verification:** check:frontend 0; frontend suite 389/389.