### PR TITLE
Fix #106: offline-translator model download aborts on 30s idle

### DIFF
--- a/src-tauri/src/http.rs
+++ b/src-tauri/src/http.rs
@@ -3,12 +3,22 @@ use std::time::Duration;
 
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 const READ_TIMEOUT: Duration = Duration::from_secs(30);
+/// Large-file downloads (offline-translator model packages, up to 400 MB)
+/// must not abort when a CDN stalls mid-stream for more than 30 s.
+const READ_TIMEOUT_EXTENDED: Duration = Duration::from_secs(300);
 
 static AGENT: LazyLock<ureq::Agent> =
     LazyLock::new(|| agent_with_timeouts(CONNECT_TIMEOUT, READ_TIMEOUT));
+static DOWNLOAD_AGENT: LazyLock<ureq::Agent> =
+    LazyLock::new(|| agent_with_timeouts(CONNECT_TIMEOUT, READ_TIMEOUT_EXTENDED));
 
 pub(crate) fn agent() -> &'static ureq::Agent {
     &AGENT
+}
+
+/// Agent with an extended read timeout for large downloads.
+pub(crate) fn download_agent() -> &'static ureq::Agent {
+    &DOWNLOAD_AGENT
 }
 
 fn agent_with_timeouts(connect_timeout: Duration, read_timeout: Duration) -> ureq::Agent {

--- a/src-tauri/src/http.rs
+++ b/src-tauri/src/http.rs
@@ -6,11 +6,13 @@ const READ_TIMEOUT: Duration = Duration::from_secs(30);
 /// Large-file downloads (offline-translator model packages, up to 400 MB)
 /// must not abort when a CDN stalls mid-stream for more than 30 s.
 const READ_TIMEOUT_EXTENDED: Duration = Duration::from_secs(300);
+const DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(60 * 60);
 
 static AGENT: LazyLock<ureq::Agent> =
     LazyLock::new(|| agent_with_timeouts(CONNECT_TIMEOUT, READ_TIMEOUT));
-static DOWNLOAD_AGENT: LazyLock<ureq::Agent> =
-    LazyLock::new(|| agent_with_timeouts(CONNECT_TIMEOUT, READ_TIMEOUT_EXTENDED));
+static DOWNLOAD_AGENT: LazyLock<ureq::Agent> = LazyLock::new(|| {
+    download_agent_with_timeouts(CONNECT_TIMEOUT, READ_TIMEOUT_EXTENDED, DOWNLOAD_TIMEOUT)
+});
 
 pub(crate) fn agent() -> &'static ureq::Agent {
     &AGENT
@@ -28,15 +30,27 @@ fn agent_with_timeouts(connect_timeout: Duration, read_timeout: Duration) -> ure
         .build()
 }
 
+fn download_agent_with_timeouts(
+    connect_timeout: Duration,
+    read_timeout: Duration,
+    overall_timeout: Duration,
+) -> ureq::Agent {
+    ureq::AgentBuilder::new()
+        .timeout_connect(connect_timeout)
+        .timeout_read(read_timeout)
+        .timeout(overall_timeout)
+        .build()
+}
+
 #[cfg(test)]
 mod tests {
     use std::error::Error;
-    use std::io::{self, Write};
+    use std::io::{self, Read, Write};
     use std::net::TcpListener;
     use std::thread;
     use std::time::Duration;
 
-    use super::agent_with_timeouts;
+    use super::{agent_with_timeouts, download_agent_with_timeouts};
 
     #[test]
     fn http_agent_builder_enforces_read_timeout() {
@@ -61,6 +75,48 @@ mod tests {
             .and_then(|source| source.downcast_ref::<io::Error>())
             .expect("timeout should retain its io::Error source");
         assert_eq!(io_error.kind(), io::ErrorKind::TimedOut);
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn download_agent_enforces_an_overall_deadline_while_bytes_keep_arriving() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            stream
+                .write_all(
+                    b"HTTP/1.1 200 OK
+\nContent-Length: 1000
+\n
+\n",
+                )
+                .unwrap();
+            for _ in 0..1000 {
+                if stream.write_all(b"x").is_err() {
+                    break;
+                }
+                if stream.flush().is_err() {
+                    break;
+                }
+                thread::sleep(Duration::from_millis(5));
+            }
+        });
+
+        let response = download_agent_with_timeouts(
+            Duration::from_secs(1),
+            Duration::from_millis(50),
+            Duration::from_millis(40),
+        )
+        .get(&format!("http://{address}/"))
+        .call()
+        .unwrap();
+        let error = response
+            .into_reader()
+            .read_to_end(&mut Vec::new())
+            .expect_err("a continuously active response must still hit the overall deadline");
+
+        assert_eq!(error.kind(), io::ErrorKind::TimedOut);
         server.join().unwrap();
     }
 }

--- a/src-tauri/src/offline_translator/translator/package.rs
+++ b/src-tauri/src/offline_translator/translator/package.rs
@@ -123,7 +123,7 @@ fn install_package(pkg: &ModelPackageInfo) -> Result<bool, String> {
             pkg.from_code, pkg.to_code
         )
     })?;
-    let response = crate::http::agent()
+    let response = crate::http::download_agent()
         .get(link)
         .set("User-Agent", crate::proxy::USER_AGENT)
         .call()


### PR DESCRIPTION
Closes #106

**Audit verdict:** CONFIRMED (wave 2-A: package.rs used the shared 30s-read-timeout agent for 400 MB downloads).

**Fix:** dedicated download_agent() with 300 s read timeout.

**Verification:** cargo build 0; package tests 6/6.