### PR TITLE
Fix #134: deb depends — WebKitGTK floor + poppler-utils, drop dead libxdo3

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ chmod +x WordHunter-1.0.10-x86_64.AppImage
 sudo apt install ./word-hunter_1.0.10_amd64.deb
 ```
 
+> **Linux system requirement:** WebKitGTK **4.1** (≥ 2.40) — e.g. Ubuntu 22.04+, Debian 12+, Fedora 38+. The DEB declares `libwebkit2gtk-4.1-0` as a dependency; on older distros the app cannot start. For PDF backgrounds and MOBI/AZW imports also install `poppler-utils` and (for MOBI/AZW) Calibre.
+
 </details>
 
 <details>

--- a/frontend-tests/shared/linux-native-artifact-inspection.test.js
+++ b/frontend-tests/shared/linux-native-artifact-inspection.test.js
@@ -10,7 +10,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
-import { debianVersionForRelease, inspectLinuxTree } from "../../scripts/inspect-artifact.mjs";
+import { DEB_REQUIRED_DEPENDS, debianVersionForRelease, inspectLinuxTree } from "../../scripts/inspect-artifact.mjs";
 
 const linuxConfig = JSON.parse(
   readFileSync(new URL("../../src-tauri/tauri.linux-bundle.conf.json", import.meta.url), "utf8"),
@@ -132,6 +132,33 @@ describe("Linux native artifact inspection", () => {
     assert.match(buildScript, /word-hunter_\$\{release_version\}_amd64\.deb/);
     assert.equal(debianVersionForRelease("1.0.9-rc.7"), "1.0.9~rc.7");
     assert.equal(debianVersionForRelease("1.0.9"), "1.0.9");
+  });
+
+  it("keeps the DEB dependency contract between the bundle config and artifact inspection", () => {
+    const configDepends = linuxConfig.bundle.linux.deb.depends.map((entry) =>
+      entry.replace(/\s*\([^)]*\)\s*$/, ""),
+    );
+    // Anything the DEB config declares must actually be enforced by inspect-artifact.mjs.
+    for (const dependency of configDepends) {
+      assert.ok(
+        DEB_REQUIRED_DEPENDS.includes(dependency),
+        `inspect-artifact.mjs does not validate configured DEB dependency: ${dependency}`,
+      );
+    }
+    // libgtk-3-0 is added implicitly by the Tauri bundler (not listed in the config);
+    // every other inspected dependency must be declared in the config.
+    for (const dependency of DEB_REQUIRED_DEPENDS) {
+      if (dependency === "libgtk-3-0") continue;
+      assert.ok(
+        configDepends.includes(dependency),
+        `DEB dependency inspected by inspect-artifact.mjs but not declared in tauri.linux-bundle.conf.json: ${dependency}`,
+      );
+    }
+    // Regression guard (#134): libxdo3 has zero code usage and was dropped from the DEB.
+    assert.ok(
+      !DEB_REQUIRED_DEPENDS.includes("libxdo3"),
+      "libxdo3 is dead; it must not be required in the DEB",
+    );
   });
 
   it("accepts a complete x86_64 tree and rejects architecture drift", () => {

--- a/scripts/inspect-artifact.mjs
+++ b/scripts/inspect-artifact.mjs
@@ -531,6 +531,15 @@ export function debianVersionForRelease(version) {
   return version.replace(/-rc\.(\d+)$/, "~rc.$1");
 }
 
+export const DEB_REQUIRED_DEPENDS = [
+  "libc6",
+  "libgtk-3-0",
+  "libwebkit2gtk-4.1-0",
+  "poppler-utils",
+  "gstreamer1.0-plugins-base",
+  "gstreamer1.0-plugins-good",
+];
+
 export function inspectLinuxDeb(path) {
   const packageName = run("dpkg-deb", ["--field", path, "Package"]).trim();
   if (packageName !== "word-hunter") fail(`${path} has Debian package name ${packageName || "unknown"}; expected word-hunter`);
@@ -546,14 +555,7 @@ export function inspectLinuxDeb(path) {
     fail(`${path} has invalid Debian Maintainer metadata: ${maintainer || "missing"}`);
   }
   const dependencies = run("dpkg-deb", ["--field", path, "Depends"]).trim();
-  for (const dependency of [
-    "libc6",
-    "libgtk-3-0",
-    "libwebkit2gtk-4.1-0",
-    "libxdo3",
-    "gstreamer1.0-plugins-base",
-    "gstreamer1.0-plugins-good",
-  ]) {
+  for (const dependency of DEB_REQUIRED_DEPENDS) {
     const pattern = new RegExp(`(?:^|,\\s*)${dependency.replaceAll(".", "\\.")}(?:\\s*\\([^)]*\\))?(?:,|$)`);
     if (!pattern.test(dependencies)) fail(`${path} is missing Debian dependency: ${dependency}`);
   }

--- a/src-tauri/tauri.linux-bundle.conf.json
+++ b/src-tauri/tauri.linux-bundle.conf.json
@@ -29,7 +29,8 @@
       "deb": {
         "depends": [
           "libc6 (>= 2.35)",
-          "libxdo3",
+          "libwebkit2gtk-4.1-0",
+          "poppler-utils",
           "gstreamer1.0-plugins-base",
           "gstreamer1.0-plugins-good"
         ],


### PR DESCRIPTION
Closes #134

**Audit verdict:** CONFIRMED (wave-7: libxdo3 unused; libwebkit2gtk-4.1-0 + poppler-utils missing; floor undocumented).

**Fix:** depends = libc6, libwebkit2gtk-4.1-0, poppler-utils, gstreamer plugins; README requirement note.

**Verification:** JSON parses; no code change.