### PR TITLE
Fix #120: Android backend port has no fallback (app fails to start)

### DIFF
--- a/frontend-tests/shared/android-port-fallback.test.js
+++ b/frontend-tests/shared/android-port-fallback.test.js
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it } from "node:test";
+
+const defaultRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const root = process.env.WORDHUNTER_TEST_ROOT || defaultRoot;
+const androidSource = readFileSync(resolve(root, "src-tauri/src/platform/android.rs"), "utf8");
+
+describe("Android backend port fallback", () => {
+  it("retries the bounded fallback range when the preferred port cannot bind", () => {
+    assert.match(androidSource, /let mut port = ANDROID_SERVER_PORT;/);
+    assert.match(androidSource, /port < ANDROID_SERVER_PORT \+ 10/);
+    assert.match(androidSource, /port \+= 1;/);
+  });
+
+  it("opens the webview on the port that actually bound", () => {
+    assert.match(androidSource, /let actual_port = loop/);
+    assert.match(androidSource, /Ok\(bound\)\s*=>\s*break bound/);
+    assert.match(
+      androidSource,
+      /WebviewUrl::External\([\s\S]*127\.0\.0\.1:\{actual_port\}\/index\.html/,
+    );
+  });
+});

--- a/src-tauri/src/platform/android.rs
+++ b/src-tauri/src/platform/android.rs
@@ -1,4 +1,4 @@
-use tauri::{Manager, WebviewWindowBuilder};
+use tauri::{Manager, WebviewUrl, WebviewWindowBuilder};
 
 use crate::{APP_NAME, server, store::Store};
 
@@ -19,16 +19,34 @@ pub(crate) fn setup(app: &mut tauri::App) -> SetupResult {
     });
     let token = server::make_token();
     let app_handle = app.handle().clone();
-    server::start_server_on_port(store, token, app_handle, ANDROID_SERVER_PORT)
-        .map_err(boxed_string)?;
-    eprintln!("WordHunter Android setup: backend ready on 127.0.0.1:{ANDROID_SERVER_PORT}");
+    // The fixed port can be taken (stale process, second instance); fall
+    // back to the next ports instead of failing the whole app.
+    let mut port = ANDROID_SERVER_PORT;
+    let actual_port = loop {
+        match server::start_server_on_port(store.clone(), token.clone(), app_handle.clone(), port) {
+            Ok(bound) => break bound,
+            Err(error) if port < ANDROID_SERVER_PORT + 10 => {
+                eprintln!("WordHunter Android setup: port {port} unavailable ({error}), trying next");
+                port += 1;
+            }
+            Err(error) => return Err(boxed_string(error)),
+        }
+    };
+    eprintln!("WordHunter Android setup: backend ready on 127.0.0.1:{actual_port}");
     let window_config = app
         .config()
         .app
         .windows
         .first()
         .ok_or_else(|| boxed_string("Android window config is missing".to_string()))?;
-    WebviewWindowBuilder::from_config(app.handle(), window_config)?.build()?;
+    // The config URL embeds the default port; point the webview at the
+    // port that was actually bound.
+    WebviewWindowBuilder::from_config(app.handle(), window_config)?
+        .url(WebviewUrl::External(
+            url::Url::parse(&format!("http://127.0.0.1:{actual_port}/index.html"))
+                .map_err(boxed_string)?,
+        ))
+        .build()?;
     Ok(())
 }
 

--- a/src-tauri/src/platform/android.rs
+++ b/src-tauri/src/platform/android.rs
@@ -26,27 +26,29 @@ pub(crate) fn setup(app: &mut tauri::App) -> SetupResult {
         match server::start_server_on_port(store.clone(), token.clone(), app_handle.clone(), port) {
             Ok(bound) => break bound,
             Err(error) if port < ANDROID_SERVER_PORT + 10 => {
-                eprintln!("WordHunter Android setup: port {port} unavailable ({error}), trying next");
+                eprintln!(
+                    "WordHunter Android setup: port {port} unavailable ({error}), trying next"
+                );
                 port += 1;
             }
             Err(error) => return Err(boxed_string(error)),
         }
     };
     eprintln!("WordHunter Android setup: backend ready on 127.0.0.1:{actual_port}");
-    let window_config = app
+    let mut window_config = app
         .config()
         .app
         .windows
         .first()
-        .ok_or_else(|| boxed_string("Android window config is missing".to_string()))?;
+        .ok_or_else(|| boxed_string("Android window config is missing".to_string()))?
+        .clone();
     // The config URL embeds the default port; point the webview at the
     // port that was actually bound.
-    WebviewWindowBuilder::from_config(app.handle(), window_config)?
-        .url(WebviewUrl::External(
-            url::Url::parse(&format!("http://127.0.0.1:{actual_port}/index.html"))
-                .map_err(boxed_string)?,
-        ))
-        .build()?;
+    window_config.url = WebviewUrl::External(
+        url::Url::parse(&format!("http://127.0.0.1:{actual_port}/index.html"))
+            .map_err(|error| boxed_string(error.to_string()))?,
+    );
+    WebviewWindowBuilder::from_config(app.handle(), &window_config)?.build()?;
     Ok(())
 }
 


### PR DESCRIPTION
Addresses the Android fixed-port item from #120. This PR intentionally does not close the broader robustness batch.

## What changed
- retries backend binding across 38619..38629 when the preferred port is occupied
- points the Tauri webview at the exact port returned by the successful server bind
- adds a focused source-contract regression test

## TDD and verification
- focused test against the integration base without this fix: 0/2 (expected RED)
- focused test on this branch: 2/2 GREEN
- current-base frontend: 492/492 in 69 suites
- Rust library: 288/288
- `cargo fmt --check`
- `git diff --check`
