### PR TITLE
Fix #104: app can run with an invisible window forever (Linux)

### DIFF
--- a/src-tauri/src/platform/web_app.rs
+++ b/src-tauri/src/platform/web_app.rs
@@ -15,6 +15,7 @@ use super::SetupResult;
 #[cfg(target_os = "linux")]
 const LINUX_DESKTOP_APP_ID: &str = "com.wordhunter.app";
 const GRACEFUL_EXIT_TIMEOUT: Duration = Duration::from_secs(90);
+const WINDOW_WATCHDOG_DELAY: Duration = Duration::from_secs(20);
 
 #[derive(Default)]
 struct ExitCoordinator {
@@ -28,6 +29,24 @@ impl ExitCoordinator {
             .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
             .is_ok()
     }
+}
+
+fn spawn_window_watchdog<F>(
+    page_ready: Arc<AtomicBool>,
+    delay: Duration,
+    show_window: F,
+) -> std::io::Result<std::thread::JoinHandle<()>>
+where
+    F: FnOnce() + Send + 'static,
+{
+    std::thread::Builder::new()
+        .name("window-watchdog".to_string())
+        .spawn(move || {
+            std::thread::sleep(delay);
+            if !page_ready.load(Ordering::Acquire) {
+                show_window();
+            }
+        })
 }
 
 pub(crate) fn exit_is_permitted(app_handle: &tauri::AppHandle) -> bool {
@@ -121,17 +140,22 @@ pub(crate) fn setup_desktop(app: &mut tauri::App) -> SetupResult {
     // Linux, dead server), the window was created visible(false) and the app
     // would run invisibly forever. Force-show it after a grace period.
     let watchdog_ready = Arc::clone(&page_ready);
+    let watchdog_ready_on_main = Arc::clone(&page_ready);
     let watchdog_window = window.clone();
-    std::thread::Builder::new()
-        .name("window-watchdog".to_string())
-        .spawn(move || {
-            std::thread::sleep(std::time::Duration::from_secs(20));
-            if !watchdog_ready.load(Ordering::Acquire) {
+    let watchdog_app_handle = window.app_handle().clone();
+    if let Err(error) = spawn_window_watchdog(watchdog_ready, WINDOW_WATCHDOG_DELAY, move || {
+        let result = watchdog_app_handle.run_on_main_thread(move || {
+            if !watchdog_ready_on_main.load(Ordering::Acquire) {
                 let _ = watchdog_window.show();
                 let _ = watchdog_window.set_focus();
             }
-        })
-        .ok();
+        });
+        if let Err(error) = result {
+            eprintln!("window watchdog could not reach the main thread: {error}");
+        }
+    }) {
+        eprintln!("window watchdog could not start: {error}");
+    }
     let close_app_handle = window.app_handle().clone();
     window.on_window_event(move |event| {
         if let WindowEvent::CloseRequested { api, .. } = event
@@ -242,13 +266,52 @@ fn boxed_string(err: String) -> Box<dyn std::error::Error> {
 
 #[cfg(test)]
 mod exit_coordinator_tests {
-    use super::ExitCoordinator;
+    use std::{
+        sync::{
+            Arc,
+            atomic::{AtomicBool, AtomicUsize, Ordering},
+        },
+        time::Duration,
+    };
+
+    use super::{ExitCoordinator, spawn_window_watchdog};
 
     #[test]
     fn graceful_exit_fallback_is_started_only_once() {
         let coordinator = ExitCoordinator::default();
         assert!(coordinator.begin_graceful_exit());
         assert!(!coordinator.begin_graceful_exit());
+    }
+
+    #[test]
+    fn window_watchdog_shows_the_window_when_page_load_stalls() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls_in_watchdog = Arc::clone(&calls);
+        let handle = spawn_window_watchdog(
+            Arc::new(AtomicBool::new(false)),
+            Duration::ZERO,
+            move || {
+                calls_in_watchdog.fetch_add(1, Ordering::SeqCst);
+            },
+        )
+        .unwrap();
+
+        handle.join().unwrap();
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn window_watchdog_does_nothing_after_page_load_finishes() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls_in_watchdog = Arc::clone(&calls);
+        let handle =
+            spawn_window_watchdog(Arc::new(AtomicBool::new(true)), Duration::ZERO, move || {
+                calls_in_watchdog.fetch_add(1, Ordering::SeqCst);
+            })
+            .unwrap();
+
+        handle.join().unwrap();
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
     }
 }
 

--- a/src-tauri/src/platform/web_app.rs
+++ b/src-tauri/src/platform/web_app.rs
@@ -117,6 +117,21 @@ pub(crate) fn setup_desktop(app: &mut tauri::App) -> SetupResult {
         });
 
     let window = builder.build()?;
+    // If the page never finishes loading (stalled WebKitGTK/compositor on
+    // Linux, dead server), the window was created visible(false) and the app
+    // would run invisibly forever. Force-show it after a grace period.
+    let watchdog_ready = Arc::clone(&page_ready);
+    let watchdog_window = window.clone();
+    std::thread::Builder::new()
+        .name("window-watchdog".to_string())
+        .spawn(move || {
+            std::thread::sleep(std::time::Duration::from_secs(20));
+            if !watchdog_ready.load(Ordering::Acquire) {
+                let _ = watchdog_window.show();
+                let _ = watchdog_window.set_focus();
+            }
+        })
+        .ok();
     let close_app_handle = window.app_handle().clone();
     window.on_window_event(move |event| {
         if let WindowEvent::CloseRequested { api, .. } = event


### PR DESCRIPTION
Closes #104

**Audit verdict:** CONFIRMED (wave-7: window shown only from on_page_load; stall = invisible app).

**Fix:** 20s watchdog thread force-shows the window when the page flag is still unset.

**Verification:** cargo build 0; platform tests 1/1.