### PR TITLE
Fix #144: Android build hygiene — gradle cache + Play changelog

### DIFF
--- a/.github/workflows/artifact-validation.yml
+++ b/.github/workflows/artifact-validation.yml
@@ -108,6 +108,9 @@ jobs:
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
 
+      - name: Cache Gradle
+        uses: gradle/actions/setup-gradle@889dc537cf3672c0c060560c9ead940a2b8b7077
+
       - name: Install pinned Tauri CLI
         run: cargo install tauri-cli --version 2.11.4 --locked
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -111,6 +111,9 @@ jobs:
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
 
+      - name: Cache Gradle
+        uses: gradle/actions/setup-gradle@889dc537cf3672c0c060560c9ead940a2b8b7077
+
       - name: Install pinned Tauri CLI
         run: cargo install tauri-cli --version 2.11.4 --locked
 

--- a/fastlane/metadata/android/en-US/changelogs/101001099.txt
+++ b/fastlane/metadata/android/en-US/changelogs/101001099.txt
@@ -1,0 +1,8 @@
+Release 1.0.10 — what's new:
+- Faster saves: delta snapshots and journaled writes
+- YouTube import with caption language picker
+- Reader search (Ctrl+F) and new shortcut hints
+- AI explanations for words and graph summaries
+- Youglish fallback that opens the site in your browser
+- Faster, safer PDF imports and background OCR
+- Stability and translation fixes across the board


### PR DESCRIPTION
Refs #144 (caches + changelog items only — remaining #144 items tracked in #208)

**Audit verdict:** CONFIRMED (wave-8: no gradle cache in CI; changelogs ended at 101001003).

**Verification:** repo-validation 7/7 (action pins enforced).