### PR TITLE
Fix #135: Polish default locale fallback

### DIFF
--- a/frontend-tests/shared/initial-locale.test.js
+++ b/frontend-tests/shared/initial-locale.test.js
@@ -1,0 +1,22 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+const { initialLocale } = await import("../../dist/web/js/i18n.js");
+
+describe("initialLocale (#135: Polish default locale)", () => {
+  it("prefers the saved locale preference over the system locale", () => {
+    assert.equal(initialLocale("de", "pl-PL"), "de");
+    assert.equal(initialLocale("pl", "en-US"), "pl");
+  });
+
+  it("seeds the first-launch locale from navigator.language", () => {
+    assert.equal(initialLocale(undefined, "de-DE"), "de");
+    assert.equal(initialLocale(undefined, "en-US"), "en");
+    assert.equal(initialLocale("", "fr-FR"), "fr");
+  });
+
+  it("falls back to Polish when the system locale is unknown or empty", () => {
+    assert.equal(initialLocale(undefined, ""), "pl");
+    assert.equal(initialLocale(undefined, undefined), "pl");
+  });
+});

--- a/frontend-tests/shared/persistence-lifecycle.test.js
+++ b/frontend-tests/shared/persistence-lifecycle.test.js
@@ -123,7 +123,7 @@ async function loadAppHarness({
       hydrateCurrentReaderText
     },
     "./js/render.js": { render: () => calls.push("render"), ensureCurrentText: noOp },
-    "./js/i18n.js": { loadLocale, applyTranslations: noOp, t: (key) => key, getLocale: () => "en" },
+    "./js/i18n.js": { loadLocale, applyTranslations: noOp, t: (key) => key, getLocale: () => "en", initialLocale: () => "en" },
     "./js/state.js": {
       applyBridgeSnapshotToState: noOp,
       flushFrontendStateBuffers() { calls.push("flush-buffers"); },

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -5,7 +5,7 @@ import { bindEvents } from "./js/events.js";
 import { applyPreferences, syncSettingsControls } from "./js/preferences.js";
 import { hydrateCurrentReaderText, loadBooksCatalog } from "./js/books.js";
 import { render, ensureCurrentText } from "./js/render.js";
-import { loadLocale, applyTranslations, t, getLocale } from "./js/i18n.js";
+import { loadLocale, applyTranslations, t, getLocale, initialLocale } from "./js/i18n.js";
 import { applyBridgeSnapshotToState, flushFrontendStateBuffers, flushUiStateSync, saveState, state } from "./js/state.js";
 import { bindLibraryEvents, renderLibrary } from "./js/views/library.js";
 import { renderReview, renderVocabulary } from "./js/views/vocabulary.js";
@@ -129,7 +129,7 @@ window.addEventListener("wordhunter:state-replaced", () => {
   syncSettingsControls();
   if (document.documentElement.classList.contains("app-booting")) return;
   if (getLocale() !== state.preferences?.locale) {
-    void loadLocale(state.preferences?.locale || "en").then(() => applyTranslations());
+    void loadLocale(initialLocale(state.preferences?.locale, typeof navigator !== "undefined" ? navigator.language : "")).then(() => applyTranslations());
   }
   ensureCurrentText();
   render();
@@ -183,7 +183,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     startBridgeStateLoad();
     await Promise.all([
       applyPreferences(),
-      loadLocale(state.preferences?.locale || "en"),
+      loadLocale(initialLocale(state.preferences?.locale, typeof navigator !== "undefined" ? navigator.language : "")),
       loadBooksCatalog()
     ]);
     applyTranslations();

--- a/src/web/js/events/shared.ts
+++ b/src/web/js/events/shared.ts
@@ -1,6 +1,6 @@
 // Shared helpers used by both events.js barrel and navigation.js submodule.
 import { state } from "../state.js";
-import { t } from "../i18n.js";
+import { getLocale, t } from "../i18n.js";
 import { getReaderSelectionText } from "../reader/selection.js";
 import { showToast } from "../toast.js";
 import { isAndroidPlatform, openAndroidUrl } from "../platform.js";
@@ -28,7 +28,7 @@ export async function openDictionary(word: string): Promise<void> {
       return;
     }
     const theme = resolveTheme(state.preferences.theme, document.documentElement.dataset.theme === "dark");
-    const locale = state.preferences.locale || "pl";
+    const locale = getLocale();
     const url = `/__argos/ui?text=${encodeURIComponent(word || "")}&from=${fromLang}&to=${toLang}&theme=${theme.mode}&family=${theme.family}&locale=${locale}`;
     const dictUrl = `/__open_dict?url=${encodeURIComponent(url)}&mode=internal&title=${encodeURIComponent(t("translator.argosTitle"))}`;
     fetch(dictUrl).catch(e => console.warn("Failed to open offline translator UI", e));

--- a/src/web/js/i18n.ts
+++ b/src/web/js/i18n.ts
@@ -15,6 +15,17 @@ export function getLocale() {
   return currentLocale;
 }
 
+/**
+ * First-launch locale (issue #135): the saved preference wins, else the
+ * browser/OS language (matched against the shipped locales by `loadLocale`),
+ * else Polish — the app's default locale when the system locale is unknown.
+ */
+export function initialLocale(savedLocale?: string, navigatorLanguage?: string): string {
+  if (savedLocale) return savedLocale;
+  const nav = (navigatorLanguage || "").split("-")[0];
+  return nav || "pl";
+}
+
 export async function loadLocale(locale: string) {
   const code = SUPPORTED.includes(locale) ? locale : FALLBACK;
   try {


### PR DESCRIPTION
Narrowed to the only real bullet of #135 — **Polish default locale** (issue stays open; the remaining bullets moved to separate follow-ups).

**What changed**
- `initialLocale()` now lives in `src/web/js/i18n.ts` (exported, pure): saved preference wins → `navigator.language` prefix → **`"pl"`** when the system locale is unknown/empty (previously `"en"`).
- `src/web/app.ts` uses it at both startup paths; the `navigator` access is sandbox-safe (guarded at the call site).
- `src/web/js/events/shared.ts`: the hardcoded translator locale fallback (`|| "pl"`) now uses the actually loaded locale (`getLocale()`).
- New contract test `frontend-tests/shared/initial-locale.test.js` pins the behavior — verified RED (`'en' !== 'pl'`) before the fallback flip, GREEN after.

**Verification**
- `node --experimental-vm-modules --test frontend-tests/shared/*.test.js` → 422/422 pass (incl. `initial-locale.test.js` 3/3; `persistence-lifecycle` harness mock updated for the new export)
- `npm run check:frontend` → 0 (lint:css, lint:html, build:frontend, check:ts)
- `git diff --check` → clean

**Follow-ups (remaining #135 bullets, separate PRs — #135 NOT closed)**
1. APPDATA gating on Unix (revert in #175 was correct: the redirect test enforces APPDATA on Linux — needs a test change first)
2. HOME-unset startup failure (getpwuid fallback)
3. xdg-open exit status surfaced as toast
4. rfd GTK3 feature as dialog fallback
5. Confinement data-dir reset (PermissionDenied vs NotFound)
6. yt-dlp Linux docs/bundling
