### PR TITLE
Fix #29: clippy batch — 30 warnings down to 0 (ours)

### DIFF
--- a/src-tauri/src/ai_explainer.rs
+++ b/src-tauri/src/ai_explainer.rs
@@ -91,12 +91,13 @@ fn build_user_content(
             rect.get("y0").and_then(Value::as_f64),
             rect.get("x1").and_then(Value::as_f64),
             rect.get("y1").and_then(Value::as_f64),
-        ) {
-            prompt.push_str(&format!(
-                "\nThe word is highlighted in the attached page image between \
+        )
+    {
+        prompt.push_str(&format!(
+            "\nThe word is highlighted in the attached page image between \
                  normalized coordinates ({x0:.3}, {y0:.3}) and ({x1:.3}, {y1:.3})."
-            ));
-        }
+        ));
+    }
 
     let Some(image) = image else {
         return json!(prompt);

--- a/src-tauri/src/ai_explainer.rs
+++ b/src-tauri/src/ai_explainer.rs
@@ -85,8 +85,8 @@ fn build_user_content(
          it is, any nuance or idiom it carries here, and give one short example \
          sentence of your own. Stay focused and learner-friendly."
     );
-    if let Some(rect) = rect {
-        if let (Some(x0), Some(y0), Some(x1), Some(y1)) = (
+    if let Some(rect) = rect
+        && let (Some(x0), Some(y0), Some(x1), Some(y1)) = (
             rect.get("x0").and_then(Value::as_f64),
             rect.get("y0").and_then(Value::as_f64),
             rect.get("x1").and_then(Value::as_f64),
@@ -97,7 +97,6 @@ fn build_user_content(
                  normalized coordinates ({x0:.3}, {y0:.3}) and ({x1:.3}, {y1:.3})."
             ));
         }
-    }
 
     let Some(image) = image else {
         return json!(prompt);

--- a/src-tauri/src/ebook/text.rs
+++ b/src-tauri/src/ebook/text.rs
@@ -50,6 +50,24 @@ pub(crate) fn decode_epub_text(data: &[u8]) -> String {
     data.iter().map(|byte| char::from(*byte)).collect()
 }
 
+pub(crate) fn clean_imported_ebook_text(text: &str) -> String {
+    let text = text.replace("\r\n", "\n").replace('\r', "\n");
+    let text = TRAILING_SPACE.replace_all(&text, "\n");
+    MULTI_NEWLINE.replace_all(&text, "\n\n").trim().to_string()
+}
+
+pub(crate) fn strip_xhtml_to_text(markup: &str) -> String {
+    let text = XHTML_SKIP_TAGS.replace_all(markup, "");
+    let text = XHTML_BLOCK_TAGS.replace_all(&text, "\u{E000}");
+    let text = XHTML_TAGS.replace_all(&text, "");
+    let text = html_escape::decode_html_entities(&text);
+    let text = XHTML_WHITESPACE.replace_all(text.as_ref(), " ");
+    XHTML_BOUNDARIES
+        .replace_all(text.as_ref(), "\n")
+        .trim()
+        .to_string()
+}
+
 #[cfg(test)]
 mod tests {
     use super::decode_epub_text;
@@ -75,22 +93,4 @@ mod tests {
 
         assert!(decode_epub_text(&bytes).contains("café"));
     }
-}
-
-pub(crate) fn clean_imported_ebook_text(text: &str) -> String {
-    let text = text.replace("\r\n", "\n").replace('\r', "\n");
-    let text = TRAILING_SPACE.replace_all(&text, "\n");
-    MULTI_NEWLINE.replace_all(&text, "\n\n").trim().to_string()
-}
-
-pub(crate) fn strip_xhtml_to_text(markup: &str) -> String {
-    let text = XHTML_SKIP_TAGS.replace_all(markup, "");
-    let text = XHTML_BLOCK_TAGS.replace_all(&text, "\u{E000}");
-    let text = XHTML_TAGS.replace_all(&text, "");
-    let text = html_escape::decode_html_entities(&text);
-    let text = XHTML_WHITESPACE.replace_all(text.as_ref(), " ");
-    XHTML_BOUNDARIES
-        .replace_all(text.as_ref(), "\n")
-        .trim()
-        .to_string()
 }

--- a/src-tauri/src/pdf_ocr/mod.rs
+++ b/src-tauri/src/pdf_ocr/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(test)]
 use base64::Engine;
 use serde_json::{Value, json};
 use std::{
@@ -63,17 +64,6 @@ impl Drop for FailedImportAssetCleanup<'_> {
             );
         }
     }
-}
-
-pub fn import(
-    payload: Value,
-    store: &Store,
-    app_handle: &AppHandle,
-    jobs: &Mutex<OcrJobState>,
-) -> Result<Value, String> {
-    let data_url = payload.get("data").and_then(Value::as_str).unwrap_or("");
-    let data = decode_payload(data_url)?;
-    import_decoded(payload, data, store, app_handle, jobs)
 }
 
 pub fn import_bytes(
@@ -723,7 +713,8 @@ pub fn image_ocr_available(app_handle: &AppHandle) -> bool {
 mod tests {
     use std::sync::Mutex;
 
-    use base64::Engine;
+    #[cfg(test)]
+use base64::Engine;
     use serde_json::json;
 
     use crate::server::{ActiveOcrJob, OcrJobState};
@@ -947,10 +938,12 @@ mod tests {
     }
 }
 
+#[cfg(test)]
 fn decode_payload(data_url: &str) -> Result<Vec<u8>, String> {
     decode_payload_with_limit(data_url, MAX_PDF_BYTES)
 }
 
+#[cfg(test)]
 fn decode_payload_with_limit(data_url: &str, max_pdf_bytes: usize) -> Result<Vec<u8>, String> {
     let encoded = data_url
         .split_once(',')

--- a/src-tauri/src/pdf_ocr/mod.rs
+++ b/src-tauri/src/pdf_ocr/mod.rs
@@ -714,7 +714,7 @@ mod tests {
     use std::sync::Mutex;
 
     #[cfg(test)]
-use base64::Engine;
+    use base64::Engine;
     use serde_json::json;
 
     use crate::server::{ActiveOcrJob, OcrJobState};

--- a/src-tauri/src/pdf_text_layer.rs
+++ b/src-tauri/src/pdf_text_layer.rs
@@ -38,7 +38,7 @@ fn extract_plain_text_pages(
         let mut text = String::new();
         {
             let mut output = PlainTextOutput::new(&mut text);
-            pdf_extract::output_doc_page(&document, &mut output, *page_num)
+            pdf_extract::output_doc_page(document, &mut output, *page_num)
                 .map_err(|error| format!("Could not read PDF page {page_num}: {error}"))?;
         }
         plain_text_by_page.push(text);

--- a/src-tauri/src/platform/web_app.rs
+++ b/src-tauri/src/platform/web_app.rs
@@ -264,6 +264,17 @@ fn boxed_string(err: String) -> Box<dyn std::error::Error> {
     Box::new(std::io::Error::other(err))
 }
 
+fn show_startup_error(message: &str) {
+    #[cfg(not(target_os = "android"))]
+    let _ = rfd::MessageDialog::new()
+        .set_title("Word Hunter could not start")
+        .set_description(message)
+        .set_level(rfd::MessageLevel::Error)
+        .show();
+    #[cfg(target_os = "android")]
+    let _ = message;
+}
+
 #[cfg(test)]
 mod exit_coordinator_tests {
     use std::{
@@ -313,15 +324,4 @@ mod exit_coordinator_tests {
         handle.join().unwrap();
         assert_eq!(calls.load(Ordering::SeqCst), 0);
     }
-}
-
-fn show_startup_error(message: &str) {
-    #[cfg(not(target_os = "android"))]
-    let _ = rfd::MessageDialog::new()
-        .set_title("Word Hunter could not start")
-        .set_description(message)
-        .set_level(rfd::MessageLevel::Error)
-        .show();
-    #[cfg(target_os = "android")]
-    let _ = message;
 }

--- a/src-tauri/src/popup.rs
+++ b/src-tauri/src/popup.rs
@@ -73,10 +73,7 @@ pub fn serve_open_dict(
         // webview: file:/custom-protocol URLs must never be handed
         // out (audit #93). The internal popup legitimately shows
         // third-party https pages (Youglish), so no host restriction.
-        let target = match validated_open_target(&target) {
-            Ok(ok) => ok,
-            Err(err) => return Err(err),
-        };
+        let target = validated_open_target(&target)?;
         let mode = params.get("mode").map(String::as_str).unwrap_or("external");
         let title = params
             .get("title")

--- a/src-tauri/src/router.rs
+++ b/src-tauri/src/router.rs
@@ -287,7 +287,7 @@ pub fn handle_request(request: Request, state: Arc<ServerState>) -> Result<(), S
             update::check(proxy::USER_AGENT, crate::APP_VERSION),
         ),
         (Method::Get, "/__book/text") => {
-            let params = response::parse_query(&query);
+            let params = response::parse_query(query);
             let id = params.get("id").cloned().unwrap_or_default();
             match state.store.get_text_content(&id) {
                 Ok(text) => response::json_response(request, json!({ "text": text })),
@@ -295,16 +295,16 @@ pub fn handle_request(request: Request, state: Arc<ServerState>) -> Result<(), S
             }
         }
         (Method::Get, "/__book/pdf_pages") => {
-            let params = response::parse_query(&query);
+            let params = response::parse_query(query);
             let id = params.get("id").cloned().unwrap_or_default();
             match state.store.get_pdf_ocr_pages(&id) {
                 Ok(pages) => response::json_response(request, json!({ "pages": pages })),
                 Err(error) => response::error_response(request, 404, &error),
             }
         }
-        (Method::Get, "/__media") => handlers::serve_media(request, &state, &query),
+        (Method::Get, "/__media") => handlers::serve_media(request, &state, query),
         (Method::Get, "/__open_dict") => {
-            popup::serve_open_dict(request, &state.base_url, &state.app_handle, &query)
+            popup::serve_open_dict(request, &state.base_url, &state.app_handle, query)
         }
         (Method::Get, "/__open_external") => {
             let url = response::parse_query(query)
@@ -327,16 +327,16 @@ pub fn handle_request(request: Request, state: Arc<ServerState>) -> Result<(), S
             Ok(payload) => response::json_response(request, payload),
             Err(_) => response::error_response(request, 500, "offline package listing failed"),
         },
-        (Method::Get, "/__argos/translate") => match offline_translator::translate(&query) {
+        (Method::Get, "/__argos/translate") => match offline_translator::translate(query) {
             Ok(payload) => response::json_response(request, payload),
             Err(err) if err.starts_with("invalid request:") => {
                 response::error_response(request, 400, &err)
             }
             Err(_) => response::error_response(request, 500, "offline translation failed"),
         },
-        (Method::Get, "/__argos/ui") => handlers::serve_offline_translator_ui(request, &query),
-        (Method::Get, "/__tts") => handlers::serve_edge_tts(request, &query),
-        (Method::Get, _) => handlers::serve_static(request, &path),
+        (Method::Get, "/__argos/ui") => handlers::serve_offline_translator_ui(request, query),
+        (Method::Get, "/__tts") => handlers::serve_edge_tts(request, query),
+        (Method::Get, _) => handlers::serve_static(request, path),
         (Method::Post, "/__log_error") => {
             let body = match response::read_body_limited(&mut request, MAX_LOG_BODY) {
                 Ok(body) => body,
@@ -504,7 +504,7 @@ pub fn handle_request(request: Request, state: Arc<ServerState>) -> Result<(), S
                     }
                     Err(std::sync::TryLockError::Poisoned(error)) => error.into_inner(),
                 };
-                let params = response::parse_query(&query);
+                let params = response::parse_query(query);
                 let job_id = params.get("job_id").cloned().unwrap_or_default();
                 let _job_guard = match ActiveOcrJob::begin(&state.ocr_jobs, &job_id) {
                     Ok(guard) => guard,
@@ -548,7 +548,7 @@ pub fn handle_request(request: Request, state: Arc<ServerState>) -> Result<(), S
                     }
                     Err(std::sync::TryLockError::Poisoned(error)) => error.into_inner(),
                 };
-                let params = response::parse_query(&query);
+                let params = response::parse_query(query);
                 let job_id = params.get("job_id").cloned().unwrap_or_default();
                 let _job_guard = match ActiveOcrJob::begin(&state.ocr_jobs, &job_id) {
                     Ok(guard) => guard,

--- a/src-tauri/src/store/record_files.rs
+++ b/src-tauri/src/store/record_files.rs
@@ -40,6 +40,9 @@ pub(crate) type Fingerprints = BTreeMap<String, RecordFingerprint>;
 
 pub(crate) struct MergeResult {
     pub records: BTreeMap<String, SyncRecord>,
+    // Retained for merge diagnostics and regression assertions; production
+    // callers currently persist only the resolved record set.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub conflicts: Vec<Value>,
 }
 

--- a/src-tauri/src/store/snapshot.rs
+++ b/src-tauri/src/store/snapshot.rs
@@ -239,7 +239,7 @@ impl Store {
         )?;
 
         self.commit_bulk_save_with_context(&payload, &base, saved_at)?;
-        remove_if_exists(journal);
+        remove_if_exists(journal)?;
         self.invalidate_records_cache();
         Ok(())
     }

--- a/src-tauri/src/store/snapshot.rs
+++ b/src-tauri/src/store/snapshot.rs
@@ -56,7 +56,7 @@ impl Store {
                 .map_err(|e| format!("could not read interrupted save journal: {e}"))?;
             let journal_value: Value = match serde_json::from_slice(&payload) {
                 Ok(value) => value,
-                Err(error) => {
+                Err(_error) => {
                     quarantine_journal(path)?;
                     continue;
                 }
@@ -69,7 +69,7 @@ impl Store {
             let (payload, base, saved_at) = match decode_save_journal(&journal_value, current_base)
             {
                 Ok(journal) => journal,
-                Err(error) => {
+                Err(_error) => {
                     quarantine_journal(path)?;
                     continue;
                 }
@@ -727,7 +727,7 @@ mod tests {
         );
     }
 
-    fn delta_payload(word: &str, full_keys: &[&str], vocab: Value) -> Value {
+    fn delta_payload(_word: &str, full_keys: &[&str], vocab: Value) -> Value {
         json!({
             "schemaVersion": SNAPSHOT_SCHEMA_VERSION,
             "delta": true,

--- a/src-tauri/src/tests/http_boundary/tests.rs
+++ b/src-tauri/src/tests/http_boundary/tests.rs
@@ -27,14 +27,14 @@ fn handle_boundary_request(request: Request, base_url: &str) -> Result<(), Strin
     if method_not_allowed(request.method(), path) {
         return response::error_response(request, 405, "method not allowed");
     }
-    let Some(request) = authenticate_request(request, &path, TOKEN)? else {
+    let Some(request) = authenticate_request(request, path, TOKEN)? else {
         return Ok(());
     };
-    let Some(request) = dispatch_state_independent_request(request, &path, &query)? else {
+    let Some(request) = dispatch_state_independent_request(request, path, query)? else {
         return Ok(());
     };
     if request.method() == &Method::Get {
-        handlers::serve_static(request, &path)
+        handlers::serve_static(request, path)
     } else {
         response::error_response(request, 404, "not found")
     }

--- a/src-tauri/src/tokenizer.rs
+++ b/src-tauri/src/tokenizer.rs
@@ -180,8 +180,7 @@ pub fn vocabulary_word_key(value: &str, lang: &str) -> String {
     } else {
         compatible
     }
-    .replace('‘', "'")
-    .replace('’', "'");
+    .replace(['‘', '’'], "'");
     let prefixes: &[(&str, &str)] = match language.as_ref() {
         "fr" => &[("l'", "l’")],
         "it" => &[("un'", "un’"), ("l'", "l’")],


### PR DESCRIPTION
Closes #29

Also resolves the clippy/dead-code subset of #120; the broader #120 remains open.

## What changed
- applies the current-base needless-borrow, collapsible-if, tokenizer, unused-variable, test-layout, and dead PDF OCR cleanup
- preserves the secure URL opener and current HTTP boundary behavior while resolving stale rebase conflicts
- clears integration-base warnings in PDF text extraction, popup validation, save-journal cleanup, and merge diagnostics

## Verification
- Rust library suite: 288/288
- `cargo clippy --all-targets -- -D warnings` (only vendor build-script informational output)
- `cargo fmt --check`
- `git diff --check`
