### PR TITLE
Fix #141: PDF page renders at 1400px on small screens

### DIFF
--- a/frontend-tests/android/pocket-platform.test.js
+++ b/frontend-tests/android/pocket-platform.test.js
@@ -581,7 +581,10 @@ describe("Android Pocket platform", () => {
     assert.match(source, /if \(!androidPdfOverlay && !await confirmWholeBookOcr\(\)\)\s*return false;/);
     assert.match(source, /renderAndSaveAndroidPdfPages\(data, id, pages\)/);
     assert.match(source, /bridge\.beginPdfRender\(sessionId, data\)/);
-    assert.match(source, /bridge\.renderPdfPage\(sessionId, index, 1400\)/);
+    assert.match(source, /bridge\.renderPdfPage\(sessionId, index, pdfRenderWidth\(\)\)/);
+    // The render width follows the screen (device pixels), clamped to the
+    // native 512..2400 range instead of a fixed 1400.
+    assert.match(source, /function pdfRenderWidth\(\)[\s\S]*Math\.min\(2400, Math\.max\(512, width\)\)/);
     assert.match(source, /new FileReader\(\)/);
     assert.match(source, /fetch\(`\/__import\/pdf_ocr\/raw\?\$\{params\}`/);
     assert.match(source, /MAX_POCKET_PDF_BYTES = 32 \* 1024 \* 1024/);

--- a/src/web/js/events/book-import.ts
+++ b/src/web/js/events/book-import.ts
@@ -91,6 +91,14 @@ const MAX_POCKET_PDF_BYTES = 32 * 1024 * 1024;
  * page loop yields between pages so the spinner keeps painting).
  */
 const MAX_POCKET_PDF_RENDER_PAGES = 300;
+// Render at the screen width (device pixels) so small phones do not
+// allocate 1400px bitmaps, clamped to the native renderer range.
+function pdfRenderWidth(): number {
+  const width = typeof window !== "undefined" && window.devicePixelRatio
+    ? Math.round(window.innerWidth * window.devicePixelRatio)
+    : 1400;
+  return Math.min(2400, Math.max(512, width));
+}
 const MAX_DESKTOP_OCR_IMAGE_BYTES = 32 * 1024 * 1024;
 const MAX_DESKTOP_IMPORT_FILE_BYTES = 64 * 1024 * 1024;
 const MAX_POCKET_IMPORT_FILE_BYTES = 24 * 1024 * 1024;
@@ -211,7 +219,7 @@ async function renderAndSaveAndroidPdfPages(data: string, bookId: string, pages:
       updateAndroidPdfProgress(index + 1, limitedPages.length);
       const page = limitedPages[index];
       const rendered = parseAndroidPdfRenderResponse(
-        bridge.renderPdfPage(sessionId, index, 1400),
+        bridge.renderPdfPage(sessionId, index, pdfRenderWidth()),
         t("toast.pdfOcrNoText")
       );
       if (!rendered.dataUrl || !page?.imageName) {


### PR DESCRIPTION
Part of #141 (width item only — OOM risk and JavaBridge thread blocking tracked separately in #141)

**Audit verdict:** CONFIRMED (wave-8: book-import.ts:214 hardcoded 1400 vs native 512..2400).

**Verification:** check:frontend 0; 465/465 tests; deterministic RED-on-base regression test.