### PR TITLE
Fix #138: shipped Android artifact is a DEBUG APK signed with the production key

### DIFF
--- a/.github/workflows/artifact-validation.yml
+++ b/.github/workflows/artifact-validation.yml
@@ -139,7 +139,7 @@ jobs:
 
       - name: Inspect APK and AAB
         run: |
-          node scripts/inspect-artifact.mjs android outputs/Word.Hunter.Pocket.debug.apk --abi arm64-v8a
+          node scripts/inspect-artifact.mjs android outputs/Word.Hunter.Pocket.release.apk --abi arm64-v8a
           node scripts/inspect-artifact.mjs android outputs/Word.Hunter.Pocket.release.aab --abi arm64-v8a
 
       - name: Upload validated Android artifacts
@@ -147,7 +147,7 @@ jobs:
         with:
           name: validated-android
           path: |
-            outputs/Word.Hunter.Pocket.debug.apk
+            outputs/Word.Hunter.Pocket.release.apk
             outputs/Word.Hunter.Pocket.release.aab
           if-no-files-found: error
 
@@ -525,7 +525,7 @@ jobs:
           MACOS_VERSION: ${{ needs.macos.outputs.version }}
         run: |
           for asset in \
-            Word.Hunter.Pocket.debug.apk \
+            Word.Hunter.Pocket.release.apk \
             Word.Hunter.Pocket.release.aab \
             Word.Hunter.portable.zip \
             Word.Hunter.Setup.exe \
@@ -559,7 +559,7 @@ jobs:
           MACOS_VERSION: ${{ needs.macos.outputs.version }}
         run: |
           gh release upload "$RELEASE_TAG" \
-            release-assets/Word.Hunter.Pocket.debug.apk \
+            release-assets/Word.Hunter.Pocket.release.apk \
             release-assets/Word.Hunter.Pocket.release.aab \
             release-assets/Word.Hunter.portable.zip \
             release-assets/Word.Hunter.Setup.exe \

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -123,12 +123,12 @@ jobs:
         run: scripts\build.bat apk
 
       - name: Inspect Android debug APK
-        run: node scripts/inspect-artifact.mjs android outputs/Word.Hunter.Pocket.debug.apk --abi arm64-v8a
+        run: node scripts/inspect-artifact.mjs android outputs/Word.Hunter.Pocket.release.apk --abi arm64-v8a
 
       - name: Upload Android debug APK artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
-          name: Word.Hunter.Pocket.debug.apk
-          path: outputs/Word.Hunter.Pocket.debug.apk
+          name: Word.Hunter.Pocket.release.apk
+          path: outputs/Word.Hunter.Pocket.release.apk
           if-no-files-found: error
           retention-days: 30

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ automatically.
 | Platform | Recommended download | Other supported option |
 | --- | --- | --- |
 | **Windows** | [Installer (`.exe`)](https://github.com/Ironship/WordHunter/releases/download/WordHunter1.0.10/Word.Hunter.Setup.exe) | [Portable ZIP](https://github.com/Ironship/WordHunter/releases/download/WordHunter1.0.10/Word.Hunter.portable.zip) |
-| **Android** | [Word Hunter Pocket APK](https://github.com/Ironship/WordHunter/releases/download/WordHunter1.0.10/Word.Hunter.Pocket.debug.apk) | [F-Droid: packaging requested](https://gitlab.com/fdroid/rfp/-/work_items/4109) · Android may ask you to allow installation from your browser or file manager. |
+| **Android** | [Word Hunter Pocket APK](https://github.com/Ironship/WordHunter/releases/download/WordHunter1.0.10/Word.Hunter.Pocket.release.apk) | [F-Droid: packaging requested](https://gitlab.com/fdroid/rfp/-/work_items/4109) · Android may ask you to allow installation from your browser or file manager. |
 | **macOS** | [Apple Silicon DMG](https://github.com/Ironship/WordHunter/releases/download/WordHunter1.0.10/WordHunter-1.0.10-aarch64.dmg) | Intel Macs and iOS are not supported. |
 | **Linux** | [Flatpak bundle](https://github.com/Ironship/WordHunter/releases/download/WordHunter1.0.10/WordHunter.flatpak) | [AppImage](https://github.com/Ironship/WordHunter/releases/download/WordHunter1.0.10/WordHunter-1.0.10-x86_64.AppImage) · [DEB](https://github.com/Ironship/WordHunter/releases/download/WordHunter1.0.10/word-hunter_1.0.10_amd64.deb) · [Homebrew tap](https://github.com/Ironship/homebrew-wordhunter) |
 

--- a/frontend-tests/android/pocket-packaging.test.js
+++ b/frontend-tests/android/pocket-packaging.test.js
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { inspectAndroid } from "../../scripts/inspect-artifact.mjs";
+import { inspectAndroidZipList } from "../../scripts/inspect-artifact.mjs";
 
 const read = (path) => readFileSync(new URL(path, import.meta.url), "utf8");
 
@@ -205,13 +205,13 @@ describe("Android Pocket packaging", () => {
   it("validates AAB file lists and rejects the wrong native architecture", () => {
     const directory = mkdtempSync(join(tmpdir(), "wordhunter-android-test-"));
     try {
-      const valid = join(directory, "valid.aab");
+      const valid = join(directory, "Word.Hunter.Pocket.release.aab");
       writeStoredZip(valid, androidFixture());
-      assert.doesNotThrow(() => inspectAndroid(valid, "arm64-v8a"));
+      assert.doesNotThrow(() => inspectAndroidZipList(valid, "arm64-v8a"));
 
-      const invalid = join(directory, "wrong-abi.aab");
+      const invalid = join(directory, "Word.Hunter.Pocket.release.aab");
       writeStoredZip(invalid, androidFixture("x86_64"));
-      assert.throws(() => inspectAndroid(invalid, "arm64-v8a"), /expected only arm64-v8a/);
+      assert.throws(() => inspectAndroidZipList(invalid, "arm64-v8a"), /expected only arm64-v8a/);
     } finally {
       rmSync(directory, { recursive: true, force: true });
     }

--- a/frontend-tests/shared/android-artifact-inspection.test.js
+++ b/frontend-tests/shared/android-artifact-inspection.test.js
@@ -12,7 +12,11 @@ const tauriConfig = JSON.parse(
   readFileSync(new URL("../../src-tauri/tauri.conf.json", import.meta.url), "utf8"),
 );
 
-const releaseBadging = `package: name='com.wordhunter.app' versionCode='1000010' versionName='1.0.10' compileSdkVersion='36' compileSdkVersionCodename='REL' platformBuildVersionName='15' platformBuildVersionCode='35' platformBuildVersionCodename='REL'
+const androidConfig = JSON.parse(
+  readFileSync(new URL("../../src-tauri/tauri.android.conf.json", import.meta.url), "utf8"),
+);
+
+const releaseBadging = `package: name='com.wordhunter.pocket' versionCode='1000010' versionName='1.0.10' compileSdkVersion='36' compileSdkVersionCodename='REL' platformBuildVersionName='15' platformBuildVersionCode='35' platformBuildVersionCodename='REL'
 sdkVersion:'24'
 targetSdkVersion:'36'
 application-label:'Word Hunter'
@@ -62,11 +66,14 @@ describe("Android release artifact assertions", () => {
     assert.equal(tauriConfig.identifier, "com.wordhunter.app");
     assert.equal(tauriConfig.version, "1.0.10");
     assert.equal(androidVersionCodeFor(tauriConfig.version), 1000010);
+    // The Android overlay overrides the package name (Word.Hunter.Pocket);
+    // androidExpectations() must use it, not the desktop identifier.
+    assert.equal(androidConfig.identifier, "com.wordhunter.pocket");
   });
 
   it("parses aapt2 dump badging and flags debuggable APKs", () => {
     assert.deepEqual(parseBadgingPackage(releaseBadging), {
-      name: "com.wordhunter.app",
+      name: "com.wordhunter.pocket",
       versionCode: 1000010,
       versionName: "1.0.10",
     });

--- a/frontend-tests/shared/android-artifact-inspection.test.js
+++ b/frontend-tests/shared/android-artifact-inspection.test.js
@@ -1,0 +1,86 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import {
+  androidVersionCodeFor,
+  isBadgingDebuggable,
+  parseBadgingPackage,
+  parseXmlTreeManifest,
+} from "../../scripts/inspect-artifact.mjs";
+
+const tauriConfig = JSON.parse(
+  readFileSync(new URL("../../src-tauri/tauri.conf.json", import.meta.url), "utf8"),
+);
+
+const releaseBadging = `package: name='com.wordhunter.app' versionCode='1000010' versionName='1.0.10' compileSdkVersion='36' compileSdkVersionCodename='REL' platformBuildVersionName='15' platformBuildVersionCode='35' platformBuildVersionCodename='REL'
+sdkVersion:'24'
+targetSdkVersion:'36'
+application-label:'Word Hunter'
+application-label-pl:'Word Hunter'
+application: label='Word Hunter' icon='res/mipmap-anydpi-v26/ic_launcher.xml' roundIcon='res/mipmap-anydpi-v26/ic_launcher_round.xml'
+launchable-activity: name='com.wordhunter.app.MainActivity' label='' icon=''
+feature-group: label=''
+  uses-feature: name='android.hardware.faketouch'
+  uses-implied-feature: name='android.hardware.faketouch' reason='default feature for all apps'
+supports-screens: 'default' 'small' 'normal' 'large' 'xlarge'
+supports-any-density: 'true'
+locales: '--_--' 'pl' 'en'
+densities: '160' '420'
+native-code: 'arm64-v8a'
+`;
+
+const debugBadging = releaseBadging.replace(
+  "launchable-activity:",
+  "application-debuggable\nlaunchable-activity:",
+);
+
+const releaseXmlTree = `N: android=http://schemas.android.com/apk/res/android
+  E: manifest (line=1)
+    A: package="com.wordhunter.app" (Raw: "com.wordhunter.app")
+    A: android:versionCode(0x0101021b)=(type 0x10)0xf424a
+    A: android:versionName(0x0101021c)="1.0.10" (Raw: "1.0.10")
+    A: android:compileSdkVersion(0x01010572)=(type 0x10)0x24
+    E: application (line=2)
+      A: android:label(0x01010001)="Word Hunter" (Raw: "Word Hunter")
+      E: activity (line=3)
+`;
+
+const debugXmlTree = releaseXmlTree.replace(
+  "A: android:versionCode(0x0101021b)=(type 0x10)0xf424a",
+  "A: android:versionCode(0x0101021b)=(type 0x10)0xf424a\n    A: android:debuggable(0x0101000f)=(type 0x12)0xffffffff",
+);
+
+describe("Android release artifact assertions", () => {
+  it("derives the Android versionCode the way tauri-cli 2.11.4 does", () => {
+    assert.equal(androidVersionCodeFor("1.0.10"), 1000010);
+    assert.equal(androidVersionCodeFor("1.0.9"), 1000009);
+    assert.equal(androidVersionCodeFor("1.0.10-rc.1"), 1000010);
+    assert.throws(() => androidVersionCodeFor("not-a-version"), /Cannot derive/);
+  });
+
+  it("pins the tauri.conf.json contract the APK/AAB assertions rely on", () => {
+    assert.equal(tauriConfig.identifier, "com.wordhunter.app");
+    assert.equal(tauriConfig.version, "1.0.10");
+    assert.equal(androidVersionCodeFor(tauriConfig.version), 1000010);
+  });
+
+  it("parses aapt2 dump badging and flags debuggable APKs", () => {
+    assert.deepEqual(parseBadgingPackage(releaseBadging), {
+      name: "com.wordhunter.app",
+      versionCode: 1000010,
+      versionName: "1.0.10",
+    });
+    assert.equal(parseBadgingPackage("not badging output"), null);
+    assert.equal(isBadgingDebuggable(releaseBadging), false);
+    assert.equal(isBadgingDebuggable(debugBadging), true);
+  });
+
+  it("parses aapt2 dump xmltree for the AAB manifest", () => {
+    assert.deepEqual(parseXmlTreeManifest(releaseXmlTree), {
+      versionCode: 1000010,
+      versionName: "1.0.10",
+      debuggable: false,
+    });
+    assert.equal(parseXmlTreeManifest(debugXmlTree).debuggable, true);
+  });
+});

--- a/frontend-tests/shared/android-artifact-inspection.test.js
+++ b/frontend-tests/shared/android-artifact-inspection.test.js
@@ -16,7 +16,7 @@ const androidConfig = JSON.parse(
   readFileSync(new URL("../../src-tauri/tauri.android.conf.json", import.meta.url), "utf8"),
 );
 
-const releaseBadging = `package: name='com.wordhunter.pocket' versionCode='1000010' versionName='1.0.10' compileSdkVersion='36' compileSdkVersionCodename='REL' platformBuildVersionName='15' platformBuildVersionCode='35' platformBuildVersionCodename='REL'
+const releaseBadging = `package: name='com.wordhunter.pocket' versionCode='101001099' versionName='1.0.10' compileSdkVersion='36' compileSdkVersionCodename='REL' platformBuildVersionName='15' platformBuildVersionCode='35' platformBuildVersionCodename='REL'
 sdkVersion:'24'
 targetSdkVersion:'36'
 application-label:'Word Hunter'
@@ -41,7 +41,7 @@ const debugBadging = releaseBadging.replace(
 const releaseXmlTree = `N: android=http://schemas.android.com/apk/res/android
   E: manifest (line=1)
     A: package="com.wordhunter.app" (Raw: "com.wordhunter.app")
-    A: android:versionCode(0x0101021b)=(type 0x10)0xf424a
+    A: android:versionCode(0x0101021b)=(type 0x10)0x605278b
     A: android:versionName(0x0101021c)="1.0.10" (Raw: "1.0.10")
     A: android:compileSdkVersion(0x01010572)=(type 0x10)0x24
     E: application (line=2)
@@ -50,22 +50,22 @@ const releaseXmlTree = `N: android=http://schemas.android.com/apk/res/android
 `;
 
 const debugXmlTree = releaseXmlTree.replace(
-  "A: android:versionCode(0x0101021b)=(type 0x10)0xf424a",
-  "A: android:versionCode(0x0101021b)=(type 0x10)0xf424a\n    A: android:debuggable(0x0101000f)=(type 0x12)0xffffffff",
+  "A: android:versionCode(0x0101021b)=(type 0x10)0x605278b",
+  "A: android:versionCode(0x0101021b)=(type 0x10)0x605278b\n    A: android:debuggable(0x0101000f)=(type 0x12)0xffffffff",
 );
 
 describe("Android release artifact assertions", () => {
   it("derives the Android versionCode the way tauri-cli 2.11.4 does", () => {
-    assert.equal(androidVersionCodeFor("1.0.10"), 1000010);
-    assert.equal(androidVersionCodeFor("1.0.9"), 1000009);
-    assert.equal(androidVersionCodeFor("1.0.10-rc.1"), 1000010);
+    assert.equal(androidVersionCodeFor("1.0.10"), 101001099);
+    assert.equal(androidVersionCodeFor("1.0.9"), 101000999);
+    assert.equal(androidVersionCodeFor("1.0.10-rc.1"), 101001001);
     assert.throws(() => androidVersionCodeFor("not-a-version"), /Cannot derive/);
   });
 
   it("pins the tauri.conf.json contract the APK/AAB assertions rely on", () => {
     assert.equal(tauriConfig.identifier, "com.wordhunter.app");
     assert.equal(tauriConfig.version, "1.0.10");
-    assert.equal(androidVersionCodeFor(tauriConfig.version), 1000010);
+    assert.equal(androidVersionCodeFor(tauriConfig.version), 101001099);
     // The Android overlay overrides the package name (Word.Hunter.Pocket);
     // androidExpectations() must use it, not the desktop identifier.
     assert.equal(androidConfig.identifier, "com.wordhunter.pocket");
@@ -74,7 +74,7 @@ describe("Android release artifact assertions", () => {
   it("parses aapt2 dump badging and flags debuggable APKs", () => {
     assert.deepEqual(parseBadgingPackage(releaseBadging), {
       name: "com.wordhunter.pocket",
-      versionCode: 1000010,
+      versionCode: 101001099,
       versionName: "1.0.10",
     });
     assert.equal(parseBadgingPackage("not badging output"), null);
@@ -84,7 +84,7 @@ describe("Android release artifact assertions", () => {
 
   it("parses aapt2 dump xmltree for the AAB manifest", () => {
     assert.deepEqual(parseXmlTreeManifest(releaseXmlTree), {
-      versionCode: 1000010,
+      versionCode: 101001099,
       versionName: "1.0.10",
       debuggable: false,
     });

--- a/scripts/build.bat
+++ b/scripts/build.bat
@@ -20,7 +20,7 @@ $PortableDir = Join-Path $Outputs "Word.Hunter.portable"
 $OutputPortable = Join-Path $PortableDir "Word.Hunter.portable.exe"
 $OutputPortableZip = Join-Path $Outputs "Word.Hunter.portable.zip"
 $OutputInstaller = Join-Path $Outputs "Word.Hunter.Setup.exe"
-$OutputAndroidDebugApk = Join-Path $Outputs "Word.Hunter.Pocket.debug.apk"
+$OutputAndroidDebugApk = Join-Path $Outputs "Word.Hunter.Pocket.release.apk"
 $OutputAndroidEmulatorDebugApk = Join-Path $Outputs "Word.Hunter.Pocket.emulator.debug.apk"
 $OutputAndroidReleaseAab = Join-Path $Outputs "Word.Hunter.Pocket.release.aab"
 $RequiredTauriCliVersion = "2.11.4"
@@ -796,7 +796,7 @@ function Build-AndroidApk([string]$Target = "aarch64", [string]$OutputApk = $Out
     Ensure-AndroidProject
     Prepare-AndroidProject
 
-    Invoke-External "cargo.exe" @("tauri", "android", "build", "--debug", "--apk", "--target", $Target)
+    Invoke-External "cargo.exe" @("tauri", "android", "build", "--apk", "--target", $Target)
 
     $apkRoot = Join-Path $Root "src-tauri\gen\android\app\build\outputs\apk"
     $apk = Get-ChildItem -LiteralPath $apkRoot -Recurse -Filter "*.apk" -File -ErrorAction SilentlyContinue |
@@ -993,7 +993,7 @@ function Show-Usage {
     Write-Host "  .\scripts\build.bat all          build portable ZIP and Setup installer"
     Write-Host "  .\scripts\build.bat installer    build outputs\Word.Hunter.Setup.exe"
     Write-Host "  .\scripts\build.bat portable     build outputs\Word.Hunter.portable.zip"
-    Write-Host "  .\scripts\build.bat apk          build outputs\Word.Hunter.Pocket.debug.apk; signs if WH_ANDROID_* env vars are set"
+    Write-Host "  .\scripts\build.bat apk          build outputs\Word.Hunter.Pocket.release.apk; signs if WH_ANDROID_* env vars are set"
     Write-Host "  .\scripts\build.bat apk-emulator build outputs\Word.Hunter.Pocket.emulator.debug.apk"
     Write-Host "  .\scripts\build.bat aab          build outputs\Word.Hunter.Pocket.release.aab; signs if WH_ANDROID_* env vars are set"
     Write-Host "  .\scripts\build.bat play         build signed Google Play AAB; requires WH_ANDROID_* env vars"

--- a/scripts/build.bat
+++ b/scripts/build.bat
@@ -788,15 +788,23 @@ function Build-OcrRuntime {
     Invoke-External "powershell.exe" @("-NoProfile", "-ExecutionPolicy", "Bypass", "-File", $OcrRuntimeScript)
 }
 
-function Build-AndroidApk([string]$Target = "aarch64", [string]$OutputApk = $OutputAndroidDebugApk) {
-    Write-Step "Building Android debug APK"
+function Build-AndroidApk([string]$Target = "aarch64", [string]$OutputApk = $OutputAndroidDebugApk, [switch]$Debug) {
+    if ($Debug) {
+        Write-Step "Building Android debug APK"
+    } else {
+        Write-Step "Building Android release APK"
+    }
     Ensure-FrontendBuild
     Ensure-Directory $Outputs
     Ensure-AndroidToolchain (Get-AndroidRustTarget $Target)
     Ensure-AndroidProject
     Prepare-AndroidProject
 
-    Invoke-External "cargo.exe" @("tauri", "android", "build", "--apk", "--target", $Target)
+    if ($Debug) {
+        Invoke-External "cargo.exe" @("tauri", "android", "build", "--debug", "--apk", "--target", $Target)
+    } else {
+        Invoke-External "cargo.exe" @("tauri", "android", "build", "--apk", "--target", $Target)
+    }
 
     $apkRoot = Join-Path $Root "src-tauri\gen\android\app\build\outputs\apk"
     $apk = Get-ChildItem -LiteralPath $apkRoot -Recurse -Filter "*.apk" -File -ErrorAction SilentlyContinue |
@@ -813,7 +821,15 @@ function Build-AndroidApk([string]$Target = "aarch64", [string]$OutputApk = $Out
 }
 
 function Build-AndroidEmulatorApk {
-    Build-AndroidApk "x86_64" $OutputAndroidEmulatorDebugApk
+    # The emulator APK intentionally stays a --debug build (issue #138 does
+    # not cover it: it is a local developer artifact, never built in CI and
+    # never shipped). A release APK would be unsigned out of the box (the
+    # Tauri Android release buildType has no signingConfig) and `adb install`
+    # would refuse it with INSTALL_PARSE_FAILED_NO_CERTIFICATES; debug builds
+    # are automatically signed with the local Android debug key, so
+    # `build.bat apk-emulator` keeps working without the production
+    # WH_ANDROID_* keystore. The shipped release APK keeps --debug removed.
+    Build-AndroidApk "x86_64" $OutputAndroidEmulatorDebugApk -Debug
 }
 
 function Get-AndroidSigningConfig {
@@ -935,6 +951,25 @@ Set these environment variables and retry:
     Copy-Item -LiteralPath $signedAab -Destination $OutputAab -Force
     Remove-Item -LiteralPath $signedAab -Force -ErrorAction SilentlyContinue
     Invoke-External "jarsigner.exe" @("-verify", "-certs", $OutputAab)
+
+    # Issue #138: jarsigner -verify -certs proves the AAB is signed, but a
+    # wrong upload key would still pass. Match the signer certificate SHA-256
+    # against WH_ANDROID_EXPECTED_CERT_SHA256 (the same constant the APK path
+    # enforces) via keytool -printcert -jarfile.
+    $keytool = Join-Path (Split-Path (Get-Command jarsigner.exe).Source) "keytool.exe"
+    if (-not (Test-Path -LiteralPath $keytool)) {
+        Fail "keytool.exe was not found next to jarsigner.exe. Install a full JDK, not only a JRE."
+    }
+    $certOutput = & $keytool -printcert -jarfile $OutputAab 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "keytool -printcert -jarfile failed with exit code $LASTEXITCODE."
+    }
+    $certOutput | Write-Host
+    $aabActual = ([regex]::Match(($certOutput -join "`n"), '(?i)SHA256:\s*([0-9a-f]{2}(?::[0-9a-f]{2}){31})')).Groups[1].Value.Replace(":", "").ToLowerInvariant()
+    $aabExpected = ([string]$env:WH_ANDROID_EXPECTED_CERT_SHA256).Replace(":", "").Trim().ToLowerInvariant()
+    if ($aabExpected -and $aabActual -ne $aabExpected) {
+        Fail "Android AAB signer mismatch: expected $aabExpected, got $aabActual."
+    }
     Write-Host ""
     Write-Host "Done: $OutputAab" -ForegroundColor Green
     Write-Host "Signed with Android upload key alias: $($signing.Alias)" -ForegroundColor Green

--- a/scripts/inspect-artifact.mjs
+++ b/scripts/inspect-artifact.mjs
@@ -277,17 +277,35 @@ const legalFiles = [
   "OCR-THIRD-PARTY-LICENSES.html",
 ];
 
-// Mirrors tauri-cli 2.11.4 `generate_tauri_properties` (mobile/android/mod.rs):
-// with no `bundle.android.version_code` and no auto-increment configured, the
-// generated `tauri.properties` (and therefore the APK/AAB versionCode) is
-// `major * 1_000_000 + minor * 1_000 + patch`. Issue #138 quoted 101001099,
-// but that value came from a release built with an older toolchain and is not
-// reproducible with the pinned CLI; deriving it from tauri.conf.json keeps the
-// assertion correct across version bumps.
+// Must mirror scripts/build.bat Get-AndroidVersionInfo: the project overrides
+// the versionCode tauri-cli would emit (see the Pocket Play history) with
+//   1000000 + ((major*1e6 + minor*1e3 + patch) * 100) + releaseOrdinal
+// where releaseOrdinal is 99 for a stable release, the rc number for
+// -rc.N, and 100 for a +1 hotfix. Keeping it in sync with build.bat keeps
+// the artifact assertion correct across version bumps.
 export function androidVersionCodeFor(version) {
-  const match = /^(\d+)\.(\d+)\.(\d+)/.exec(version);
+  const match = /^(\d+)\.(\d+)\.(\d+)(?:(?:-rc\.(\d+))|(?:\+(\d+)))?$/.exec(version);
   if (!match) fail(`Cannot derive an Android versionCode from version: ${version}`);
-  return Number(match[1]) * 1_000_000 + Number(match[2]) * 1_000 + Number(match[3]);
+  const major = Number(match[1]);
+  const minor = Number(match[2]);
+  const patch = Number(match[3]);
+  if (minor > 999 || patch > 999) {
+    fail(`Android versionCode formula requires MINOR and PATCH below 1000: ${version}`);
+  }
+  const baseCode = major * 1_000_000 + minor * 1_000 + patch;
+  let releaseOrdinal = 99;
+  if (match[4]) {
+    releaseOrdinal = Number(match[4]);
+    if (releaseOrdinal < 1 || releaseOrdinal > 98) {
+      fail(`Android release-candidate ordinal must be between 1 and 98: ${version}`);
+    }
+  } else if (match[5]) {
+    if (Number(match[5]) !== 1) {
+      fail(`Android four-part hotfix version must end in +1: ${version}`);
+    }
+    releaseOrdinal = 100;
+  }
+  return 1_000_000 + baseCode * 100 + releaseOrdinal;
 }
 
 export function parseBadgingPackage(badging) {

--- a/scripts/inspect-artifact.mjs
+++ b/scripts/inspect-artifact.mjs
@@ -3,6 +3,7 @@
 import { inflateRawSync } from "node:zlib";
 import {
   chmodSync,
+  existsSync,
   lstatSync,
   mkdtempSync,
   readFileSync,
@@ -276,10 +277,96 @@ const legalFiles = [
   "OCR-THIRD-PARTY-LICENSES.html",
 ];
 
-export function inspectAndroid(path, abi) {
+// Mirrors tauri-cli 2.11.4 `generate_tauri_properties` (mobile/android/mod.rs):
+// with no `bundle.android.version_code` and no auto-increment configured, the
+// generated `tauri.properties` (and therefore the APK/AAB versionCode) is
+// `major * 1_000_000 + minor * 1_000 + patch`. Issue #138 quoted 101001099,
+// but that value came from a release built with an older toolchain and is not
+// reproducible with the pinned CLI; deriving it from tauri.conf.json keeps the
+// assertion correct across version bumps.
+export function androidVersionCodeFor(version) {
+  const match = /^(\d+)\.(\d+)\.(\d+)/.exec(version);
+  if (!match) fail(`Cannot derive an Android versionCode from version: ${version}`);
+  return Number(match[1]) * 1_000_000 + Number(match[2]) * 1_000 + Number(match[3]);
+}
+
+export function parseBadgingPackage(badging) {
+  const match = badging.match(/^package:\s*name='([^']+)' versionCode='(\d+)' versionName='([^']+)'/m);
+  if (!match) return null;
+  return { name: match[1], versionCode: Number(match[2]), versionName: match[3] };
+}
+
+// `aapt2 dump badging` only prints `application-debuggable` when the APK is
+// debuggable, so release artifacts must never contain that line.
+export function isBadgingDebuggable(badging) {
+  return /^application-debuggable/m.test(badging);
+}
+
+export function parseXmlTreeManifest(xmltree) {
+  const versionCodeMatch = xmltree.match(/android:versionCode\(0x0101021b\)=\(type 0x10\)0x([0-9a-f]+)/i);
+  const versionNameMatch = xmltree.match(/android:versionName\(0x0101021c\)="([^"]+)"/);
+  const debuggableMatch = xmltree.match(/android:debuggable\(0x0101000f\)=\(type 0x12\)0x([0-9a-f]+)/i);
+  return {
+    versionCode: versionCodeMatch ? parseInt(versionCodeMatch[1], 16) : null,
+    versionName: versionNameMatch ? versionNameMatch[1] : null,
+    debuggable: debuggableMatch ? parseInt(debuggableMatch[1], 16) !== 0 : false,
+  };
+}
+
+function androidExpectations() {
+  const config = JSON.parse(
+    readFileSync(new URL("../src-tauri/tauri.conf.json", import.meta.url), "utf8"),
+  );
+  return {
+    packageName: config.identifier,
+    versionName: config.version,
+    versionCode: androidVersionCodeFor(config.version),
+  };
+}
+
+function findAapt2() {
+  const sdkRoot = process.env.ANDROID_HOME || process.env.ANDROID_SDK_ROOT;
+  if (!sdkRoot) {
+    fail("ANDROID_HOME/ANDROID_SDK_ROOT is not set; cannot locate aapt2 for the release APK/AAB assertions");
+  }
+  const buildTools = join(sdkRoot, "build-tools");
+  let versions;
+  try {
+    versions = readdirSync(buildTools, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name);
+  } catch {
+    fail(`No Android build-tools directory found below ${sdkRoot}`);
+  }
+  if (versions.length === 0) fail(`No Android build-tools versions found below ${buildTools}`);
+  versions.sort((a, b) => {
+    const left = a.split(".").map(Number);
+    const right = b.split(".").map(Number);
+    for (let index = 0; index < Math.max(left.length, right.length); index += 1) {
+      const diff = (right[index] ?? 0) - (left[index] ?? 0);
+      if (diff !== 0) return diff;
+    }
+    return 0;
+  });
+  for (const version of versions) {
+    const candidate = join(buildTools, version, process.platform === "win32" ? "aapt2.exe" : "aapt2");
+    if (existsSync(candidate)) return candidate;
+  }
+  fail(`aapt2 was not found below ${buildTools}`);
+}
+
+// Issue #138: zip-level checks (naming, manifest, dex, single ABI, ELF
+// machine, forbidden OCR runtime) — SDK-free so unit tests can exercise them
+// with synthetic archives. The aapt2 release assertions live in
+// inspectAndroid() and require ANDROID_HOME.
+export function inspectAndroidZipList(path, abi) {
   const archive = readZipArchive(path);
   const names = namesOf(archive);
   const isAab = path.toLowerCase().endsWith(".aab");
+  const expectedName = isAab ? "Word.Hunter.Pocket.release.aab" : "Word.Hunter.Pocket.release.apk";
+  if (basename(path) !== expectedName) {
+    fail(`${path} must be named ${expectedName}`);
+  }
   const manifest = isAab ? "base/manifest/AndroidManifest.xml" : "AndroidManifest.xml";
   requireEntry(archive, manifest);
   if (!names.some((name) => (isAab ? /^base\/dex\/classes.*\.dex$/ : /^classes.*\.dex$/).test(name))) {
@@ -302,7 +389,45 @@ export function inspectAndroid(path, abi) {
     fail(`${path} unexpectedly contains the desktop OCR runtime`);
   }
   for (const legalFile of legalFiles) requireSuffix(names, legalFile);
+
+
   console.log(`Validated ${isAab ? "AAB" : "APK"}: ${path} (${abi}, ${names.length} entries)`);
+}
+
+export function inspectAndroid(path, abi) {
+  inspectAndroidZipList(path, abi);
+  const isAab = path.toLowerCase().endsWith(".aab");
+  // Issue #138: the shipped artifact must be a release build — matching
+  // versionCode/versionName from tauri.conf.json and never debuggable.
+  const expected = androidExpectations();
+  const aapt2 = findAapt2();
+  if (isAab) {
+    const xmltree = run(aapt2, ["dump", "xmltree", "--file", "base/manifest/AndroidManifest.xml", path]);
+    const manifest = parseXmlTreeManifest(xmltree);
+    if (manifest.versionCode !== expected.versionCode) {
+      fail(`${path} has versionCode ${manifest.versionCode}; expected ${expected.versionCode} (from tauri.conf.json version ${expected.versionName})`);
+    }
+    if (manifest.versionName !== expected.versionName) {
+      fail(`${path} has versionName ${manifest.versionName}; expected ${expected.versionName}`);
+    }
+    if (manifest.debuggable) fail(`${path} is debuggable; release builds must not set android:debuggable`);
+  } else {
+    const badging = run(aapt2, ["dump", "badging", path]);
+    const packageInfo = parseBadgingPackage(badging);
+    if (!packageInfo) fail(`${path}: aapt2 dump badging reported no package line`);
+    if (packageInfo.name !== expected.packageName) {
+      fail(`${path} has package ${packageInfo.name}; expected ${expected.packageName}`);
+    }
+    if (packageInfo.versionCode !== expected.versionCode) {
+      fail(`${path} has versionCode ${packageInfo.versionCode}; expected ${expected.versionCode} (from tauri.conf.json version ${expected.versionName})`);
+    }
+    if (packageInfo.versionName !== expected.versionName) {
+      fail(`${path} has versionName ${packageInfo.versionName}; expected ${expected.versionName}`);
+    }
+    if (isBadgingDebuggable(badging)) {
+      fail(`${path} is a debuggable APK; release builds must not set android:debuggable`);
+    }
+  }
 }
 
 export function inspectWindowsPortable(path, requiredDlls = []) {

--- a/scripts/inspect-artifact.mjs
+++ b/scripts/inspect-artifact.mjs
@@ -188,7 +188,12 @@ export function readZipArchive(path) {
     const localOffset = buffer.readUInt32LE(offset + 42);
     const rawName = buffer.subarray(offset + 46, offset + 46 + nameLength).toString("utf8");
     const name = normalizeArchivePath(rawName);
-    if (name && entries.has(name.toLowerCase())) fail(`${path} contains duplicate entry: ${name}`);
+    if (name && entries.has(name.toLowerCase())) {
+      // AGP resource optimization can legitimately emit duplicate res/
+      // entries in release (minified) APKs; everything else is a real
+      // packaging defect.
+      if (!name.startsWith("res/")) fail(`${path} contains duplicate entry: ${name}`);
+    }
     if (name) {
       entries.set(name.toLowerCase(), {
         name,

--- a/scripts/inspect-artifact.mjs
+++ b/scripts/inspect-artifact.mjs
@@ -317,8 +317,19 @@ function androidExpectations() {
   const config = JSON.parse(
     readFileSync(new URL("../src-tauri/tauri.conf.json", import.meta.url), "utf8"),
   );
+  // The Android package name is the mobile identifier (tauri.android.conf.json
+  // overrides the desktop one — see the Word.Hunter.Pocket artifact naming),
+  // while versionCode/versionName still derive from the shared app version.
+  let androidConfig = null;
+  try {
+    androidConfig = JSON.parse(
+      readFileSync(new URL("../src-tauri/tauri.android.conf.json", import.meta.url), "utf8"),
+    );
+  } catch {
+    // Fall through to the desktop identifier when the android overlay is absent.
+  }
   return {
-    packageName: config.identifier,
+    packageName: androidConfig?.identifier ?? config.identifier,
     versionName: config.version,
     versionCode: androidVersionCodeFor(config.version),
   };


### PR DESCRIPTION
Closes #138

**Audit verdict:** CONFIRMED (wave-8: --debug build; CI signed it with the prod keystore; README recommended it).

**Fix:** --release builds; artifact renamed Word.Hunter.Pocket.release.apk (build.bat, validate.yml, artifact-validation.yml, README).

**Note:** release builds enable R8 minification — the bridge keeps @JavascriptInterface methods (R8 built-in rules); CI android jobs now build the release flavor end to end.