### PR TITLE
Fix #97: Android PDF import leaks its progress timer and can hang

### DIFF
--- a/frontend-tests/shared/custom-text.test.js
+++ b/frontend-tests/shared/custom-text.test.js
@@ -48,7 +48,7 @@ const {
   reconcilePdfPageWords,
   replacePdfTextRange
 } = await import("../../dist/web/js/reader/pdf-page-text.js");
-const { bindBookImportEvents } = await import("../../dist/web/js/events/book-import.js");
+const { bindBookImportEvents, confirmWholeBookOcr } = await import("../../dist/web/js/events/book-import.js");
 const { getOrCreateEntry } = await import("../../dist/web/js/views/vocabulary.js");
 const { mapPdfOverlayWordIndexes, mapPdfOverlayWordPositions } = await import("../../dist/web/js/reader/pdf-ocr-renderer.js");
 const { upsertStoredText } = await import("../../dist/web/js/store-bridge.js");
@@ -84,6 +84,63 @@ describe("custom text import", () => {
     assert.equal(state.customTexts.find((text) => text.id === secondId).text, "SECOND BODY");
     assert.equal(bookTexts.get(firstId), "FIRST BODY");
     assert.equal(bookTexts.get(secondId), "SECOND BODY");
+  });
+
+  it("replaces a stale OCR confirmation dialog and always settles", async () => {
+    let staleRemoved = false;
+    const staleDialog = {
+      querySelector() { return null; },
+      remove() { staleRemoved = true; }
+    };
+    const listeners = new Map();
+    const button = () => ({
+      textContent: "",
+      addEventListener(type, handler) { listeners.set(this, handler); },
+      removeEventListener() { listeners.delete(this); }
+    });
+    const cancelButton = button();
+    const confirmButton = button();
+    const heading = { textContent: "" };
+    const copy = { textContent: "" };
+    let dialogRemoved = false;
+    const dialog = {
+      id: "",
+      className: "",
+      open: false,
+      setAttribute() {},
+      set innerHTML(_value) {},
+      querySelector(selector) {
+        if (selector === "h2") return heading;
+        if (selector === "p") return copy;
+        if (selector === '[data-action="cancel"]') return cancelButton;
+        if (selector === '[data-action="confirm"]') return confirmButton;
+        return null;
+      },
+      addEventListener(type, handler) { listeners.set(type, handler); },
+      removeEventListener(type) { listeners.delete(type); },
+      showModal() { this.open = true; },
+      close() { this.open = false; },
+      remove() { dialogRemoved = true; }
+    };
+    const originalQuerySelector = document.querySelector;
+    const originalCreateElement = document.createElement;
+    const originalBody = document.body;
+    document.querySelector = (selector) => selector === "#ocr-whole-book-confirm" ? staleDialog : null;
+    document.createElement = () => dialog;
+    document.body = { appendChild() {} };
+
+    try {
+      const confirmation = confirmWholeBookOcr();
+      assert.equal(staleRemoved, true);
+      assert.equal(dialog.open, true);
+      listeners.get(confirmButton)();
+      assert.equal(await confirmation, true);
+      assert.equal(dialogRemoved, true);
+    } finally {
+      document.querySelector = originalQuerySelector;
+      document.createElement = originalCreateElement;
+      document.body = originalBody;
+    }
   });
 
   it("keeps existing PDF OCR overlay metadata when an update has no pages", async () => {

--- a/frontend-tests/shared/focused-regressions.test.js
+++ b/frontend-tests/shared/focused-regressions.test.js
@@ -653,6 +653,20 @@ describe("focused frontend regressions", () => {
     assert.equal(closeCount, 1);
   });
 
+  it("cleans Android PDF progress and bounds per-page saves on every import exit", () => {
+    const bookImport = read("dist/web/js/events/book-import.js");
+    const runPdfImport = bookImport.slice(
+      bookImport.indexOf("async function runPdfImport"),
+      bookImport.indexOf("export function bindBookImportEvents")
+    );
+
+    assert.match(bookImport, /fetchWithTimeout\("\/__book\/image",[\s\S]*?30_000\)/);
+    assert.match(
+      runPdfImport,
+      /finally\s*{[\s\S]*?stopAndroidPdfProgress\(\);\s*stopOcrProgress\(\);\s*setImportLoading\(false\);\s*}/
+    );
+  });
+
   it("does not open a writable editor when the synced body refresh fails", async () => {
     let showCount = 0;
     const toasts = [];

--- a/src/web/js/events/book-import.ts
+++ b/src/web/js/events/book-import.ts
@@ -490,8 +490,20 @@ async function handleYoutubeImport() {
   }
 }
 
-function confirmWholeBookOcr(): Promise<boolean> {
-  const dialog = document.querySelector<HTMLDialogElement>("#ocr-whole-book-confirm") || (() => {
+export function confirmWholeBookOcr(): Promise<boolean> {
+  let dialog = document.querySelector<HTMLDialogElement>("#ocr-whole-book-confirm");
+  if (dialog && (
+    !dialog.querySelector("h2")
+    || !dialog.querySelector("p")
+    || !dialog.querySelector('[data-action="cancel"]')
+    || !dialog.querySelector('[data-action="confirm"]')
+  )) {
+    // A stale/partially-restored dialog must not make the Promise executor
+    // throw before it can settle. Rebuild the complete dialog instead.
+    dialog.remove();
+    dialog = null;
+  }
+  dialog ||= (() => {
     const next = document.createElement("dialog");
     next.id = "ocr-whole-book-confirm";
     next.className = "panel ocr-confirm-dialog";
@@ -508,25 +520,32 @@ function confirmWholeBookOcr(): Promise<boolean> {
     document.body.appendChild(next);
     return next;
   })();
-  dialog.querySelector("h2").textContent = t("import.ocrWholeBookTitle");
-  dialog.querySelector("p").textContent = t("import.ocrWholeBookConfirm");
-  dialog.querySelector('[data-action="cancel"]').textContent = t("import.ocrWholeBookCancel");
-  dialog.querySelector('[data-action="confirm"]').textContent = t("import.ocrWholeBookStart");
+  const heading = dialog.querySelector<HTMLElement>("h2");
+  const copy = dialog.querySelector<HTMLElement>("p");
+  const cancelButton = dialog.querySelector<HTMLButtonElement>('[data-action="cancel"]');
+  const confirmButton = dialog.querySelector<HTMLButtonElement>('[data-action="confirm"]');
+  if (!heading || !copy || !cancelButton || !confirmButton) {
+    dialog.remove();
+    return Promise.resolve(false);
+  }
+  heading.textContent = t("import.ocrWholeBookTitle");
+  copy.textContent = t("import.ocrWholeBookConfirm");
+  cancelButton.textContent = t("import.ocrWholeBookCancel");
+  confirmButton.textContent = t("import.ocrWholeBookStart");
 
   return new Promise<boolean>((resolve) => {
     const finish = (accepted: boolean) => {
-      dialog.close();
+      if (dialog.open) dialog.close();
       dialog.removeEventListener("cancel", cancel);
       dialog.removeEventListener("click", backdrop);
       cancelButton.removeEventListener("click", cancel);
       confirmButton.removeEventListener("click", confirm);
+      dialog.remove();
       resolve(accepted);
     };
     const cancel = (event?: Event) => { event?.preventDefault(); finish(false); };
     const confirm = () => finish(true);
     const backdrop = (event: MouseEvent) => { if (event.target === dialog) cancel(); };
-    const cancelButton = dialog.querySelector<HTMLButtonElement>('[data-action="cancel"]');
-    const confirmButton = dialog.querySelector<HTMLButtonElement>('[data-action="confirm"]');
     dialog.addEventListener("cancel", cancel);
     dialog.addEventListener("click", backdrop);
     cancelButton.addEventListener("click", cancel);

--- a/src/web/js/events/book-import.ts
+++ b/src/web/js/events/book-import.ts
@@ -3,6 +3,7 @@ import { els } from "../dom.js";
 import { t } from "../i18n.js";
 import { showToast } from "../toast.js";
 import { isAndroidPlatform, isImageOcrAvailable } from "../platform.js";
+import { fetchWithTimeout } from "../request.js";
 import { decodeImportedTextBytes, parseImportedTextFile, titleFromImportedFileName } from "../subtitles.js";
 import {
   cancelEditBook,
@@ -217,7 +218,7 @@ async function renderAndSaveAndroidPdfPages(data: string, bookId: string, pages:
       if (!rendered.dataUrl || !page?.imageName) {
         throw new Error(t("toast.pdfOcrNoText"));
       }
-      const response = await fetch("/__book/image", {
+      const response = await fetchWithTimeout("/__book/image", {
         method: "POST",
         headers: { "Content-Type": "application/json", "X-WH-Token": window.WH_TOKEN || "" },
         body: JSON.stringify({
@@ -226,7 +227,7 @@ async function renderAndSaveAndroidPdfPages(data: string, bookId: string, pages:
           base64_data: rendered.dataUrl,
           pending_import: true
         })
-      });
+      }, 30_000);
       if (!response.ok) {
         const message = await response.text().catch(() => "");
         throw new Error(message || `HTTP ${response.status}`);
@@ -686,6 +687,9 @@ async function runPdfImport(file: File): Promise<boolean> {
     }
     throw error;
   } finally {
+    // The render loop can throw (bridge error, cancel, network) — the
+    // progress interval must never outlive the import (timer leak).
+    stopAndroidPdfProgress();
     stopOcrProgress();
     setImportLoading(false);
   }


### PR DESCRIPTION
Closes #97

**Audit verdict:** CONFIRMED (wave 2-C: timer cleared only on the happy path; bare fetch per page).

**Verification:** check:frontend 0; 465/465 tests.