### PR TITLE
Fix #95: MOBI/AZW import deadlocks on ebook-convert pipes

### DIFF
--- a/src-tauri/src/ebook/calibre.rs
+++ b/src-tauri/src/ebook/calibre.rs
@@ -1,5 +1,5 @@
 use std::path::PathBuf;
-use std::process::{Command, Stdio};
+use std::process::{Child, Command, Output, Stdio};
 use std::time::{Duration, Instant};
 use std::{fs, thread};
 
@@ -40,6 +40,61 @@ fn find_ebook_convert() -> Option<PathBuf> {
     None
 }
 
+fn wait_with_output_timeout(mut child: Child, timeout: Duration) -> Result<Output, String> {
+    // Drain both pipes while the child is running. Waiting first can deadlock
+    // once either OS pipe buffer fills.
+    let stdout_thread = child.stdout.take().map(|mut pipe| {
+        thread::spawn(move || {
+            let mut buffer = Vec::new();
+            use std::io::Read;
+            let _ = pipe.read_to_end(&mut buffer);
+            buffer
+        })
+    });
+    let stderr_thread = child.stderr.take().map(|mut pipe| {
+        thread::spawn(move || {
+            let mut buffer = Vec::new();
+            use std::io::Read;
+            let _ = pipe.read_to_end(&mut buffer);
+            buffer
+        })
+    });
+
+    let deadline = Instant::now() + timeout;
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break Ok(status),
+            Ok(None) if Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                break Err(format!(
+                    "ebook-convert timed out after {} seconds",
+                    timeout.as_secs()
+                ));
+            }
+            Ok(None) => thread::sleep(Duration::from_millis(100)),
+            Err(error) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                break Err(error.to_string());
+            }
+        }
+    };
+
+    let stdout = stdout_thread
+        .and_then(|handle| handle.join().ok())
+        .unwrap_or_default();
+    let stderr = stderr_thread
+        .and_then(|handle| handle.join().ok())
+        .unwrap_or_default();
+
+    Ok(Output {
+        status: status?,
+        stdout,
+        stderr,
+    })
+}
+
 pub(crate) fn convert_with_calibre(data: &[u8], suffix: &str) -> Result<String, String> {
     let converter = find_ebook_convert()
         .ok_or_else(|| "MOBI/AZW import requires Calibre and ebook-convert in PATH".to_string())?;
@@ -58,55 +113,14 @@ pub(crate) fn convert_with_calibre(data: &[u8], suffix: &str) -> Result<String, 
     #[cfg(windows)]
     command.creation_flags(0x08000000);
 
-    let mut child = command.spawn().map_err(|e| e.to_string())?;
-    // Drain stdout/stderr concurrently: ebook-convert writes progress to
-    // both pipes, and once a pipe buffer fills (~64 KB) the child blocks
-    // forever. Reading only after wait() is a deadlock.
-    let stdout_pipe = child.stdout.take();
-    let stderr_pipe = child.stderr.take();
-    let stdout_thread = stdout_pipe.map(|mut pipe| {
-        thread::spawn(move || {
-            let mut buf = Vec::new();
-            use std::io::Read;
-            let _ = pipe.read_to_end(&mut buf);
-            buf
-        })
-    });
-    let stderr_thread = stderr_pipe.map(|mut pipe| {
-        thread::spawn(move || {
-            let mut buf = Vec::new();
-            use std::io::Read;
-            let _ = pipe.read_to_end(&mut buf);
-            buf
-        })
-    });
+    let output = wait_with_output_timeout(
+        command.spawn().map_err(|error| error.to_string())?,
+        Duration::from_secs(180),
+    )?;
 
-    let deadline = Instant::now() + Duration::from_secs(180);
-    let status = loop {
-        match child.try_wait() {
-            Ok(Some(s)) => break s,
-            Ok(None) => {
-                if Instant::now() >= deadline {
-                    let _ = child.kill();
-                    let _ = child.wait();
-                    return Err("ebook-convert timed out after 180 seconds".to_string());
-                }
-                thread::sleep(Duration::from_millis(100));
-            }
-            Err(e) => return Err(e.to_string()),
-        }
-    };
-
-    let stdout = stdout_thread
-        .and_then(|handle| handle.join().ok())
-        .unwrap_or_default();
-    let stderr = stderr_thread
-        .and_then(|handle| handle.join().ok())
-        .unwrap_or_default();
-
-    if !status.success() {
-        let stderr_text = String::from_utf8_lossy(&stderr).trim().to_string();
-        let stdout_text = String::from_utf8_lossy(&stdout).trim().to_string();
+    if !output.status.success() {
+        let stderr_text = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let stdout_text = String::from_utf8_lossy(&output.stdout).trim().to_string();
         return Err(if stderr_text.is_empty() {
             stdout_text
         } else {
@@ -116,4 +130,43 @@ pub(crate) fn convert_with_calibre(data: &[u8], suffix: &str) -> Result<String, 
 
     let text = fs::read(&target).map_err(|e| e.to_string())?;
     Ok(clean_imported_ebook_text(&decode_epub_text(&text)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::wait_with_output_timeout;
+    use std::process::{Command, Stdio};
+    use std::time::Duration;
+
+    #[test]
+    fn drains_large_stdout_and_stderr_without_deadlocking() {
+        let mut command = if cfg!(windows) {
+            let mut command = Command::new("cmd");
+            command.args([
+                "/d",
+                "/s",
+                "/c",
+                "(for /L %i in (1,1,5000) do @echo 012345678901234567890123456789)&(for /L %i in (1,1,5000) do @echo abcdefghijklmnopqrstuvwxyz 1>&2)",
+            ]);
+            command
+        } else {
+            let mut command = Command::new("sh");
+            command.args([
+                "-c",
+                "yes 012345678901234567890123456789 | head -c 160000; yes abcdefghijklmnopqrstuvwxyz | head -c 160000 >&2",
+            ]);
+            command
+        };
+        command
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        let output = wait_with_output_timeout(command.spawn().unwrap(), Duration::from_secs(10))
+            .expect("large piped output should be drained before the child exits");
+
+        assert!(output.status.success());
+        assert!(output.stdout.len() > 64 * 1024);
+        assert!(output.stderr.len() > 64 * 1024);
+    }
 }

--- a/src-tauri/src/ebook/calibre.rs
+++ b/src-tauri/src/ebook/calibre.rs
@@ -59,6 +59,28 @@ pub(crate) fn convert_with_calibre(data: &[u8], suffix: &str) -> Result<String, 
     command.creation_flags(0x08000000);
 
     let mut child = command.spawn().map_err(|e| e.to_string())?;
+    // Drain stdout/stderr concurrently: ebook-convert writes progress to
+    // both pipes, and once a pipe buffer fills (~64 KB) the child blocks
+    // forever. Reading only after wait() is a deadlock.
+    let stdout_pipe = child.stdout.take();
+    let stderr_pipe = child.stderr.take();
+    let stdout_thread = stdout_pipe.map(|mut pipe| {
+        thread::spawn(move || {
+            let mut buf = Vec::new();
+            use std::io::Read;
+            let _ = pipe.read_to_end(&mut buf);
+            buf
+        })
+    });
+    let stderr_thread = stderr_pipe.map(|mut pipe| {
+        thread::spawn(move || {
+            let mut buf = Vec::new();
+            use std::io::Read;
+            let _ = pipe.read_to_end(&mut buf);
+            buf
+        })
+    });
+
     let deadline = Instant::now() + Duration::from_secs(180);
     let status = loop {
         match child.try_wait() {
@@ -75,16 +97,8 @@ pub(crate) fn convert_with_calibre(data: &[u8], suffix: &str) -> Result<String, 
         }
     };
 
-    let mut stdout = Vec::new();
-    let mut stderr = Vec::new();
-    if let Some(mut out) = child.stdout.take() {
-        use std::io::Read;
-        let _ = out.read_to_end(&mut stdout);
-    }
-    if let Some(mut err) = child.stderr.take() {
-        use std::io::Read;
-        let _ = err.read_to_end(&mut stderr);
-    }
+    let stdout = stdout_thread.and_then(|handle| handle.join().ok()).unwrap_or_default();
+    let stderr = stderr_thread.and_then(|handle| handle.join().ok()).unwrap_or_default();
 
     if !status.success() {
         let stderr_text = String::from_utf8_lossy(&stderr).trim().to_string();

--- a/src-tauri/src/ebook/calibre.rs
+++ b/src-tauri/src/ebook/calibre.rs
@@ -97,8 +97,12 @@ pub(crate) fn convert_with_calibre(data: &[u8], suffix: &str) -> Result<String, 
         }
     };
 
-    let stdout = stdout_thread.and_then(|handle| handle.join().ok()).unwrap_or_default();
-    let stderr = stderr_thread.and_then(|handle| handle.join().ok()).unwrap_or_default();
+    let stdout = stdout_thread
+        .and_then(|handle| handle.join().ok())
+        .unwrap_or_default();
+    let stderr = stderr_thread
+        .and_then(|handle| handle.join().ok())
+        .unwrap_or_default();
 
     if !status.success() {
         let stderr_text = String::from_utf8_lossy(&stderr).trim().to_string();


### PR DESCRIPTION
Closes #95

**Audit verdict:** CONFIRMED (wave 1-A + wave 4: pipes read after wait() only).

**Fix:** concurrent drain threads for stdout/stderr while try_wait polls.

**Verification:** cargo build 0; ebook tests 9/9.