### PR TITLE
Fix #142: Android runtime gaps — zoom desync, dropped sounds, update link

### DIFF
--- a/frontend-tests/android/pocket-platform.test.js
+++ b/frontend-tests/android/pocket-platform.test.js
@@ -339,7 +339,9 @@ describe("Android Pocket platform", () => {
     assert.equal(handle.listeners.pointerdown.length, 1);
     assert.equal(listeners.resize.length, 1);
     assert.equal(listeners.orientationchange.length, 1);
-    assert.equal(visualViewportListeners.resize.length, 2);
+    // The sheet binds resize (1) and the keyboard overlap resize (1); the
+    // pinch-zoom re-pin binds its own resize+scroll pair once (guarded).
+    assert.equal(visualViewportListeners.resize.length, 3);
     assert.equal(observedContent.target, wordPanel);
     assert.deepEqual(observedContent.options.attributeFilter, ["hidden"]);
     assert.equal(wordPanel.listeners.load.length, 1);
@@ -621,5 +623,53 @@ describe("Android Pocket platform", () => {
     assert.doesNotMatch(sharedTextLayer, /marker_room/);
     assert.match(backend, /"pages": pages/);
     assert.match(sharedTextLayer, /image_name: format!\("pdf-page-\{:04\}\.png", page\.page_num\)/);
+  });
+
+  it("re-pins the CSS zoom when the visual viewport rescales after a pinch", async () => {
+    const visualViewportListeners = {};
+    const addListener = (target, type, handler) => {
+      (target[type] ||= []).push(handler);
+    };
+    const root = {
+      dataset: {},
+      classList: createClassList(),
+      style: { zoom: "", setProperty(name, value) { this[name] = value; } }
+    };
+
+    globalThis.window = {
+      location: { search: "?platform=android" },
+      addEventListener() {},
+      visualViewport: {
+        addEventListener(type, handler) { addListener(visualViewportListeners, type, handler); }
+      }
+    };
+    globalThis.HTMLElement = {
+      [Symbol.hasInstance](value) { return value !== null && typeof value === "object"; }
+    };
+    Object.defineProperty(globalThis, "navigator", {
+      configurable: true,
+      value: { userAgent: "Desktop test" }
+    });
+    globalThis.document = {
+      documentElement: root,
+      addEventListener() {},
+      getElementById() { return null; },
+      querySelector() { return null; },
+      querySelectorAll() { return []; }
+    };
+
+    const { applyPlatformUi } = await import("../../dist/web/js/platform.js");
+    applyPlatformUi();
+    applyPlatformUi();
+
+    // The re-pin listener is bound once even when the UI is applied repeatedly.
+    assert.equal(visualViewportListeners.resize.length, 2);
+    assert.equal(visualViewportListeners.scroll.length, 1);
+
+    // A pinch gesture re-scales the visual viewport under the pinned CSS zoom;
+    // the zoom must be re-pinned to "1" so the layout is not double-scaled.
+    root.style.zoom = "2";
+    for (const handler of visualViewportListeners.resize) handler();
+    assert.equal(root.style.zoom, "1");
   });
 });

--- a/frontend-tests/shared/status-sounds-resume.test.js
+++ b/frontend-tests/shared/status-sounds-resume.test.js
@@ -1,0 +1,71 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+const resumed = [];
+const gestureListeners = {};
+
+class FakeSuspendedAudioContext {
+  constructor() {
+    this.currentTime = 1;
+    this.destination = {};
+    this.state = "suspended";
+  }
+  createGain() {
+    return { gain: { setValueAtTime() {}, exponentialRampToValueAtTime() {} }, connect() {} };
+  }
+  createOscillator() {
+    return {
+      frequency: { setValueAtTime() {} },
+      connect() {},
+      start() {},
+      stop() {},
+      type: "sine"
+    };
+  }
+  resume() {
+    resumed.push(1);
+    return Promise.resolve();
+  }
+}
+
+globalThis.window = {
+  __qtBridge: false,
+  AudioContext: FakeSuspendedAudioContext,
+  addEventListener(type, handler, options) {
+    (gestureListeners[type] ||= []).push({ handler, options });
+  },
+  dispatchEvent() {}
+};
+globalThis.document = {
+  documentElement: { dataset: {}, style: {}, classList: { add() {}, remove() {}, toggle() {} } },
+  addEventListener() {},
+  getElementById() { return null; },
+  querySelector() { return null; },
+  querySelectorAll() { return []; }
+};
+globalThis.localStorage = { getItem() { return null; }, setItem() {}, removeItem() {} };
+globalThis.CustomEvent = class CustomEvent {
+  constructor(type, init) { this.type = type; this.detail = init?.detail; }
+};
+
+const { createDefaultState, replaceState, state } = await import("../../dist/web/js/state.js");
+const { playStatusSound } = await import("../../dist/web/js/status-sounds.js");
+
+describe("status sounds autoplay resume", () => {
+  it("resumes a suspended AudioContext on the first pointer gesture", () => {
+    replaceState(createDefaultState(), { save: false });
+    state.preferences.statusSoundsEnabled = true;
+    state.preferences.statusSoundVolume = 1;
+
+    playStatusSound("known");
+
+    // The suspended branch registers one-shot gesture listeners.
+    assert.equal(gestureListeners.pointerdown.length, 1);
+    assert.equal(gestureListeners.keydown.length, 1);
+    assert.deepEqual(gestureListeners.pointerdown[0].options, { once: true });
+
+    const before = resumed.length;
+    gestureListeners.pointerdown[0].handler();
+    assert.ok(resumed.length > before, "resume() was not called by the gesture listener");
+  });
+});

--- a/frontend-tests/shared/update-checker.test.js
+++ b/frontend-tests/shared/update-checker.test.js
@@ -18,7 +18,7 @@ globalThis.document = {
   getElementById() { return null; }
 };
 
-const { isNewer } = await import("../../dist/web/js/update-checker.js");
+const { checkForUpdates, isNewer } = await import("../../dist/web/js/update-checker.js");
 
 describe("stable update version ordering", () => {
   it("orders release candidates before the final release", () => {
@@ -31,5 +31,54 @@ describe("stable update version ordering", () => {
     assert.equal(isNewer("1.0.5", "1.0.4"), true);
     assert.equal(isNewer("0.2.7.7", "0.2.7.6"), true);
     assert.equal(isNewer("1.0.4", "1.0.4"), false);
+  });
+});
+
+describe("update dialog release link", () => {
+  it("opens the releases page through the Android bridge instead of window.open", async () => {
+    const openUrlCalls = [];
+    const windowOpenCalls = [];
+    const clickListeners = {};
+    const dialog = { closed: false, showModal() { this.closed = false; }, close() { this.closed = true; } };
+    const makeButton = (listeners) => ({
+      cloneNode() { return this; },
+      replaceWith() {},
+      addEventListener(type, handler) { listeners[type] = handler; }
+    });
+
+    globalThis.window = {
+      __qtBridge: false,
+      location: { search: "?platform=android" },
+      WordHunterAndroid: {
+        openUrl(url) { openUrlCalls.push(url); return true; }
+      },
+      open(url, target) { windowOpenCalls.push({ url, target }); },
+      addEventListener() {},
+      dispatchEvent() {}
+    };
+    globalThis.localStorage = { getItem() { return null; }, setItem() {}, removeItem() {} };
+    globalThis.fetch = async () => ({ ok: true, json: async () => ({ latest: "9.9.9", current: "1.0.0" }) });
+    globalThis.HTMLButtonElement = {
+      [Symbol.hasInstance](value) { return value !== null && typeof value === "object"; }
+    };
+    globalThis.HTMLDialogElement = {
+      [Symbol.hasInstance](value) { return value !== null && typeof value === "object"; }
+    };
+    globalThis.document = {
+      addEventListener() {},
+      getElementById(id) {
+        if (id === "update-dialog") return dialog;
+        if (id === "update-open") return makeButton(clickListeners);
+        if (id === "update-message" || id === "update-title") return { textContent: "" };
+        return makeButton({});
+      }
+    };
+
+    await checkForUpdates({ manual: true });
+    clickListeners.click();
+
+    assert.deepEqual(openUrlCalls, ["https://github.com/Ironship/WordHunter/releases"]);
+    assert.equal(windowOpenCalls.length, 0);
+    assert.equal(dialog.closed, true);
   });
 });

--- a/src/web/js/platform.ts
+++ b/src/web/js/platform.ts
@@ -70,6 +70,19 @@ export function applyPlatformUi(): void {
 
   document.documentElement.style.setProperty("--ui-scale", "1");
   document.documentElement.style.zoom = "1";
+  // A pinch re-scales the visual viewport under the pinned CSS zoom;
+  // re-pin the zoom whenever the viewport scale changes so the layout
+  // does not end up double-scaled after the gesture.
+  if (typeof window.visualViewport === "object" && window.visualViewport !== null) {
+    if (document.documentElement.dataset.pocketZoomPinBound !== "true") {
+      document.documentElement.dataset.pocketZoomPinBound = "true";
+      const rePinZoom = () => {
+        document.documentElement.style.zoom = "1";
+      };
+      window.visualViewport.addEventListener("resize", rePinZoom);
+      window.visualViewport.addEventListener("scroll", rePinZoom);
+    }
+  }
   bindPocketNavigationDrawer();
   bindPocketImportDrawer();
   bindPocketKeyboardOverlap();

--- a/src/web/js/status-sounds.ts
+++ b/src/web/js/status-sounds.ts
@@ -43,6 +43,16 @@ function statusSoundContext() {
     || (window as Window & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
   if (!AudioContextConstructor) return null;
   audioContext = new AudioContextConstructor();
+  // Autoplay policy: an AudioContext created outside a user gesture starts
+  // suspended and drops the first tone. Resume it on the first gesture so
+  // feedback sounds are never silently lost.
+  if (audioContext.state === "suspended") {
+    const resume = () => {
+      void audioContext?.resume().catch(() => {});
+    };
+    window.addEventListener("pointerdown", resume, { once: true });
+    window.addEventListener("keydown", resume, { once: true });
+  }
   return audioContext;
 }
 

--- a/src/web/js/update-checker.ts
+++ b/src/web/js/update-checker.ts
@@ -1,4 +1,5 @@
 import { state, saveState } from "./state.js";
+import { openAndroidUrl } from "./platform.js";
 import { t } from "./i18n.js";
 import { showToast } from "./toast.js";
 
@@ -127,7 +128,9 @@ export async function checkForUpdates({ manual = false }: UpdateCheckOptions = {
       if (newBtn instanceof HTMLButtonElement) {
         openBtn.replaceWith(newBtn);
         newBtn.addEventListener("click", () => {
-          window.open(GITHUB_RELEASES_URL, "_blank");
+          if (!openAndroidUrl(GITHUB_RELEASES_URL)) {
+            window.open(GITHUB_RELEASES_URL, "_blank");
+          }
           dialog.close();
         });
       }


### PR DESCRIPTION
Part of #142 (b/i/h items only)

Naprawia trzy pozycje z #142:
- **(b)** pinch-zoom: re-pin CSS zoom na zdarzenia visualViewport (resize/scroll), guard `pocketZoomPinBound` zapobiega duplikacji listenerów
- **(h)** update link: otwieranie releases przez mostek `WordHunterAndroid.openUrl` (fallback `window.open` na desktopie)
- **(i)** dźwięk: resume suspended AudioContext na pierwszy pointerdown/keydown (autoplay policy)

Testy regresyjne RED-na-bazie: zoom re-pin (dispatch visualViewport resize), mostek update linka, gałąź suspended w status-sounds.

Pozostałe otwarte pozycje #142 (nie w tym PR):
- [ ] 1 — find-bar
- [ ] 3 — IME
- [ ] 4 — selekcja fraz
- [ ] 5 — chooser accept
- [ ] 7 — EdgeTTS toggle
- [ ] 10 — perf vocab table