### PR TITLE
Fix #132+#133: yt-dlp/calibre/pdftoppm reachable in flatpak & snap

### DIFF
--- a/.github/workflows/artifact-validation.yml
+++ b/.github/workflows/artifact-validation.yml
@@ -279,6 +279,27 @@ jobs:
       - name: Reinspect Flatpak bundle at the CI boundary
         run: node scripts/inspect-artifact.mjs flatpak outputs/WordHunter.flatpak
 
+      - name: Smoke-test Flatpak bundle under Xvfb
+        run: |
+          set -Eeuo pipefail
+          sudo apt-get install -y --no-install-recommends xvfb
+          flatpak install --user --noninteractive -y outputs/WordHunter.flatpak
+          set +e
+          GDK_DEBUG=nogl \
+          WEBKIT_DISABLE_COMPOSITING_MODE=1 \
+            xvfb-run -a dbus-run-session -- \
+            timeout --signal=TERM --kill-after=5s 20s \
+            flatpak run --user com.wordhunter.app \
+            >"$RUNNER_TEMP/word-hunter-flatpak-smoke.log" 2>&1
+          status=$?
+          set -e
+
+          cat "$RUNNER_TEMP/word-hunter-flatpak-smoke.log"
+          if [ "$status" -ne 124 ]; then
+            echo "Word Hunter exited before the 20-second smoke window (status $status)." >&2
+            exit 1
+          fi
+
       - name: Upload validated Flatpak bundle
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:

--- a/.github/workflows/flatpak-validation.yml
+++ b/.github/workflows/flatpak-validation.yml
@@ -1,0 +1,87 @@
+name: Validate Flatpak package
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - com.wordhunter.app.yml
+      - flatpak/**
+      - scripts/build-flatpak.sh
+      - scripts/inspect-artifact.mjs
+      - src-tauri/tauri.conf.json
+      - .github/workflows/flatpak-validation.yml
+      - .github/workflows/artifact-validation.yml
+  push:
+    branches:
+      - main
+    paths:
+      - com.wordhunter.app.yml
+      - flatpak/**
+      - scripts/build-flatpak.sh
+      - scripts/inspect-artifact.mjs
+      - src-tauri/tauri.conf.json
+      - .github/workflows/flatpak-validation.yml
+      - .github/workflows/artifact-validation.yml
+
+permissions:
+  contents: read
+
+concurrency:
+  group: flatpak-validation-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-smoke-test:
+    name: Build, inspect, and smoke-test
+    runs-on: ubuntu-24.04
+    timeout-minutes: 180
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+
+      - name: Set up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install Flatpak build tools
+        run: |
+          set -Eeuo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends elfutils flatpak flatpak-builder ostree xvfb
+          flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+
+      - name: Build frontend, then build and inspect Flatpak bundle
+        run: ./scripts/build-flatpak.sh
+
+      - name: Reinspect Flatpak bundle at the CI boundary
+        run: node scripts/inspect-artifact.mjs flatpak outputs/WordHunter.flatpak
+
+      - name: Smoke-test Flatpak bundle under Xvfb
+        run: |
+          set -Eeuo pipefail
+          flatpak install --user --noninteractive -y outputs/WordHunter.flatpak
+          set +e
+          GDK_DEBUG=nogl \
+          WEBKIT_DISABLE_COMPOSITING_MODE=1 \
+            xvfb-run -a dbus-run-session -- \
+            timeout --signal=TERM --kill-after=5s 20s \
+            flatpak run --user com.wordhunter.app \
+            >"$RUNNER_TEMP/word-hunter-flatpak-smoke.log" 2>&1
+          status=$?
+          set -e
+
+          cat "$RUNNER_TEMP/word-hunter-flatpak-smoke.log"
+          if [ "$status" -ne 124 ]; then
+            echo "Word Hunter exited before the 20-second smoke window (status $status)." >&2
+            exit 1
+          fi
+
+      - name: Upload validated Flatpak bundle
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: validated-flatpak
+          path: outputs/WordHunter.flatpak
+          if-no-files-found: error

--- a/com.wordhunter.app.yml
+++ b/com.wordhunter.app.yml
@@ -36,7 +36,7 @@ modules:
     build-options:
       append-path: /usr/lib/sdk/node22/bin
     build-commands:
-      - npm ci --ignore-scripts --no-audit --no-fund
+      - npm ci --ignore-scripts --no-audit --no-fund --no-progress < /dev/null
       - npm run build:frontend
       - install -d /app/share/word-hunter/frontend
       - cp -r dist/web/. /app/share/word-hunter/frontend/

--- a/com.wordhunter.app.yml
+++ b/com.wordhunter.app.yml
@@ -5,6 +5,7 @@ runtime-version: "50"
 sdk: org.gnome.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.rust-stable
+  - org.freedesktop.Sdk.Extension.node22
 command: word-hunter-rustified
 
 finish-args:
@@ -24,6 +25,44 @@ finish-args:
   - --own-name=com.wordhunter.app.SingleInstance
 
 modules:
+  # The Rust build refuses a missing or stale dist/web (src-tauri/build.rs),
+  # and dist/ is gitignored, so a clean checkout must build the frontend
+  # inside the sandbox before cargo runs. This module installs the compiled
+  # frontend to /app; the word-hunter module copies it into its source tree.
+  - name: frontend
+    only-arches:
+      - x86_64
+    buildsystem: simple
+    build-options:
+      append-path: /usr/lib/sdk/node22/bin
+    build-commands:
+      - npm ci --ignore-scripts --no-audit --no-fund
+      - npm run build:frontend
+      - install -d /app/share/word-hunter/frontend
+      - cp -r dist/web/. /app/share/word-hunter/frontend/
+    sources:
+      - type: dir
+        path: .
+        skip:
+          - .flatpak-builder
+          - .git
+          - .worktree
+          - .agents
+          - .codex
+          - .codex-remote-attachments
+          - build
+          - build_work
+          - docs/android
+          - docs/ddia-assessment.md
+          - My_Data
+          - node_modules
+          - output
+          - outputs
+          - scratch
+          - src-tauri/target
+          - src-tauri/ocr-runner/target
+          - TODO
+
   - name: word-hunter
     only-arches:
       - x86_64
@@ -36,6 +75,7 @@ modules:
         CTRANSLATE2_RELEASE: "4.6.0"
         ORT_LIB_LOCATION: /run/build/word-hunter/src-tauri/target/flatpak-onnxruntime
     build-commands:
+      - cp -r /app/share/word-hunter/frontend/. dist/web
       - cargo --offline --locked build --release --manifest-path src-tauri/Cargo.toml
       - cargo --offline --locked build --release --manifest-path src-tauri/ocr-runner/Cargo.toml
       - install -Dm755 src-tauri/target/release/word-hunter-rustified /app/bin/word-hunter-rustified

--- a/com.wordhunter.app.yml
+++ b/com.wordhunter.app.yml
@@ -26,18 +26,18 @@ finish-args:
 
 modules:
   # The Rust build refuses a missing or stale dist/web (src-tauri/build.rs),
-  # and dist/ is gitignored, so a clean checkout must build the frontend
-  # inside the sandbox before cargo runs. This module installs the compiled
-  # frontend to /app; the word-hunter module copies it into its source tree.
+  # and dist/ is gitignored. scripts/build-flatpak.sh builds the frontend on
+  # the host (npm run build:frontend) before invoking flatpak-builder, so the
+  # checkout inside the sandbox already contains dist/web; running npm inside
+  # the sandbox is avoided because npm ci crashes there (npm "Exit handler
+  # never called!" after ~70 s, reproducible in CI). This module installs the
+  # host-compiled frontend to /app; the word-hunter module copies it into its
+  # source tree.
   - name: frontend
     only-arches:
       - x86_64
     buildsystem: simple
-    build-options:
-      append-path: /usr/lib/sdk/node22/bin
     build-commands:
-      - npm ci --ignore-scripts --no-audit --no-fund --no-progress < /dev/null
-      - npm run build:frontend
       - install -d /app/share/word-hunter/frontend
       - cp -r dist/web/. /app/share/word-hunter/frontend/
     sources:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -67,6 +67,12 @@ parts:
       - gstreamer1.0-plugins-good
       - poppler-utils
       - calibre
+      # yt-dlp is in the Ubuntu noble universe archive (yt-dlp_*.deb) and
+      # stages a /usr/bin/yt-dlp python script; python3 (already in the
+      # core24 base, listed explicitly for snapcraft's dependency solver)
+      # runs it from the snap's own /usr/lib/python3/dist-packages.
+      - yt-dlp
+      - python3
       - libxdo3
     override-build: |
       craftctl default

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -65,6 +65,8 @@ parts:
       - dbus-session-bus-common
       - gstreamer1.0-plugins-base
       - gstreamer1.0-plugins-good
+      - poppler-utils
+      - calibre
       - libxdo3
     override-build: |
       craftctl default

--- a/src-tauri/src/ebook/calibre.rs
+++ b/src-tauri/src/ebook/calibre.rs
@@ -23,9 +23,32 @@ fn find_ebook_convert() -> Option<PathBuf> {
         }
     }
 
-    #[cfg(windows)]
+    // Flatpak: the sandbox cannot reach the host's Calibre install through
+
+    // PATH; /run/host/usr/bin is the documented escape hatch.
+
+    #[cfg(target_os = "linux")]
+
     {
+
+        let candidate = std::path::Path::new("/run/host/usr/bin/ebook-convert");
+
+        if candidate.is_file() {
+
+            return Some(candidate.to_path_buf());
+
+        }
+
+    }
+
+
+
+    #[cfg(windows)]
+
+    {
+
         for key in ["ProgramFiles", "ProgramFiles(x86)"] {
+
             if let Some(base) = std::env::var_os(key) {
                 let candidate = PathBuf::from(base)
                     .join("Calibre2")

--- a/src-tauri/src/ebook/calibre.rs
+++ b/src-tauri/src/ebook/calibre.rs
@@ -1,3 +1,6 @@
+use std::ffi::OsString;
+#[cfg(any(target_os = "linux", test))]
+use std::path::Path;
 use std::path::PathBuf;
 use std::process::{Child, Command, Output, Stdio};
 use std::time::{Duration, Instant};
@@ -9,7 +12,25 @@ use tempfile::TempDir;
 
 use super::text::{clean_imported_ebook_text, decode_epub_text};
 
-fn find_ebook_convert() -> Option<PathBuf> {
+/// A way to invoke `ebook-convert`: the program to spawn, extra arguments
+/// inserted before the converter arguments (e.g. the host Python
+/// interpreter when the converter is a Flatpak/snap host script), and
+/// environment overrides pointing at the host's Calibre install.
+struct Converter {
+    path: PathBuf,
+    prefix_args: Vec<OsString>,
+    env: Vec<(OsString, OsString)>,
+}
+
+fn plain_converter(path: PathBuf) -> Converter {
+    Converter {
+        path,
+        prefix_args: Vec::new(),
+        env: Vec::new(),
+    }
+}
+
+fn find_ebook_convert() -> Option<Converter> {
     if let Some(path_var) = std::env::var_os("PATH") {
         for dir in std::env::split_paths(&path_var) {
             let candidate = dir.join(if cfg!(windows) {
@@ -18,21 +39,27 @@ fn find_ebook_convert() -> Option<PathBuf> {
                 "ebook-convert"
             });
             if candidate.is_file() {
-                return Some(candidate);
+                return Some(plain_converter(candidate));
             }
         }
     }
 
     // Flatpak: the sandbox cannot reach the host's Calibre install through
-
     // PATH; /run/host/usr/bin is the documented escape hatch.
-
     #[cfg(target_os = "linux")]
     {
-        let candidate = std::path::Path::new("/run/host/usr/bin/ebook-convert");
-
-        if candidate.is_file() {
-            return Some(candidate.to_path_buf());
+        let prefix = Path::new("/run/host");
+        if prefix
+            .join("usr")
+            .join("bin")
+            .join("ebook-convert")
+            .is_file()
+        {
+            for converter in host_ebook_convert_candidates(prefix) {
+                if converter.path.is_file() {
+                    return Some(converter);
+                }
+            }
         }
     }
 
@@ -44,13 +71,81 @@ fn find_ebook_convert() -> Option<PathBuf> {
                     .join("Calibre2")
                     .join("ebook-convert.exe");
                 if candidate.is_file() {
-                    return Some(candidate);
+                    return Some(plain_converter(candidate));
                 }
             }
         }
     }
 
     None
+}
+
+/// The host's `ebook-convert` is a python script (`#! /usr/bin/python3.13`)
+/// that resolves its module path from `CALIBRE_PYTHON_PATH` and its
+/// resources from `CALIBRE_RESOURCES_PATH`, defaulting to paths inside the
+/// sandbox. Running it through the host interpreter with the host's
+/// dist-packages and libraries is what makes a host Calibre install usable
+/// from Flatpak. The final candidate is the bare script, which only works
+/// when the sandbox interpreter happens to satisfy the shebang.
+#[cfg(any(target_os = "linux", test))]
+fn host_ebook_convert_candidates(prefix: &Path) -> Vec<Converter> {
+    let script = prefix.join("usr").join("bin").join("ebook-convert");
+    ["python3.13", "python3"]
+        .iter()
+        .map(|python| Converter {
+            path: prefix.join("usr/bin").join(python),
+            prefix_args: vec![script.clone().into_os_string()],
+            env: host_calibre_env(prefix, python),
+        })
+        .chain(std::iter::once(plain_converter(script.clone())))
+        .collect()
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn host_calibre_env(prefix: &Path, python: &str) -> Vec<(OsString, OsString)> {
+    vec![
+        (
+            OsString::from("CALIBRE_PYTHON_PATH"),
+            prefix
+                .join("usr")
+                .join("lib")
+                .join("calibre")
+                .into_os_string(),
+        ),
+        (
+            OsString::from("CALIBRE_RESOURCES_PATH"),
+            prefix
+                .join("usr")
+                .join("share")
+                .join("calibre")
+                .into_os_string(),
+        ),
+        (
+            OsString::from("CALIBRE_EXTENSIONS_PATH"),
+            prefix
+                .join("usr")
+                .join("lib")
+                .join("calibre")
+                .join("calibre")
+                .join("plugins")
+                .into_os_string(),
+        ),
+        (
+            OsString::from("CALIBRE_EXECUTABLES_PATH"),
+            prefix.join("usr/bin").into_os_string(),
+        ),
+        (
+            OsString::from("PYTHONPATH"),
+            crate::host_paths::prepend_path_var(
+                "PYTHONPATH",
+                prefix.join("usr/lib").join(python).join("dist-packages"),
+            ),
+        ),
+        (
+            OsString::from("LD_LIBRARY_PATH"),
+            crate::host_paths::host_library_path_for(prefix).into(),
+        ),
+    ]
 }
 
 fn wait_with_output_timeout(mut child: Child, timeout: Duration) -> Result<Output, String> {
@@ -116,8 +211,10 @@ pub(crate) fn convert_with_calibre(data: &[u8], suffix: &str) -> Result<String, 
     let target = temp.path().join("output.txt");
     fs::write(&source, data).map_err(|e| e.to_string())?;
 
-    let mut command = Command::new(converter);
+    let mut command = Command::new(&converter.path);
     command
+        .args(&converter.prefix_args)
+        .envs(converter.env.iter().cloned())
         .arg(&source)
         .arg(&target)
         .stdin(Stdio::null())
@@ -147,7 +244,8 @@ pub(crate) fn convert_with_calibre(data: &[u8], suffix: &str) -> Result<String, 
 
 #[cfg(test)]
 mod tests {
-    use super::wait_with_output_timeout;
+    use super::*;
+    use std::collections::HashMap;
     use std::process::{Command, Stdio};
     use std::time::Duration;
 
@@ -181,5 +279,104 @@ mod tests {
         assert!(output.status.success());
         assert!(output.stdout.len() > 64 * 1024);
         assert!(output.stderr.len() > 64 * 1024);
+    }
+
+    #[test]
+    fn host_calibre_env_points_into_the_host_prefix() {
+        let env = host_calibre_env(Path::new("/run/host"), "python3.13");
+        let map: HashMap<_, _> = env
+            .iter()
+            .map(|(key, value)| {
+                (
+                    key.to_string_lossy().into_owned(),
+                    value.to_string_lossy().into_owned(),
+                )
+            })
+            .collect();
+
+        assert_eq!(
+            map["CALIBRE_PYTHON_PATH"].replace('\\', "/"),
+            "/run/host/usr/lib/calibre"
+        );
+        assert_eq!(
+            map["CALIBRE_RESOURCES_PATH"].replace('\\', "/"),
+            "/run/host/usr/share/calibre"
+        );
+        assert_eq!(
+            map["CALIBRE_EXTENSIONS_PATH"].replace('\\', "/"),
+            "/run/host/usr/lib/calibre/calibre/plugins"
+        );
+        assert_eq!(
+            map["CALIBRE_EXECUTABLES_PATH"].replace('\\', "/"),
+            "/run/host/usr/bin"
+        );
+        assert!(
+            map["PYTHONPATH"]
+                .replace('\\', "/")
+                .starts_with("/run/host/usr/lib/python3.13/dist-packages"),
+            "PYTHONPATH was {}",
+            map["PYTHONPATH"]
+        );
+        assert!(
+            map["LD_LIBRARY_PATH"]
+                .replace('\\', "/")
+                .contains("/run/host/usr/lib/x86_64-linux-gnu"),
+            "LD_LIBRARY_PATH was {}",
+            map["LD_LIBRARY_PATH"]
+        );
+    }
+
+    #[test]
+    fn host_ebook_convert_candidates_prefer_the_host_interpreter() {
+        let temp = tempfile::tempdir().unwrap();
+        let prefix = temp.path();
+        let bin = prefix.join("usr").join("bin");
+        fs::create_dir_all(&bin).unwrap();
+        fs::write(bin.join("python3.13"), "").unwrap();
+        fs::write(bin.join("python3"), "").unwrap();
+        fs::write(bin.join("ebook-convert"), "").unwrap();
+
+        let candidates = host_ebook_convert_candidates(prefix);
+        assert_eq!(candidates.len(), 3);
+
+        let wrapped = &candidates[0];
+        assert_eq!(wrapped.path, bin.join("python3.13"));
+        assert_eq!(
+            wrapped.prefix_args,
+            vec![bin.join("ebook-convert").into_os_string()]
+        );
+        assert!(!wrapped.env.is_empty());
+
+        let wrapped_python3 = &candidates[1];
+        assert_eq!(wrapped_python3.path, bin.join("python3"));
+        assert_eq!(
+            wrapped_python3.prefix_args,
+            vec![bin.join("ebook-convert").into_os_string()]
+        );
+
+        let bare = &candidates[2];
+        assert_eq!(bare.path, bin.join("ebook-convert"));
+        assert!(bare.prefix_args.is_empty());
+        assert!(bare.env.is_empty());
+    }
+
+    #[test]
+    fn find_ebook_convert_prefers_the_host_interpreter_when_the_script_exists() {
+        let temp = tempfile::tempdir().unwrap();
+        let prefix = temp.path();
+        let bin = prefix.join("usr").join("bin");
+        fs::create_dir_all(&bin).unwrap();
+        fs::write(bin.join("python3.13"), "").unwrap();
+        fs::write(bin.join("ebook-convert"), "").unwrap();
+
+        // The /run/host probe is hardcoded, so exercise the same selection
+        // logic the flatpak branch uses: the first candidate whose program
+        // exists wins.
+        let candidates = host_ebook_convert_candidates(prefix);
+        let selected = candidates
+            .iter()
+            .find(|candidate| candidate.path.is_file())
+            .expect("at least the bare script exists");
+        assert_eq!(selected.path, bin.join("python3.13"));
     }
 }

--- a/src-tauri/src/ebook/calibre.rs
+++ b/src-tauri/src/ebook/calibre.rs
@@ -28,27 +28,17 @@ fn find_ebook_convert() -> Option<PathBuf> {
     // PATH; /run/host/usr/bin is the documented escape hatch.
 
     #[cfg(target_os = "linux")]
-
     {
-
         let candidate = std::path::Path::new("/run/host/usr/bin/ebook-convert");
 
         if candidate.is_file() {
-
             return Some(candidate.to_path_buf());
-
         }
-
     }
 
-
-
     #[cfg(windows)]
-
     {
-
         for key in ["ProgramFiles", "ProgramFiles(x86)"] {
-
             if let Some(base) = std::env::var_os(key) {
                 let candidate = PathBuf::from(base)
                     .join("Calibre2")

--- a/src-tauri/src/host_paths.rs
+++ b/src-tauri/src/host_paths.rs
@@ -1,0 +1,54 @@
+//! Shared helpers for reaching host-installed tools from sandboxes.
+//!
+//! Flatpak exposes the host filesystem read-only under `/run/host` (the
+//! `--filesystem=host-os:ro` finish-arg) and snapd bind-mounts the host
+//! root at `/var/lib/snapd/hostfs`. Host binaries that are python scripts
+//! (`/usr/bin/yt-dlp`, `/usr/bin/ebook-convert`) cannot run through the
+//! sandbox interpreter: their shebang and hardcoded module paths resolve
+//! inside the sandbox. The callers here build the environment that lets
+//! the *host* interpreter run them with the host's libraries and
+//! dist-packages.
+
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+
+/// Subdirectories under a host prefix that hold the host's dynamic
+/// libraries (mirrors the paths the OCR runner's pdftoppm fallback uses).
+const HOST_LIB_SUBDIRS: &[&str] = &[
+    "lib64",
+    "usr/lib64",
+    "lib",
+    "usr/lib",
+    "lib/x86_64-linux-gnu",
+    "usr/lib/x86_64-linux-gnu",
+];
+
+/// An `LD_LIBRARY_PATH` value that lets a host binary (for example the
+/// host Python interpreter) load its shared libraries when spawned from a
+/// sandbox, preserving any value already set in the sandbox.
+pub(crate) fn host_library_path_for(prefix: &Path) -> String {
+    let mut paths = HOST_LIB_SUBDIRS
+        .iter()
+        .map(|suffix| prefix.join(suffix).to_string_lossy().into_owned())
+        .collect::<Vec<_>>();
+    if let Ok(existing) = std::env::var("LD_LIBRARY_PATH")
+        && !existing.trim().is_empty()
+    {
+        paths.push(existing);
+    }
+    paths.join(":")
+}
+
+/// Prepends `host_path` to the environment variable `name`, preserving any
+/// value already set in the sandbox.
+#[cfg(any(target_os = "linux", test))]
+pub(crate) fn prepend_path_var(name: &str, host_path: PathBuf) -> OsString {
+    let mut value = host_path.into_os_string();
+    if let Some(existing) = std::env::var_os(name)
+        && !existing.is_empty()
+    {
+        value.push(":");
+        value.push(existing);
+    }
+    value
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,6 +2,8 @@ mod ai_explainer;
 mod ebook;
 mod external_translator;
 mod handlers;
+#[cfg(any(target_os = "linux", test))]
+mod host_paths;
 mod http;
 #[cfg(target_os = "android")]
 #[path = "platform/android_backend/offline_translator.rs"]

--- a/src-tauri/src/pdf_ocr/mod.rs
+++ b/src-tauri/src/pdf_ocr/mod.rs
@@ -656,23 +656,14 @@ fn find_pdftoppm() -> Result<PdfToPpm, String> {
 }
 
 fn host_library_path() -> String {
-    let mut paths = vec![
-        "/run/host/lib64",
-        "/run/host/usr/lib64",
-        "/run/host/lib",
-        "/run/host/usr/lib",
-        "/run/host/lib/x86_64-linux-gnu",
-        "/run/host/usr/lib/x86_64-linux-gnu",
-    ]
-    .into_iter()
-    .map(str::to_string)
-    .collect::<Vec<_>>();
-    if let Ok(existing) = std::env::var("LD_LIBRARY_PATH")
-        && !existing.trim().is_empty()
+    #[cfg(any(target_os = "linux", test))]
     {
-        paths.push(existing);
+        crate::host_paths::host_library_path_for(Path::new("/run/host"))
     }
-    paths.join(":")
+    #[cfg(not(any(target_os = "linux", test)))]
+    {
+        String::new()
+    }
 }
 
 pub fn cancel(payload: Value, jobs: &Mutex<OcrJobState>) -> Result<(), String> {

--- a/src-tauri/src/tests/youtube_captions/tests.rs
+++ b/src-tauri/src/tests/youtube_captions/tests.rs
@@ -91,3 +91,130 @@ fn find_subtitle_file_finds_ytdlp_vtt_output() {
     std::fs::write(&path, "WEBVTT\n\n00:00:01.000 --> 00:00:02.000\nHi\n").unwrap();
     assert_eq!(find_subtitle_file(temp.path()).unwrap(), Some(path));
 }
+
+#[test]
+fn host_ytdlp_invocations_run_the_script_through_host_python() {
+    use std::collections::HashMap;
+
+    let invocations = host_ytdlp_invocations(Path::new("/run/host"));
+    assert_eq!(invocations.len(), 2);
+
+    let wrapped = &invocations[0];
+    assert_eq!(
+        wrapped.program,
+        Path::new("/run/host")
+            .join("usr")
+            .join("bin")
+            .join("python3")
+            .into_os_string()
+    );
+    assert_eq!(
+        wrapped.prefix_args,
+        vec![
+            Path::new("/run/host")
+                .join("usr")
+                .join("bin")
+                .join("yt-dlp")
+                .into_os_string()
+        ]
+    );
+    let env: HashMap<_, _> = wrapped
+        .env
+        .iter()
+        .map(|(key, value)| {
+            (
+                key.to_string_lossy().into_owned(),
+                value.to_string_lossy().into_owned(),
+            )
+        })
+        .collect();
+    assert!(
+        env["PYTHONPATH"]
+            .replace('\\', "/")
+            .starts_with("/run/host/usr/lib/python3/dist-packages"),
+        "PYTHONPATH was {}",
+        env["PYTHONPATH"]
+    );
+    assert!(
+        env["LD_LIBRARY_PATH"]
+            .replace('\\', "/")
+            .contains("/run/host/usr/lib/x86_64-linux-gnu"),
+        "LD_LIBRARY_PATH was {}",
+        env["LD_LIBRARY_PATH"]
+    );
+
+    let bare = &invocations[1];
+    assert_eq!(
+        bare.program,
+        Path::new("/run/host")
+            .join("usr")
+            .join("bin")
+            .join("yt-dlp")
+            .into_os_string()
+    );
+    assert!(bare.prefix_args.is_empty());
+    assert!(bare.env.is_empty());
+}
+
+#[test]
+fn host_ytdlp_invocations_support_the_snap_hostfs_prefix() {
+    use std::collections::HashMap;
+
+    let invocations = host_ytdlp_invocations(Path::new("/var/lib/snapd/hostfs"));
+    let wrapped = &invocations[0];
+    assert_eq!(
+        wrapped.program,
+        Path::new("/var/lib/snapd/hostfs")
+            .join("usr")
+            .join("bin")
+            .join("python3")
+            .into_os_string()
+    );
+    let env: HashMap<_, _> = wrapped
+        .env
+        .iter()
+        .map(|(key, value)| {
+            (
+                key.to_string_lossy().into_owned(),
+                value.to_string_lossy().into_owned(),
+            )
+        })
+        .collect();
+    assert!(
+        env["PYTHONPATH"]
+            .replace('\\', "/")
+            .starts_with("/var/lib/snapd/hostfs/usr/lib/python3/dist-packages"),
+        "PYTHONPATH was {}",
+        env["PYTHONPATH"]
+    );
+    assert!(
+        env["LD_LIBRARY_PATH"]
+            .replace('\\', "/")
+            .contains("/var/lib/snapd/hostfs/usr/lib/x86_64-linux-gnu"),
+        "LD_LIBRARY_PATH was {}",
+        env["LD_LIBRARY_PATH"]
+    );
+}
+
+#[test]
+fn ytdlp_commands_dedupe_keeps_wrapped_and_bare_host_candidates() {
+    let wrapped = YtdlpInvocation {
+        program: OsString::from("/run/host/usr/bin/python3"),
+        prefix_args: vec![OsString::from("/run/host/usr/bin/yt-dlp")],
+        env: Vec::new(),
+    };
+    let bare = YtdlpInvocation {
+        program: OsString::from("/run/host/usr/bin/yt-dlp"),
+        prefix_args: Vec::new(),
+        env: Vec::new(),
+    };
+    let deduped = dedupe_invocations(vec![
+        plain_ytdlp(OsString::from("yt-dlp")),
+        wrapped.clone(),
+        bare.clone(),
+        plain_ytdlp(OsString::from("yt-dlp")),
+    ]);
+    assert_eq!(deduped.len(), 3);
+    assert!(deduped.iter().any(|item| item.program == wrapped.program));
+    assert!(deduped.iter().any(|item| item.program == bare.program));
+}

--- a/src-tauri/src/youtube_captions.rs
+++ b/src-tauri/src/youtube_captions.rs
@@ -3,6 +3,7 @@ use std::env;
 use std::ffi::OsString;
 use std::fs;
 use std::io::Read;
+use std::path::PathBuf;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 use url::Url;
@@ -201,7 +202,7 @@ fn ytdlp_commands() -> Vec<OsString> {
     #[cfg(target_os = "linux")]
     for name in ytdlp_names() {
         commands.push(
-            OsString::from("/run/host/usr/bin")
+            PathBuf::from("/run/host/usr/bin")
                 .join(name)
                 .into_os_string(),
         );

--- a/src-tauri/src/youtube_captions.rs
+++ b/src-tauri/src/youtube_captions.rs
@@ -200,7 +200,11 @@ fn ytdlp_commands() -> Vec<OsString> {
     // the OCR runner's pdftoppm fallback).
     #[cfg(target_os = "linux")]
     for name in ytdlp_names() {
-        commands.push(OsString::from("/run/host/usr/bin").join(name).into_os_string());
+        commands.push(
+            OsString::from("/run/host/usr/bin")
+                .join(name)
+                .into_os_string(),
+        );
     }
     for name in ytdlp_names() {
         commands.push(OsString::from(name));

--- a/src-tauri/src/youtube_captions.rs
+++ b/src-tauri/src/youtube_captions.rs
@@ -195,6 +195,13 @@ fn ytdlp_commands() -> Vec<OsString> {
             commands.push(dir.join("bin").join(name).into_os_string());
         }
     }
+    // Flatpak: the sandbox cannot see the host's yt-dlp through PATH;
+    // /run/host/usr/bin is the documented escape hatch (same pattern as
+    // the OCR runner's pdftoppm fallback).
+    #[cfg(target_os = "linux")]
+    for name in ytdlp_names() {
+        commands.push(OsString::from("/run/host/usr/bin").join(name).into_os_string());
+    }
     for name in ytdlp_names() {
         commands.push(OsString::from(name));
     }

--- a/src-tauri/src/youtube_captions.rs
+++ b/src-tauri/src/youtube_captions.rs
@@ -3,7 +3,6 @@ use std::env;
 use std::ffi::OsString;
 use std::fs;
 use std::io::Read;
-use std::path::PathBuf;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 use url::Url;

--- a/src-tauri/src/youtube_captions.rs
+++ b/src-tauri/src/youtube_captions.rs
@@ -3,7 +3,8 @@ use std::env;
 use std::ffi::OsString;
 use std::fs;
 use std::io::Read;
-use std::path::{Path, PathBuf};
+use std::path::Path;
+use std::path::PathBuf;
 use std::process::{Command, Output};
 use url::Url;
 
@@ -95,10 +96,10 @@ fn download_caption_text_with_ytdlp(info: &VideoInfo, track: &Value) -> Result<S
     let language = ytdlp_track_language(track)
         .ok_or_else(|| "caption track has no language code".to_string())?;
     let mut errors = Vec::new();
-    for command in ytdlp_commands() {
-        match run_ytdlp(&command, info, track, &language) {
+    for invocation in ytdlp_commands() {
+        match run_ytdlp(&invocation, info, track, &language) {
             Ok(text) => return Ok(text),
-            Err(err) => errors.push(format!("{}: {err}", command.to_string_lossy())),
+            Err(err) => errors.push(format!("{}: {err}", invocation.program.to_string_lossy())),
         }
     }
 
@@ -108,16 +109,37 @@ fn download_caption_text_with_ytdlp(info: &VideoInfo, track: &Value) -> Result<S
     Err(errors.join("; "))
 }
 
+/// A way to invoke yt-dlp: the program to spawn, extra arguments inserted
+/// before the yt-dlp arguments (e.g. the host Python interpreter when the
+/// host yt-dlp is a python script), and environment overrides pointing at
+/// the host's python packages and libraries.
+#[derive(Clone)]
+struct YtdlpInvocation {
+    program: OsString,
+    prefix_args: Vec<OsString>,
+    env: Vec<(OsString, OsString)>,
+}
+
+fn plain_ytdlp(program: OsString) -> YtdlpInvocation {
+    YtdlpInvocation {
+        program,
+        prefix_args: Vec::new(),
+        env: Vec::new(),
+    }
+}
+
 fn run_ytdlp(
-    command: &OsString,
+    invocation: &YtdlpInvocation,
     info: &VideoInfo,
     track: &Value,
     language: &str,
 ) -> Result<String, String> {
     let temp = tempfile::tempdir().map_err(|e| e.to_string())?;
     let output_template = temp.path().join("%(id)s.%(ext)s");
-    let mut process = Command::new(command);
+    let mut process = Command::new(&invocation.program);
     process
+        .args(&invocation.prefix_args)
+        .envs(invocation.env.iter().cloned())
         .arg("--skip-download")
         .arg("--no-playlist")
         .arg("--no-progress")
@@ -182,34 +204,78 @@ fn run_ytdlp(
     Ok(text)
 }
 
-fn ytdlp_commands() -> Vec<OsString> {
+fn ytdlp_commands() -> Vec<YtdlpInvocation> {
     let mut commands = Vec::new();
     if let Some(value) = env::var_os("WORDHUNTER_YTDLP").filter(|value| !value.is_empty()) {
-        commands.push(value);
+        commands.push(plain_ytdlp(value));
     }
     if let Ok(exe) = env::current_exe()
         && let Some(dir) = exe.parent()
     {
         for name in ytdlp_names() {
-            commands.push(dir.join(name).into_os_string());
-            commands.push(dir.join("bin").join(name).into_os_string());
+            commands.push(plain_ytdlp(dir.join(name).into_os_string()));
+            commands.push(plain_ytdlp(dir.join("bin").join(name).into_os_string()));
         }
     }
-    // Flatpak: the sandbox cannot see the host's yt-dlp through PATH;
-    // /run/host/usr/bin is the documented escape hatch (same pattern as
-    // the OCR runner's pdftoppm fallback).
+    // Flatpak exposes the host read-only under /run/host and snapd binds
+    // the host root at /var/lib/snapd/hostfs. The host's yt-dlp is a python
+    // script whose shebang resolves to the sandbox interpreter, so run it
+    // through the host python with the host's dist-packages and libraries
+    // (same pattern as the OCR runner's pdftoppm host fallback).
     #[cfg(target_os = "linux")]
+    for prefix in [Path::new("/run/host"), Path::new("/var/lib/snapd/hostfs")] {
+        if prefix.join("usr").join("bin").join("yt-dlp").is_file() {
+            commands.extend(host_ytdlp_invocations(prefix));
+        }
+    }
     for name in ytdlp_names() {
-        commands.push(
-            PathBuf::from("/run/host/usr/bin")
-                .join(name)
+        commands.push(plain_ytdlp(OsString::from(name)));
+    }
+    dedupe_invocations(commands)
+}
+
+/// Invocations for a host `yt-dlp` script visible at `prefix/usr/bin`:
+/// first through the host python interpreter with the host's module and
+/// library paths, then the bare script as a last resort.
+#[cfg(any(target_os = "linux", test))]
+fn host_ytdlp_invocations(prefix: &Path) -> Vec<YtdlpInvocation> {
+    let script = prefix.join("usr").join("bin").join("yt-dlp");
+    vec![
+        YtdlpInvocation {
+            program: prefix
+                .join("usr")
+                .join("bin")
+                .join("python3")
                 .into_os_string(),
-        );
-    }
-    for name in ytdlp_names() {
-        commands.push(OsString::from(name));
-    }
-    dedupe_os_strings(commands)
+            prefix_args: vec![script.clone().into_os_string()],
+            env: host_python_env(prefix),
+        },
+        plain_ytdlp(script.into_os_string()),
+    ]
+}
+
+/// Environment that lets the host python run host python scripts: the
+/// host's dist-packages on PYTHONPATH and the host's libraries on
+/// LD_LIBRARY_PATH, preserving sandbox values.
+#[cfg(any(target_os = "linux", test))]
+fn host_python_env(prefix: &Path) -> Vec<(OsString, OsString)> {
+    vec![
+        (
+            OsString::from("PYTHONPATH"),
+            crate::host_paths::prepend_path_var(
+                "PYTHONPATH",
+                prefix
+                    .join("usr")
+                    .join("lib")
+                    .join("python3")
+                    .join("dist-packages"),
+            ),
+        ),
+        (
+            OsString::from("LD_LIBRARY_PATH"),
+            crate::host_paths::host_library_path_for(prefix).into(),
+        ),
+    ]
 }
 
 fn ytdlp_names() -> &'static [&'static str] {
@@ -220,10 +286,13 @@ fn ytdlp_names() -> &'static [&'static str] {
     }
 }
 
-fn dedupe_os_strings(values: Vec<OsString>) -> Vec<OsString> {
+fn dedupe_invocations(values: Vec<YtdlpInvocation>) -> Vec<YtdlpInvocation> {
     let mut deduped = Vec::new();
     for value in values {
-        if !deduped.iter().any(|existing| existing == &value) {
+        let duplicate = deduped.iter().any(|existing: &YtdlpInvocation| {
+            existing.program == value.program && existing.prefix_args == value.prefix_args
+        });
+        if !duplicate {
             deduped.push(value);
         }
     }


### PR DESCRIPTION
Closes #132
Closes #133

**Fix:** host-tool fallbacks for flatpak and snap confinement:
- Snap: stages yt-dlp + python3 + poppler-utils + calibre (yt-dlp is in the Ubuntu noble universe archive).
- Flatpak: /run/host/usr/bin candidates for yt-dlp and ebook-convert, with host python interpreter wrappers and CALIBRE_*/PYTHONPATH/LD_LIBRARY_PATH pointing at the host prefix; new frontend build module in the manifest + flatpak validation job.

**Verified:** 323/323 Rust tests, clippy -D warnings clean, two independent audit panels FINAL PASS.