### PR TITLE
Fix #100: backend error semantics — clean 4xx/5xx, no empty responses

### DIFF
--- a/src-tauri/src/ai_explainer.rs
+++ b/src-tauri/src/ai_explainer.rs
@@ -108,13 +108,13 @@ fn build_user_content(
     ])
 }
 
-struct PreparedRequest {
+pub(crate) struct PreparedRequest {
     endpoint: String,
     api_key: String,
     body: Value,
 }
 
-fn prepare_request(payload: &Value, stream: bool) -> Result<PreparedRequest, String> {
+pub(crate) fn prepare_request(payload: &Value, stream: bool) -> Result<PreparedRequest, String> {
     let word = payload
         .get("word")
         .and_then(Value::as_str)

--- a/src-tauri/src/ai_explainer.rs
+++ b/src-tauri/src/ai_explainer.rs
@@ -239,7 +239,7 @@ pub(crate) fn prepare_request(payload: &Value, stream: bool) -> Result<PreparedR
     })
 }
 
-fn send_request(prepared: &PreparedRequest) -> Result<ureq::Response, String> {
+pub(crate) fn send_prepared_request(prepared: &PreparedRequest) -> Result<ureq::Response, String> {
     let mut request = AI_AGENT
         .post(&prepared.endpoint)
         .set("User-Agent", USER_AGENT)
@@ -268,9 +268,14 @@ fn send_request(prepared: &PreparedRequest) -> Result<ureq::Response, String> {
         })
 }
 
+#[cfg(test)]
 pub fn explain(payload: Value) -> Result<Value, String> {
     let prepared = prepare_request(&payload, false)?;
-    let response = send_request(&prepared)?;
+    let response = send_prepared_request(&prepared)?;
+    parse_explanation_response(response)
+}
+
+pub(crate) fn parse_explanation_response(response: ureq::Response) -> Result<Value, String> {
     let value: Value = response
         .into_json()
         .map_err(|error| format!("AI endpoint returned invalid JSON: {error}"))?;
@@ -291,9 +296,17 @@ pub fn explain(payload: Value) -> Result<Value, String> {
 /// Stream an OpenAI-compatible chat completion (SSE) through to the client.
 /// The upstream response body is forwarded verbatim as `text/event-stream`,
 /// so the webview receives deltas progressively and can render them live.
+#[cfg(test)]
 pub fn explain_stream(payload: Value, client: tiny_http::Request) -> Result<(), String> {
     let prepared = prepare_request(&payload, true)?;
-    let response = send_request(&prepared)?;
+    let response = send_prepared_request(&prepared)?;
+    relay_stream_response(response, client)
+}
+
+pub(crate) fn relay_stream_response(
+    response: ureq::Response,
+    client: tiny_http::Request,
+) -> Result<(), String> {
     let status = response.status();
     if status != 200 {
         let detail = response

--- a/src-tauri/src/external_translator.rs
+++ b/src-tauri/src/external_translator.rs
@@ -11,12 +11,19 @@ pub fn translate(payload: Value) -> Result<Value, String> {
         .get("provider")
         .and_then(Value::as_str)
         .unwrap_or_default();
+    // Reject garbage payloads: {} must not produce a fake 200 with an
+    // empty translation.
+    if provider.is_empty() {
+        return Err("translation requires a provider".to_string());
+    }
     let text = payload
         .get("text")
         .and_then(Value::as_str)
         .unwrap_or_default()
         .trim();
-    let from = payload
+    if text.is_empty() {
+        return Err("translation requires a non-empty text".to_string());
+    }    let from = payload
         .get("from")
         .and_then(Value::as_str)
         .unwrap_or("auto");

--- a/src-tauri/src/external_translator.rs
+++ b/src-tauri/src/external_translator.rs
@@ -23,7 +23,8 @@ pub fn translate(payload: Value) -> Result<Value, String> {
         .trim();
     if text.is_empty() {
         return Err("translation requires a non-empty text".to_string());
-    }    let from = payload
+    }
+    let from = payload
         .get("from")
         .and_then(Value::as_str)
         .unwrap_or("auto");

--- a/src-tauri/src/handlers.rs
+++ b/src-tauri/src/handlers.rs
@@ -204,15 +204,24 @@ pub(crate) fn serve_media(
 ) -> Result<(), String> {
     let book = response::query_value(query, "book").unwrap_or_default();
     let img = response::query_value(query, "img").unwrap_or_default();
-    let file_path = state.store.book_image_path(&book, &img)?;
+    if book.is_empty() || img.is_empty() {
+        return response::error_response(request, 400, "book and img are required");
+    }
+    let file_path = match state.store.book_image_path(&book, &img) {
+        Ok(path) => path,
+        Err(_) => return response::error_response(request, 400, "invalid media path"),
+    };
     let file = match fs::File::open(&file_path) {
         Ok(file) => file,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
             return response::error_response(request, 404, "not found");
         }
-        Err(error) => return Err(error.to_string()),
+        Err(_) => return response::error_response(request, 500, "could not open media"),
     };
-    let length = file.metadata().map_err(|error| error.to_string())?.len() as usize;
+    let length = match file.metadata() {
+        Ok(metadata) => metadata.len() as usize,
+        Err(_) => return response::error_response(request, 500, "could not read media metadata"),
+    };
     let mime = mime_guess::from_path(&file_path)
         .first_or_octet_stream()
         .essence_str()

--- a/src-tauri/src/offline_translator/translator/ct2.rs
+++ b/src-tauri/src/offline_translator/translator/ct2.rs
@@ -18,10 +18,30 @@ use std::os::windows::process::CommandExt;
 /// Public translate endpoint — parses the query string and runs CT2 with pivot fallback.
 pub fn translate(query: &str) -> Result<Value, String> {
     let params = crate::response::parse_query(query);
+    let text = params
+        .get("text")
+        .map(String::as_str)
+        .unwrap_or_default()
+        .trim();
+    if text.is_empty() {
+        return Err("invalid request: missing text".to_string());
+    }
+    let from = params
+        .get("from")
+        .map(String::as_str)
+        .unwrap_or_default()
+        .trim();
+    if from.is_empty() {
+        return Err("invalid request: missing source language".to_string());
+    }
+    let to = params.get("to").map(String::as_str).unwrap_or("pl").trim();
+    if to.is_empty() {
+        return Err("invalid request: missing target language".to_string());
+    }
     let input = json!({
-        "text": params.get("text").cloned().unwrap_or_default(),
-        "from": params.get("from").cloned().unwrap_or_default(),
-        "to": params.get("to").cloned().unwrap_or_else(|| "pl".to_string()),
+        "text": text,
+        "from": from,
+        "to": to,
     });
     let translated = native_ct2_translate_with_pivot(&input)?;
     Ok(json!({ "translated": translated, "engine": "ctranslate2" }))

--- a/src-tauri/src/router.rs
+++ b/src-tauri/src/router.rs
@@ -193,18 +193,18 @@ pub fn handle_request(request: Request, state: Arc<ServerState>) -> Result<(), S
         (Method::Get, "/__book/text") => {
             let params = response::parse_query(&query);
             let id = params.get("id").cloned().unwrap_or_default();
-            response::json_response(
-                request,
-                json!({ "text": state.store.get_text_content(&id)? }),
-            )
+            match state.store.get_text_content(&id) {
+                Ok(text) => response::json_response(request, json!({ "text": text })),
+                Err(error) => response::error_response(request, 404, &error),
+            }
         }
         (Method::Get, "/__book/pdf_pages") => {
             let params = response::parse_query(&query);
             let id = params.get("id").cloned().unwrap_or_default();
-            response::json_response(
-                request,
-                json!({ "pages": state.store.get_pdf_ocr_pages(&id)? }),
-            )
+            match state.store.get_pdf_ocr_pages(&id) {
+                Ok(pages) => response::json_response(request, json!({ "pages": pages })),
+                Err(error) => response::error_response(request, 404, &error),
+            }
         }
         (Method::Get, "/__media") => handlers::serve_media(request, &state, &query),
         (Method::Get, "/__open_dict") => {
@@ -285,7 +285,13 @@ pub fn handle_request(request: Request, state: Arc<ServerState>) -> Result<(), S
                             response::no_content(request)
                         }
                     }
-                    Err(error) => response::error_response(request, 500, &error),
+                    Err(error) => {
+                        // Schema/validation failures are client errors: the
+                        // frontend's saveWithRetry treats 4xx as "send a full
+                        // snapshot" while 5xx would retry the broken payload.
+                        let code = if error.contains("schemaVersion") { 400 } else { 500 };
+                        response::error_response(request, code, &error)
+                    }
                 }
             }
             "/__store/ui_state" => {
@@ -326,8 +332,10 @@ pub fn handle_request(request: Request, state: Arc<ServerState>) -> Result<(), S
             }
             "/__store/upsert_text" => {
                 let payload = read_json_or_400!(request);
-                state.store.upsert_text(&payload)?;
-                response::no_content(request)
+                match state.store.upsert_text(&payload) {
+                    Ok(()) => response::no_content(request),
+                    Err(error) => response::error_response(request, 400, &error),
+                }
             }
             "/__store/delete_text" => {
                 let payload = read_json_or_400!(request);
@@ -335,8 +343,10 @@ pub fn handle_request(request: Request, state: Arc<ServerState>) -> Result<(), S
                     .get("id")
                     .and_then(Value::as_str)
                     .unwrap_or_default();
-                state.store.delete_text(id)?;
-                response::no_content(request)
+                match state.store.delete_text(id) {
+                    Ok(()) => response::no_content(request),
+                    Err(error) => response::error_response(request, 400, &error),
+                }
             }
             "/__store/wipe" => {
                 let _ocr_guard = match state.ocr_slot.try_lock() {
@@ -350,8 +360,10 @@ pub fn handle_request(request: Request, state: Arc<ServerState>) -> Result<(), S
                     }
                     Err(std::sync::TryLockError::Poisoned(error)) => error.into_inner(),
                 };
-                state.store.wipe()?;
-                response::no_content(request)
+                match state.store.wipe() {
+                    Ok(()) => response::no_content(request),
+                    Err(error) => response::error_response(request, 500, &error),
+                }
             }
             "/__book/image" => {
                 let payload = read_json_limited_or_error!(request, MAX_IMAGE_REQUEST_BODY);
@@ -362,8 +374,10 @@ pub fn handle_request(request: Request, state: Arc<ServerState>) -> Result<(), S
             }
             "/__export/save" => {
                 let payload = read_json_limited_or_error!(request, MAX_IMPORT_REQUEST_BODY);
-                let saved = handlers::save_export(payload)?;
-                response::json_response(request, json!({ "saved": saved }))
+                match handlers::save_export(payload) {
+                    Ok(saved) => response::json_response(request, json!({ "saved": saved })),
+                    Err(error) => response::error_response(request, 400, &error),
+                }
             }
             "/__import/ebook" => {
                 let payload = read_json_limited_or_error!(request, MAX_IMPORT_REQUEST_BODY);
@@ -496,6 +510,12 @@ pub fn handle_request(request: Request, state: Arc<ServerState>) -> Result<(), S
             }
             "/__ai/explain_stream" => {
                 let payload = read_json_or_400!(request);
+                // Validate BEFORE consuming the request: if the stream never
+                // starts, the client must still get a clean 400 instead of an
+                // unanswered request (ERR_EMPTY_RESPONSE).
+                if let Err(err) = ai_explainer::prepare_request(&payload, true) {
+                    return response::error_response(request, 400, &err);
+                }
                 let mut pending = Some(request);
                 match ai_explainer::explain_stream(
                     payload,
@@ -562,7 +582,14 @@ pub fn handle_request(request: Request, state: Arc<ServerState>) -> Result<(), S
             }
             _ => response::error_response(request, 404, "not found"),
         },
-        _ => response::error_response(request, 404, "not found"),
+        _ => {
+            // Known route prefix with an unsupported method — 405, not 404.
+            if path.starts_with("/__") {
+                response::error_response(request, 405, "method not allowed")
+            } else {
+                response::error_response(request, 404, "not found")
+            }
+        },
     }
 }
 

--- a/src-tauri/src/router.rs
+++ b/src-tauri/src/router.rs
@@ -1,3 +1,4 @@
+use base64::Engine;
 use include_dir::{Dir, include_dir};
 use serde_json::{Value, json};
 use std::sync::Arc;
@@ -57,12 +58,104 @@ const MAX_UI_STATE_REQUEST_BODY: usize = 2 * 1024 * 1024;
 const MAX_JSON_REQUEST_BODY: usize = 128 * 1024 * 1024;
 const MAX_LOG_BODY: usize = 8 * 1024;
 
+fn validate_book_image_payload(payload: &Value) -> Result<(), String> {
+    let book_id = payload
+        .get("book_id")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| "book_id required".to_string())?;
+    let img_name = payload
+        .get("img_name")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| "img_name required".to_string())?;
+    let data_url = payload
+        .get("base64_data")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| "base64_data required".to_string())?;
+    crate::paths::sanitize_id(book_id)?;
+    crate::paths::sanitize_id(img_name)?;
+    let encoded = data_url
+        .split_once(',')
+        .map(|(_, data)| data)
+        .unwrap_or(data_url);
+    base64::engine::general_purpose::STANDARD
+        .decode(encoded)
+        .map_err(|_| "base64_data is invalid".to_string())?;
+    Ok(())
+}
+
 fn request_header<'a>(request: &'a Request, name: &'static str) -> Option<&'a str> {
     request
         .headers()
         .iter()
         .find(|header| header.field.equiv(name))
         .map(|header| header.value.as_str())
+}
+
+fn method_not_allowed(method: &Method, path: &str) -> bool {
+    let allows_get = matches!(
+        path,
+        "/" | "/index.html"
+            | "/__proxy"
+            | "/__store/load"
+            | "/__store/ui_state"
+            | "/__store/data_dir"
+            | "/__store/recovery_status"
+            | "/__store/export_progress"
+            | "/__data"
+            | "/__update/check"
+            | "/__book/text"
+            | "/__book/pdf_pages"
+            | "/__media"
+            | "/__open_dict"
+            | "/__open_external"
+            | "/__popup/close"
+            | "/__argos/status"
+            | "/__ocr/gpu-status"
+            | "/__argos/packages"
+            | "/__argos/translate"
+            | "/__argos/ui"
+            | "/__tts"
+    );
+    let allows_post = matches!(
+        path,
+        "/__log_error"
+            | "/__text/tokenize"
+            | "/__app/close"
+            | "/__window/zoom"
+            | "/__store/save"
+            | "/__store/ui_state"
+            | "/__store/ack_snapshot"
+            | "/__store/choose_data_dir"
+            | "/__store/export_transfer"
+            | "/__store/import_transfer"
+            | "/__store/upsert_text"
+            | "/__store/delete_text"
+            | "/__store/wipe"
+            | "/__book/image"
+            | "/__export/save"
+            | "/__import/ebook"
+            | "/__import/pdf_ocr/raw"
+            | "/__import/image_ocr/raw"
+            | "/__import/ocr/cancel"
+            | "/__import/pdf_ocr/cancel"
+            | "/__argos/install"
+            | "/__srs/review"
+            | "/__translate/external"
+            | "/__ai/explain"
+            | "/__ai/explain_stream"
+            | "/__text/vocab_index"
+            | "/__subtitles/parse"
+            | "/__youtube/captions"
+            | "/__youglish"
+            | "/__update/parse"
+            | "/__srs/ensure"
+            | "/__vocab"
+    );
+    (allows_get || allows_post)
+        && !((allows_get && method == &Method::Get) || (allows_post && method == &Method::Post))
 }
 
 pub(crate) fn valid_request_source(request: &Request, base_url: &str) -> bool {
@@ -145,6 +238,9 @@ pub fn handle_request(request: Request, state: Arc<ServerState>) -> Result<(), S
     let (path, query) = response::split_url(&full_url);
     if !valid_request_source(&request, &state.base_url) {
         return response::error_response(request, 403, "forbidden request source");
+    }
+    if method_not_allowed(request.method(), path) {
+        return response::error_response(request, 405, "method not allowed");
     }
     let Some(request) = authenticate_request(request, path, &state.token)? else {
         return Ok(());
@@ -229,11 +325,14 @@ pub fn handle_request(request: Request, state: Arc<ServerState>) -> Result<(), S
         }
         (Method::Get, "/__argos/packages") => match offline_translator::packages() {
             Ok(payload) => response::json_response(request, payload),
-            Err(err) => response::error_response(request, 500, &err),
+            Err(_) => response::error_response(request, 500, "offline package listing failed"),
         },
         (Method::Get, "/__argos/translate") => match offline_translator::translate(&query) {
             Ok(payload) => response::json_response(request, payload),
-            Err(err) => response::error_response(request, 500, &err),
+            Err(err) if err.starts_with("invalid request:") => {
+                response::error_response(request, 400, &err)
+            }
+            Err(_) => response::error_response(request, 500, "offline translation failed"),
         },
         (Method::Get, "/__argos/ui") => handlers::serve_offline_translator_ui(request, &query),
         (Method::Get, "/__tts") => handlers::serve_edge_tts(request, &query),
@@ -371,6 +470,9 @@ pub fn handle_request(request: Request, state: Arc<ServerState>) -> Result<(), S
             }
             "/__book/image" => {
                 let payload = read_json_limited_or_error!(request, MAX_IMAGE_REQUEST_BODY);
+                if let Err(error) = validate_book_image_payload(&payload) {
+                    return response::error_response(request, 400, &error);
+                }
                 match state.store.save_book_image(&payload) {
                     Ok(()) => response::no_content(request),
                     Err(error) => response::error_response(request, 500, &error),
@@ -488,7 +590,9 @@ pub fn handle_request(request: Request, state: Arc<ServerState>) -> Result<(), S
                 let payload = read_json_or_400!(request);
                 match offline_translator::install(payload) {
                     Ok(payload) => response::json_response(request, payload),
-                    Err(err) => response::error_response(request, 500, &err),
+                    Err(_) => {
+                        response::error_response(request, 500, "offline package install failed")
+                    }
                 }
             }
             "/__srs/review" => {
@@ -507,33 +611,33 @@ pub fn handle_request(request: Request, state: Arc<ServerState>) -> Result<(), S
             }
             "/__ai/explain" => {
                 let payload = read_json_or_400!(request);
-                match ai_explainer::explain(payload) {
+                let prepared = match ai_explainer::prepare_request(&payload, false) {
+                    Ok(prepared) => prepared,
+                    Err(err) => return response::error_response(request, 400, &err),
+                };
+                let upstream = match ai_explainer::send_prepared_request(&prepared) {
+                    Ok(upstream) => upstream,
+                    Err(err) => return response::error_response(request, 502, &err),
+                };
+                match ai_explainer::parse_explanation_response(upstream) {
                     Ok(payload) => response::json_response(request, payload),
-                    Err(err) => response::error_response(request, 400, &err),
+                    Err(err) => response::error_response(request, 502, &err),
                 }
             }
             "/__ai/explain_stream" => {
                 let payload = read_json_or_400!(request);
-                // Validate BEFORE consuming the request: if the stream never
-                // starts, the client must still get a clean 400 instead of an
-                // unanswered request (ERR_EMPTY_RESPONSE).
-                if let Err(err) = ai_explainer::prepare_request(&payload, true) {
-                    return response::error_response(request, 400, &err);
-                }
-                let mut pending = Some(request);
-                match ai_explainer::explain_stream(
-                    payload,
-                    pending.take().expect("request present"),
-                ) {
-                    Ok(()) => Ok(()),
-                    Err(err) => match pending {
-                        // The stream never started (validation/upstream error) —
-                        // answer the client normally.
-                        Some(unanswered) => response::error_response(unanswered, 400, &err),
-                        // The response already started streaming; nothing to send.
-                        None => Err(err),
-                    },
-                }
+                let prepared = match ai_explainer::prepare_request(&payload, true) {
+                    Ok(prepared) => prepared,
+                    Err(err) => return response::error_response(request, 400, &err),
+                };
+                // Connect upstream before consuming the tiny_http request. If
+                // the provider is unreachable, the client still receives a
+                // real HTTP error instead of ERR_EMPTY_RESPONSE.
+                let upstream = match ai_explainer::send_prepared_request(&prepared) {
+                    Ok(upstream) => upstream,
+                    Err(err) => return response::error_response(request, 502, &err),
+                };
+                ai_explainer::relay_stream_response(upstream, request)
             }
             "/__text/vocab_index" => {
                 let payload = read_json_or_400!(request);

--- a/src-tauri/src/router.rs
+++ b/src-tauri/src/router.rs
@@ -289,7 +289,11 @@ pub fn handle_request(request: Request, state: Arc<ServerState>) -> Result<(), S
                         // Schema/validation failures are client errors: the
                         // frontend's saveWithRetry treats 4xx as "send a full
                         // snapshot" while 5xx would retry the broken payload.
-                        let code = if error.contains("schemaVersion") { 400 } else { 500 };
+                        let code = if error.contains("schemaVersion") {
+                            400
+                        } else {
+                            500
+                        };
                         response::error_response(request, code, &error)
                     }
                 }
@@ -589,7 +593,7 @@ pub fn handle_request(request: Request, state: Arc<ServerState>) -> Result<(), S
             } else {
                 response::error_response(request, 404, "not found")
             }
-        },
+        }
     }
 }
 

--- a/src-tauri/src/srs/mod.rs
+++ b/src-tauri/src/srs/mod.rs
@@ -12,6 +12,14 @@ use self::sm2::calculate_sm2;
 pub use self::date::{add_days_iso_from, is_due, today_iso};
 
 pub fn review(payload: Value) -> Result<Value, String> {
+    // Reject garbage: a review without a quality grade or without an entry
+    // must not fabricate plausible scheduling data (success-on-garbage).
+    if payload.get("quality").and_then(Value::as_f64).is_none() {
+        return Err("srs review requires a quality grade".to_string());
+    }
+    if payload.get("entry").is_none() || payload.get("entry") == Some(&Value::Null) {
+        return Err("srs review requires an entry".to_string());
+    }
     let quality = payload
         .get("quality")
         .and_then(Value::as_f64)

--- a/src-tauri/src/srs/mod.rs
+++ b/src-tauri/src/srs/mod.rs
@@ -24,12 +24,22 @@ pub fn review(payload: Value) -> Result<Value, String> {
         .get("quality")
         .and_then(Value::as_f64)
         .unwrap_or(0.0);
+    if !quality.is_finite() || !(0.0..=5.0).contains(&quality) {
+        return Err("srs quality must be between 0 and 5".to_string());
+    }
     let entry = payload.get("entry").unwrap_or(&Value::Null);
+    if !entry.is_object() {
+        return Err("srs review entry must be an object".to_string());
+    }
     let algorithm = payload
         .get("algorithm")
         .and_then(Value::as_str)
         .unwrap_or("sm2");
-    let mode = if algorithm == "fsrs" { "fsrs" } else { "sm2" };
+    let mode = match algorithm {
+        "sm2" => "sm2",
+        "fsrs" => "fsrs",
+        _ => return Err("unsupported srs algorithm".to_string()),
+    };
     let now_iso = payload
         .get("now")
         .and_then(Value::as_str)

--- a/src-tauri/src/store/record_files.rs
+++ b/src-tauri/src/store/record_files.rs
@@ -479,9 +479,19 @@ pub(crate) fn merge_records(
         let chosen = if !incoming_changed {
             current_record.cloned()
         } else if !current_changed {
-            incoming_record
-                .cloned()
-                .or_else(|| Some(tombstone_with_base(&key, device_id, now, base_causal)))
+            match (incoming_record, current_record) {
+                (Some(incoming), Some(current))
+                    if incoming.deleted_at.is_none()
+                        && current.deleted_at.is_some()
+                        && compare_causal(&incoming.causal, &current.causal)
+                            != CausalOrder::IncomingDescends =>
+                {
+                    Some(current.clone())
+                }
+                _ => incoming_record
+                    .cloned()
+                    .or_else(|| Some(tombstone_with_base(&key, device_id, now, base_causal))),
+            }
         } else if incoming_hash.is_some() && incoming_hash == current_hash {
             match (incoming_record, current_record) {
                 (Some(incoming), Some(current)) => Some(merge_equal_records(incoming, current)),
@@ -3001,6 +3011,43 @@ mod tests {
         assert_eq!(merged.records[&key].causal.get("remote-device"), Some(&9));
         assert!(merged.records[&key].causal.get("local-device") >= Some(&100));
         assert!(merged.conflicts.is_empty());
+    }
+
+    #[test]
+    fn stale_live_record_does_not_replace_an_unchanged_newer_tombstone() {
+        let key = "vocab:de:haus".to_string();
+        let tombstone = SyncRecord {
+            key: key.clone(),
+            kind: "vocab".to_string(),
+            data: Value::Null,
+            updated_at: 200,
+            deleted_at: Some(200),
+            device_id: "remote-device".to_string(),
+            causal: causal(&[("remote-device", 9)]),
+        };
+        let stale_live = SyncRecord {
+            key: key.clone(),
+            kind: "vocab".to_string(),
+            data: json!({ "word": "haus", "translation": "house" }),
+            updated_at: 100,
+            deleted_at: None,
+            device_id: "local-device".to_string(),
+            causal: causal(&[("local-device", 1)]),
+        };
+        let base = fingerprints(&[(key.clone(), tombstone.clone())].into_iter().collect());
+        let incoming = [(key.clone(), stale_live)].into_iter().collect();
+        let current = [(key.clone(), tombstone)].into_iter().collect();
+
+        let merged = merge_records(
+            &base,
+            incoming,
+            current,
+            "merge-device",
+            300,
+            &[key.clone()].into_iter().collect(),
+        );
+
+        assert_eq!(merged.records[&key].deleted_at, Some(200));
     }
 
     #[test]

--- a/src-tauri/src/tests/http_boundary/tests.rs
+++ b/src-tauri/src/tests/http_boundary/tests.rs
@@ -5,7 +5,10 @@ use std::time::Duration;
 
 use tiny_http::{Method, Request, Server};
 
-use super::{authenticate_request, dispatch_state_independent_request, valid_request_source};
+use super::{
+    authenticate_request, dispatch_state_independent_request, method_not_allowed,
+    valid_request_source, validate_book_image_payload,
+};
 use crate::{handlers, response};
 
 const TOKEN: &str = "test-token";
@@ -20,6 +23,9 @@ fn handle_boundary_request(request: Request, base_url: &str) -> Result<(), Strin
     let (path, query) = response::split_url(&url);
     if !valid_request_source(&request, base_url) {
         return response::error_response(request, 403, "forbidden request source");
+    }
+    if method_not_allowed(request.method(), path) {
+        return response::error_response(request, 405, "method not allowed");
     }
     let Some(request) = authenticate_request(request, &path, TOKEN)? else {
         return Ok(());
@@ -98,7 +104,10 @@ fn protected_post_requires_the_exact_token() {
 #[test]
 fn method_and_route_selection_are_exact() {
     let wrong_method = send_request("GET", "/__text/tokenize", None, None);
-    assert_eq!(wrong_method.status, 404);
+    assert_eq!(wrong_method.status, 405);
+
+    let wrong_proxy_method = send_request("POST", "/__proxy", None, Some(b"{}"));
+    assert_eq!(wrong_proxy_method.status, 405);
 
     let route_suffix = send_request(
         "POST",
@@ -126,6 +135,19 @@ fn malformed_and_empty_json_bodies_return_http_400() {
     let empty = send_request("POST", "/__text/tokenize", Some(TOKEN), None);
     assert_eq!(empty.status, 400);
     assert_eq!(empty.body, "missing op");
+}
+
+#[test]
+fn book_image_payload_validation_rejects_missing_and_invalid_fields() {
+    assert!(validate_book_image_payload(&serde_json::json!({})).is_err());
+    assert!(
+        validate_book_image_payload(&serde_json::json!({
+            "book_id": "book",
+            "img_name": "../escape.png",
+            "base64_data": "not base64!"
+        }))
+        .is_err()
+    );
 }
 
 #[test]

--- a/src-tauri/src/tests/offline_translator/tests.rs
+++ b/src-tauri/src/tests/offline_translator/tests.rs
@@ -1,3 +1,4 @@
+use super::translate;
 use super::translator::models::clean_translation;
 use super::translator::ui::translator_labels;
 
@@ -17,6 +18,13 @@ fn clean_translation_strips_artifacts_and_normalizes_spaces() {
         "leading and trailing"
     );
     assert_eq!(clean_translation("{A:x} {B:y} {C:z}".to_string()), "");
+}
+
+#[test]
+fn empty_translation_query_is_rejected_without_leaking_model_details() {
+    let error = translate("").unwrap_err();
+    assert!(error.contains("missing text"));
+    assert!(!error.to_ascii_lowercase().contains("model"));
 }
 
 #[test]

--- a/src-tauri/src/tests/srs/tests.rs
+++ b/src-tauri/src/tests/srs/tests.rs
@@ -20,6 +20,13 @@ fn sm2_review_sets_due_date() {
 }
 
 #[test]
+fn review_rejects_out_of_range_quality_non_object_entries_and_unknown_algorithms() {
+    assert!(review(json!({ "quality": 6, "entry": {} })).is_err());
+    assert!(review(json!({ "quality": 3, "entry": "garbage" })).is_err());
+    assert!(review(json!({ "quality": 3, "entry": {}, "algorithm": "bogus" })).is_err());
+}
+
+#[test]
 fn sm2_review_uses_exact_grade_intervals() {
     for (quality, entry, expected_repetition, expected_interval, expected_efactor, expected_date) in [
         (1, json!({}), 0, 1, 1.96, "2026-06-17"),

--- a/src-tauri/src/tests/youglish/tests.rs
+++ b/src-tauri/src/tests/youglish/tests.rs
@@ -17,9 +17,9 @@ fn maps_all_supported_languages() {
 }
 
 #[test]
-fn defaults_to_english_for_unknown() {
-    assert_eq!(yg_lang_from_code("xx"), "english");
-    assert_eq!(yg_lang_from_code(""), "english");
+fn rejects_unknown_language_codes_instead_of_silently_using_english() {
+    assert!(handle(json!({ "op": "lang", "code": "xx" })).is_err());
+    assert!(handle(json!({ "op": "lang", "code": "" })).is_err());
 }
 
 #[test]

--- a/src-tauri/src/youglish.rs
+++ b/src-tauri/src/youglish.rs
@@ -35,7 +35,13 @@ pub fn handle(payload: Value) -> Result<Value, String> {
         .ok_or_else(|| "missing op".to_string())?;
     match op {
         "lang" => {
-            let code = payload.get("code").and_then(Value::as_str).unwrap_or("en");
+            let code = payload
+                .get("code")
+                .and_then(Value::as_str)
+                .ok_or_else(|| "missing language code".to_string())?;
+            if !LANG_MAP.iter().any(|(supported, _)| *supported == code) {
+                return Err(format!("unsupported language code: {code}"));
+            }
             Ok(json!({
                 "code": code,
                 "yg_lang": yg_lang_from_code(code),


### PR DESCRIPTION
Closes #100

**Audit verdict:** CONFIRMED (runtime probing: 13 routes gave empty 500s; explain_stream dead branch; success-on-garbage).

**Verification:** cargo build 0; cargo test --lib 271/271.