### PR TITLE
Fix #137: Android exit flush is dropped (keepalive save)

### DIFF
--- a/frontend-tests/shared/persistence-lifecycle.test.js
+++ b/frontend-tests/shared/persistence-lifecycle.test.js
@@ -73,8 +73,7 @@ async function loadAppHarness({
   loadLocale = async () => {},
   pendingDelta = null,
   hasPending = false,
-  deltaPayload = "{}",
-  deltaCoverage = { langs: [], texts: [] }
+  deltaEnvelope = { payload: "{}", session: "harness", sequence: 0 }
 } = {}) {
   const calls = [];
   const animationFrames = [];
@@ -96,8 +95,7 @@ async function loadAppHarness({
     __qtBridge: false,
     flushPendingSave() { calls.push("flush-save"); },
     hasPendingChanges() { return hasPending; },
-    buildPendingDeltaPayload() { calls.push("build-delta"); return deltaPayload; },
-    buildPendingDeltaCoverage() { calls.push("build-coverage"); return deltaCoverage; },
+    buildPendingDeltaEnvelope() { calls.push("build-envelope"); return deltaEnvelope; },
     open() {},
     requestAnimationFrame(callback) {
       assert.equal(this, window);
@@ -141,7 +139,7 @@ async function loadAppHarness({
     "./js/api.js": {
       buildSavePayload: () => "{}",
       saveSyncXhr() { calls.push("keepalive-save"); },
-      flushPendingDeltaToLocalStorage(payload) { calls.push(`pending-flush:${payload}`); },
+      flushPendingDeltaToLocalStorage(delta) { calls.push(`pending-flush:${delta.payload}`); },
       readPendingDelta() { return pendingDelta; },
       clearPendingDelta() { calls.push("clear-pending"); },
       saveWithRetry(body) { calls.push(`replay:${body}`); return Promise.resolve({ ok: true }); }
@@ -310,15 +308,17 @@ describe("persistence lifecycle", () => {
     // payload is multi-MB, so the final mutations were silently dropped on
     // every Android activity finish. The flush must go to localStorage
     // synchronously and must not rely on a keepalive fetch.
-    const harness = await loadAppHarness({ hasPending: true, deltaPayload: '{"delta":true,"fullKeys":[]}' });
+    const harness = await loadAppHarness({
+      hasPending: true,
+      deltaEnvelope: { payload: '{"delta":true,"fullKeys":[]}', session: "s1", sequence: 3 }
+    });
     harness.setAndroid(true);
 
     harness.window.emit("pagehide");
 
     assert.deepEqual(harness.calls, [
       "flush-buffers",
-      "build-delta",
-      "build-coverage",
+      "build-envelope",
       'pending-flush:{"delta":true,"fullKeys":[]}'
     ]);
     assert.ok(
@@ -329,7 +329,7 @@ describe("persistence lifecycle", () => {
 
   it("replays a pending Android teardown flush through the normal save path at boot", async () => {
     const harness = await loadAppHarness({
-      pendingDelta: { coverage: { langs: [], texts: [] }, payload: '{"delta":true,"fullKeys":[]}' }
+      pendingDelta: { payload: '{"delta":true,"fullKeys":[]}', session: "prev", sequence: 2 }
     });
 
     await Promise.all(harness.document.emit("DOMContentLoaded"));
@@ -342,27 +342,25 @@ describe("persistence lifecycle", () => {
     assert.ok(harness.calls.includes("clear-pending"), "the pending flush is cleared on success");
   });
 
-  it("clears a stale pending delta once a newer save covers it — but not before", async () => {
+  it("clears a pending delta only when a same-session save built after the freeze supersedes it", async () => {
     // Issue #137 class: a delta frozen at an earlier hidden event must never
     // be replayed after a newer save covered its content — its frozen
     // fullKeys would tombstone keys written in the meantime. But a save whose
-    // payload did NOT cover the pending delta must not clear it either
-    // (that would drop the delta's mutations forever).
+    // payload was built BEFORE the freeze (in-flight at hidden time) or comes
+    // from a different session does NOT contain the delta's mutations and
+    // must not clear it either (that would drop them forever).
     let cleared = 0;
-    let pendingCoverage = { langs: [], texts: [] };
+    let pending = null;
+    let releaseSave;
+    const pendingResponse = new Promise((resolve) => { releaseSave = resolve; });
     const { createAutosave } = await evaluateWithMocks("../../dist/web/js/state/autosave.js", {
       "../api.js": {
         buildSavePayload: (state) => state,
         buildDeltaSavePayload: (_raw, _langs, _texts) => ({ delta: true, fullKeys: [], records: {} }),
         saveToLocalStorage() {},
-        async saveWithRetry() { return {}; },
+        saveWithRetry() { return pendingResponse; },
         saveSyncXhr() {},
-        readPendingDelta() {
-          return { coverage: pendingCoverage, payload: "{}" };
-        },
-        coverageCovers(save, pending) {
-          return pending.langs.every((lang) => save.langs.includes(lang));
-        },
+        readPendingDelta() { return pending; },
         clearPendingDelta() { cleared += 1; }
       }
     }, {
@@ -373,42 +371,30 @@ describe("persistence lifecycle", () => {
       console
     });
     const autosave = createAutosave(() => ({ preferences: {}, profiles: {} }));
+    const state = autosave.wrap({ preferences: {}, profiles: {} });
 
-    // Save with empty coverage covers an empty pending delta → cleared.
+    // Case 1 — save built BEFORE the freeze does not cover the delta:
+    // start a save (payload sequence 0), then mutate (sequence 1) and freeze
+    // the delta (sequence 1). The completing save must NOT clear it.
+    const inflight = autosave.saveState();
+    state.profiles.de = { words: {} };
+    const envelope = autosave.buildPendingDeltaEnvelope();
+    pending = envelope;
+    releaseSave({ ok: true });
+    await inflight;
+    assert.equal(cleared, 0, "a save built before the freeze must not clear the delta");
+
+    // Case 2 — a same-session save built after the freeze, carrying records,
+    // covers the delta (even for a mutation in an already-dirty language).
+    state.profiles.de.words.w1 = { status: "learning" };
     await autosave.saveState();
-    assert.equal(cleared, 1, "a covering save supersedes the pending delta");
+    assert.equal(cleared, 1, "a same-session save built after the freeze supersedes the delta");
 
-    // A pending delta covering a language the save did not touch stays.
-    pendingCoverage = { langs: ["de"], texts: [] };
+    // Case 3 — a delta from another session is never cleared by this
+    // session's saves (only the boot replay delivers and clears it).
+    pending = { payload: "{}", session: "other-session", sequence: 0 };
     await autosave.saveState();
-    assert.equal(cleared, 1, "a non-covering save must not clear the pending delta");
-  });
-
-  it("coverageCovers decides whether a save supersedes the pending delta", async () => {
-    const api = await evaluateWithMocks("../../dist/web/js/api.js", {
-      "./constants.js": { STATE_SCHEMA_VERSION: 2, STORAGE_KEY: "wordhunter-state" },
-      "./request.js": { fetchWithTimeout: async () => ({ ok: true, json: async () => ({}) }) }
-    }, {
-      window: { WH_TOKEN: "test-token" },
-      fetch: async () => ({ ok: true, json: async () => ({}) }),
-      localStorage: { getItem: () => null, setItem() {}, removeItem() {} },
-      setTimeout,
-      clearTimeout,
-      console
-    });
-
-    const { coverageCovers } = api;
-    const base = { langs: ["de"], texts: [] };
-    // A save covering more than the pending delta supersedes it.
-    assert.equal(coverageCovers({ langs: ["de", "en"], texts: [] }, base), true);
-    // A save missing the pending delta's language does not.
-    assert.equal(coverageCovers({ langs: ["en"], texts: [] }, base), false);
-    // texts: true covers any text list.
-    assert.equal(coverageCovers({ langs: ["de"], texts: true }, { langs: ["de"], texts: ["t1"] }), true);
-    assert.equal(coverageCovers({ langs: ["de"], texts: ["t1"] }, { langs: ["de"], texts: true }), false);
-    // Partial text coverage.
-    assert.equal(coverageCovers({ langs: ["de"], texts: ["t1", "t2"] }, { langs: ["de"], texts: ["t1"] }), true);
-    assert.equal(coverageCovers({ langs: ["de"], texts: ["t1"] }, { langs: ["de"], texts: ["t1", "t2"] }), false);
+    assert.equal(cleared, 1, "a cross-session delta must not be cleared by this session's saves");
   });
 
   it("coalesces a burst of completed book counters into one library render", async () => {

--- a/frontend-tests/shared/persistence-lifecycle.test.js
+++ b/frontend-tests/shared/persistence-lifecycle.test.js
@@ -238,7 +238,8 @@ describe("persistence lifecycle", () => {
           if (attempts === 1) await blockedSave;
           return {};
         },
-        saveSyncXhr() {}
+        saveSyncXhr() {},
+        clearPendingDelta() {}
       }
     }, {
       window: { __qtBridge: true, dispatchEvent() {} },
@@ -334,6 +335,34 @@ describe("persistence lifecycle", () => {
     assert.ok(harness.calls.includes("clear-pending"), "the pending flush is cleared on success");
   });
 
+  it("clears a stale pending delta once a newer save reaches the backend", async () => {
+    // Issue #137 class: a delta frozen at an earlier hidden event must never
+    // be replayed after a newer save succeeded — its frozen fullKeys would
+    // tombstone keys written in the meantime.
+    let cleared = 0;
+    const { createAutosave } = await evaluateWithMocks("../../dist/web/js/state/autosave.js", {
+      "../api.js": {
+        buildSavePayload: (state) => state,
+        buildDeltaSavePayload: (_raw, _langs, _texts) => ({ delta: true, fullKeys: [], records: {} }),
+        saveToLocalStorage() {},
+        async saveWithRetry() { return {}; },
+        saveSyncXhr() {},
+        clearPendingDelta() { cleared += 1; }
+      }
+    }, {
+      window: { __qtBridge: true, __bridgeState: {}, dispatchEvent() {} },
+      CustomEvent: class CustomEvent {},
+      setTimeout: () => 1,
+      clearTimeout() {},
+      console
+    });
+    const autosave = createAutosave(() => ({ preferences: {}, profiles: {} }));
+
+    await autosave.saveState();
+
+    assert.equal(cleared, 1, "a successful backend save supersedes the pending delta");
+  });
+
   it("coalesces a burst of completed book counters into one library render", async () => {
     const harness = await loadAppHarness();
 
@@ -409,7 +438,8 @@ describe("persistence lifecycle", () => {
           saveAttempts++;
           throw new Error("filesystem unavailable");
         },
-        saveSyncXhr() {}
+        saveSyncXhr() {},
+        clearPendingDelta() {}
       }
     }, {
       window,
@@ -451,7 +481,8 @@ describe("persistence lifecycle", () => {
         buildDeltaSavePayload: (_raw, _langs, _texts) => ({ delta: true, fullKeys: [], records: {} }),
         saveToLocalStorage() {},
         async saveWithRetry() { return {}; },
-        saveSyncXhr() {}
+        saveSyncXhr() {},
+        clearPendingDelta() {}
       }
     }, {
       window: { __qtBridge: false },
@@ -477,7 +508,8 @@ describe("persistence lifecycle", () => {
         buildDeltaSavePayload: (_raw, _langs, _texts) => ({ delta: true, fullKeys: [], records: {} }),
         saveToLocalStorage() { throw new DOMException("quota", "QuotaExceededError"); },
         async saveWithRetry() { return {}; },
-        saveSyncXhr() {}
+        saveSyncXhr() {},
+        clearPendingDelta() {}
       }
     }, {
       window: { __qtBridge: false },
@@ -509,7 +541,8 @@ describe("persistence lifecycle", () => {
         buildDeltaSavePayload: (_raw, _langs, _texts) => ({ delta: true, fullKeys: [], records: {} }),
         saveToLocalStorage() {},
         async saveWithRetry() { return {}; },
-        saveSyncXhr() {}
+        saveSyncXhr() {},
+        clearPendingDelta() {}
       }
     }, {
       window: { __qtBridge: true },
@@ -541,7 +574,8 @@ describe("persistence lifecycle", () => {
         buildDeltaSavePayload: (_raw, _langs, _texts) => ({ delta: true, fullKeys: [], records: {} }),
         saveToLocalStorage() {},
         async saveWithRetry() { return {}; },
-        saveSyncXhr() {}
+        saveSyncXhr() {},
+        clearPendingDelta() {}
       }
     }, {
       window: { __qtBridge: true },
@@ -568,7 +602,8 @@ describe("persistence lifecycle", () => {
         buildDeltaSavePayload: (_raw, _langs, _texts) => ({ delta: true, fullKeys: [], records: {} }),
         saveToLocalStorage: (payload) => { localStorageSaves.push(payload); },
         async saveWithRetry(body) { backendSaves.push(body); return {}; },
-        saveSyncXhr() {}
+        saveSyncXhr() {},
+        clearPendingDelta() {}
       }
     }, {
       window: { __qtBridge: true, __bridgeState: null },
@@ -594,7 +629,8 @@ describe("persistence lifecycle", () => {
         buildDeltaSavePayload: (_raw, _langs, _texts) => ({ delta: true, fullKeys: [], records: {} }),
         saveToLocalStorage: (payload) => { localStorageSaves.push(payload); },
         async saveWithRetry(body) { backendSaves.push(body); return {}; },
-        saveSyncXhr() {}
+        saveSyncXhr() {},
+        clearPendingDelta() {}
       }
     }, {
       window: { __qtBridge: true, __bridgeState: {} },
@@ -1076,7 +1112,8 @@ describe("persistence lifecycle", () => {
           savedThemes.push(JSON.parse(body).preferences.theme);
           return {};
         },
-        saveSyncXhr() { synchronousWrites += 1; }
+        saveSyncXhr() { synchronousWrites += 1; },
+        clearPendingDelta() {}
       }
     }, {
       window: { __qtBridge: true, dispatchEvent() {} },
@@ -1117,7 +1154,8 @@ describe("persistence lifecycle", () => {
           if (attempts > 1) throw new Error("post-import save failed");
           return {};
         },
-        saveSyncXhr() {}
+        saveSyncXhr() {},
+        clearPendingDelta() {}
       }
     }, {
       window: { __qtBridge: true, dispatchEvent() {} },
@@ -1512,7 +1550,8 @@ describe("persistence lifecycle", () => {
           }
           return {};
         },
-        saveSyncXhr() {}
+        saveSyncXhr() {},
+        clearPendingDelta() {}
       }
     }, {
       window: { __qtBridge: true, dispatchEvent() {} },
@@ -1541,7 +1580,8 @@ describe("persistence lifecycle", () => {
           attempts += 1;
           throw new TypeError("Failed to fetch");
         },
-        saveSyncXhr() {}
+        saveSyncXhr() {},
+        clearPendingDelta() {}
       }
     }, {
       window: { __qtBridge: true, dispatchEvent() {} },

--- a/frontend-tests/shared/persistence-lifecycle.test.js
+++ b/frontend-tests/shared/persistence-lifecycle.test.js
@@ -131,6 +131,10 @@ async function loadAppHarness({
       saveState() { calls.push("save-state"); return Promise.resolve(); },
       state
     },
+    "./js/api.js": {
+      buildSavePayload: () => "{}",
+      saveSyncXhr() { calls.push("keepalive-save"); }
+    },
     "./js/views/library.js": { bindLibraryEvents: noOp, renderLibrary: () => calls.push("render-library") },
     "./js/views/vocabulary.js": { renderReview: noOp, renderVocabulary: noOp },
     "./js/youglish.js": { refreshYouGlishTheme: noOp },

--- a/frontend-tests/shared/persistence-lifecycle.test.js
+++ b/frontend-tests/shared/persistence-lifecycle.test.js
@@ -73,7 +73,8 @@ async function loadAppHarness({
   loadLocale = async () => {},
   pendingDelta = null,
   hasPending = false,
-  deltaPayload = "{}"
+  deltaPayload = "{}",
+  deltaCoverage = { langs: [], texts: [] }
 } = {}) {
   const calls = [];
   const animationFrames = [];
@@ -96,6 +97,7 @@ async function loadAppHarness({
     flushPendingSave() { calls.push("flush-save"); },
     hasPendingChanges() { return hasPending; },
     buildPendingDeltaPayload() { calls.push("build-delta"); return deltaPayload; },
+    buildPendingDeltaCoverage() { calls.push("build-coverage"); return deltaCoverage; },
     open() {},
     requestAnimationFrame(callback) {
       assert.equal(this, window);
@@ -239,6 +241,8 @@ describe("persistence lifecycle", () => {
           return {};
         },
         saveSyncXhr() {},
+        readPendingDelta() { return null; },
+        coverageCovers: () => false,
         clearPendingDelta() {}
       }
     }, {
@@ -314,6 +318,7 @@ describe("persistence lifecycle", () => {
     assert.deepEqual(harness.calls, [
       "flush-buffers",
       "build-delta",
+      "build-coverage",
       'pending-flush:{"delta":true,"fullKeys":[]}'
     ]);
     assert.ok(
@@ -323,7 +328,9 @@ describe("persistence lifecycle", () => {
   });
 
   it("replays a pending Android teardown flush through the normal save path at boot", async () => {
-    const harness = await loadAppHarness({ pendingDelta: '{"delta":true,"fullKeys":[]}' });
+    const harness = await loadAppHarness({
+      pendingDelta: { coverage: { langs: [], texts: [] }, payload: '{"delta":true,"fullKeys":[]}' }
+    });
 
     await Promise.all(harness.document.emit("DOMContentLoaded"));
     await new Promise((resolve) => setTimeout(resolve, 0));
@@ -335,11 +342,14 @@ describe("persistence lifecycle", () => {
     assert.ok(harness.calls.includes("clear-pending"), "the pending flush is cleared on success");
   });
 
-  it("clears a stale pending delta once a newer save reaches the backend", async () => {
+  it("clears a stale pending delta once a newer save covers it — but not before", async () => {
     // Issue #137 class: a delta frozen at an earlier hidden event must never
-    // be replayed after a newer save succeeded — its frozen fullKeys would
-    // tombstone keys written in the meantime.
+    // be replayed after a newer save covered its content — its frozen
+    // fullKeys would tombstone keys written in the meantime. But a save whose
+    // payload did NOT cover the pending delta must not clear it either
+    // (that would drop the delta's mutations forever).
     let cleared = 0;
+    let pendingCoverage = { langs: [], texts: [] };
     const { createAutosave } = await evaluateWithMocks("../../dist/web/js/state/autosave.js", {
       "../api.js": {
         buildSavePayload: (state) => state,
@@ -347,6 +357,12 @@ describe("persistence lifecycle", () => {
         saveToLocalStorage() {},
         async saveWithRetry() { return {}; },
         saveSyncXhr() {},
+        readPendingDelta() {
+          return { coverage: pendingCoverage, payload: "{}" };
+        },
+        coverageCovers(save, pending) {
+          return pending.langs.every((lang) => save.langs.includes(lang));
+        },
         clearPendingDelta() { cleared += 1; }
       }
     }, {
@@ -358,9 +374,41 @@ describe("persistence lifecycle", () => {
     });
     const autosave = createAutosave(() => ({ preferences: {}, profiles: {} }));
 
+    // Save with empty coverage covers an empty pending delta → cleared.
     await autosave.saveState();
+    assert.equal(cleared, 1, "a covering save supersedes the pending delta");
 
-    assert.equal(cleared, 1, "a successful backend save supersedes the pending delta");
+    // A pending delta covering a language the save did not touch stays.
+    pendingCoverage = { langs: ["de"], texts: [] };
+    await autosave.saveState();
+    assert.equal(cleared, 1, "a non-covering save must not clear the pending delta");
+  });
+
+  it("coverageCovers decides whether a save supersedes the pending delta", async () => {
+    const api = await evaluateWithMocks("../../dist/web/js/api.js", {
+      "./constants.js": { STATE_SCHEMA_VERSION: 2, STORAGE_KEY: "wordhunter-state" },
+      "./request.js": { fetchWithTimeout: async () => ({ ok: true, json: async () => ({}) }) }
+    }, {
+      window: { WH_TOKEN: "test-token" },
+      fetch: async () => ({ ok: true, json: async () => ({}) }),
+      localStorage: { getItem: () => null, setItem() {}, removeItem() {} },
+      setTimeout,
+      clearTimeout,
+      console
+    });
+
+    const { coverageCovers } = api;
+    const base = { langs: ["de"], texts: [] };
+    // A save covering more than the pending delta supersedes it.
+    assert.equal(coverageCovers({ langs: ["de", "en"], texts: [] }, base), true);
+    // A save missing the pending delta's language does not.
+    assert.equal(coverageCovers({ langs: ["en"], texts: [] }, base), false);
+    // texts: true covers any text list.
+    assert.equal(coverageCovers({ langs: ["de"], texts: true }, { langs: ["de"], texts: ["t1"] }), true);
+    assert.equal(coverageCovers({ langs: ["de"], texts: ["t1"] }, { langs: ["de"], texts: true }), false);
+    // Partial text coverage.
+    assert.equal(coverageCovers({ langs: ["de"], texts: ["t1", "t2"] }, { langs: ["de"], texts: ["t1"] }), true);
+    assert.equal(coverageCovers({ langs: ["de"], texts: ["t1"] }, { langs: ["de"], texts: ["t1", "t2"] }), false);
   });
 
   it("coalesces a burst of completed book counters into one library render", async () => {
@@ -439,6 +487,8 @@ describe("persistence lifecycle", () => {
           throw new Error("filesystem unavailable");
         },
         saveSyncXhr() {},
+        readPendingDelta() { return null; },
+        coverageCovers: () => false,
         clearPendingDelta() {}
       }
     }, {
@@ -482,6 +532,8 @@ describe("persistence lifecycle", () => {
         saveToLocalStorage() {},
         async saveWithRetry() { return {}; },
         saveSyncXhr() {},
+        readPendingDelta() { return null; },
+        coverageCovers: () => false,
         clearPendingDelta() {}
       }
     }, {
@@ -509,6 +561,8 @@ describe("persistence lifecycle", () => {
         saveToLocalStorage() { throw new DOMException("quota", "QuotaExceededError"); },
         async saveWithRetry() { return {}; },
         saveSyncXhr() {},
+        readPendingDelta() { return null; },
+        coverageCovers: () => false,
         clearPendingDelta() {}
       }
     }, {
@@ -542,6 +596,8 @@ describe("persistence lifecycle", () => {
         saveToLocalStorage() {},
         async saveWithRetry() { return {}; },
         saveSyncXhr() {},
+        readPendingDelta() { return null; },
+        coverageCovers: () => false,
         clearPendingDelta() {}
       }
     }, {
@@ -575,6 +631,8 @@ describe("persistence lifecycle", () => {
         saveToLocalStorage() {},
         async saveWithRetry() { return {}; },
         saveSyncXhr() {},
+        readPendingDelta() { return null; },
+        coverageCovers: () => false,
         clearPendingDelta() {}
       }
     }, {
@@ -603,6 +661,8 @@ describe("persistence lifecycle", () => {
         saveToLocalStorage: (payload) => { localStorageSaves.push(payload); },
         async saveWithRetry(body) { backendSaves.push(body); return {}; },
         saveSyncXhr() {},
+        readPendingDelta() { return null; },
+        coverageCovers: () => false,
         clearPendingDelta() {}
       }
     }, {
@@ -630,6 +690,8 @@ describe("persistence lifecycle", () => {
         saveToLocalStorage: (payload) => { localStorageSaves.push(payload); },
         async saveWithRetry(body) { backendSaves.push(body); return {}; },
         saveSyncXhr() {},
+        readPendingDelta() { return null; },
+        coverageCovers: () => false,
         clearPendingDelta() {}
       }
     }, {
@@ -1113,6 +1175,8 @@ describe("persistence lifecycle", () => {
           return {};
         },
         saveSyncXhr() { synchronousWrites += 1; },
+        readPendingDelta() { return null; },
+        coverageCovers: () => false,
         clearPendingDelta() {}
       }
     }, {
@@ -1155,6 +1219,8 @@ describe("persistence lifecycle", () => {
           return {};
         },
         saveSyncXhr() {},
+        readPendingDelta() { return null; },
+        coverageCovers: () => false,
         clearPendingDelta() {}
       }
     }, {
@@ -1551,6 +1617,8 @@ describe("persistence lifecycle", () => {
           return {};
         },
         saveSyncXhr() {},
+        readPendingDelta() { return null; },
+        coverageCovers: () => false,
         clearPendingDelta() {}
       }
     }, {
@@ -1581,6 +1649,8 @@ describe("persistence lifecycle", () => {
           throw new TypeError("Failed to fetch");
         },
         saveSyncXhr() {},
+        readPendingDelta() { return null; },
+        coverageCovers: () => false,
         clearPendingDelta() {}
       }
     }, {

--- a/frontend-tests/shared/persistence-lifecycle.test.js
+++ b/frontend-tests/shared/persistence-lifecycle.test.js
@@ -70,7 +70,10 @@ async function loadAppHarness({
   hydrateActiveLibraryTexts = async () => {},
   hydrateCurrentReaderText = async () => true,
   loadBooksCatalog = async () => {},
-  loadLocale = async () => {}
+  loadLocale = async () => {},
+  pendingDelta = null,
+  hasPending = false,
+  deltaPayload = "{}"
 } = {}) {
   const calls = [];
   const animationFrames = [];
@@ -91,6 +94,8 @@ async function loadAppHarness({
   const window = fakeEventTarget({
     __qtBridge: false,
     flushPendingSave() { calls.push("flush-save"); },
+    hasPendingChanges() { return hasPending; },
+    buildPendingDeltaPayload() { calls.push("build-delta"); return deltaPayload; },
     open() {},
     requestAnimationFrame(callback) {
       assert.equal(this, window);
@@ -133,7 +138,11 @@ async function loadAppHarness({
     },
     "./js/api.js": {
       buildSavePayload: () => "{}",
-      saveSyncXhr() { calls.push("keepalive-save"); }
+      saveSyncXhr() { calls.push("keepalive-save"); },
+      flushPendingDeltaToLocalStorage(payload) { calls.push(`pending-flush:${payload}`); },
+      readPendingDelta() { return pendingDelta; },
+      clearPendingDelta() { calls.push("clear-pending"); },
+      saveWithRetry(body) { calls.push(`replay:${body}`); return Promise.resolve({ ok: true }); }
     },
     "./js/views/library.js": { bindLibraryEvents: noOp, renderLibrary: () => calls.push("render-library") },
     "./js/views/vocabulary.js": { renderReview: noOp, renderVocabulary: noOp },
@@ -289,6 +298,40 @@ describe("persistence lifecycle", () => {
     assert.deepEqual(harness.calls.splice(0), []);
     harness.document.emit("visibilitychange");
     assert.deepEqual(harness.calls.splice(0), []);
+  });
+
+  it("persists the Android teardown flush to localStorage instead of a keepalive fetch", async () => {
+    // Issue #137: keepalive fetches are capped at 64 KiB while the real save
+    // payload is multi-MB, so the final mutations were silently dropped on
+    // every Android activity finish. The flush must go to localStorage
+    // synchronously and must not rely on a keepalive fetch.
+    const harness = await loadAppHarness({ hasPending: true, deltaPayload: '{"delta":true,"fullKeys":[]}' });
+    harness.setAndroid(true);
+
+    harness.window.emit("pagehide");
+
+    assert.deepEqual(harness.calls, [
+      "flush-buffers",
+      "build-delta",
+      'pending-flush:{"delta":true,"fullKeys":[]}'
+    ]);
+    assert.ok(
+      !harness.calls.includes("keepalive-save"),
+      "the multi-MB payload must not go through a keepalive fetch"
+    );
+  });
+
+  it("replays a pending Android teardown flush through the normal save path at boot", async () => {
+    const harness = await loadAppHarness({ pendingDelta: '{"delta":true,"fullKeys":[]}' });
+
+    await Promise.all(harness.document.emit("DOMContentLoaded"));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    assert.ok(
+      harness.calls.includes('replay:{"delta":true,"fullKeys":[]}'),
+      "the pending delta is replayed through the normal save path"
+    );
+    assert.ok(harness.calls.includes("clear-pending"), "the pending flush is cleared on success");
   });
 
   it("coalesces a burst of completed book counters into one library render", async () => {

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -71,10 +71,7 @@ function flushPendingStateBeforeExit() {
     // localStorage synchronously instead; the next boot replays it through
     // the normal save path (recoverPendingFlush).
     if (typeof window.hasPendingChanges === "function" && window.hasPendingChanges()) {
-      flushPendingDeltaToLocalStorage(
-        window.buildPendingDeltaPayload(),
-        window.buildPendingDeltaCoverage(),
-      );
+      flushPendingDeltaToLocalStorage(window.buildPendingDeltaEnvelope());
     }
     return;
   }

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -71,7 +71,10 @@ function flushPendingStateBeforeExit() {
     // localStorage synchronously instead; the next boot replays it through
     // the normal save path (recoverPendingFlush).
     if (typeof window.hasPendingChanges === "function" && window.hasPendingChanges()) {
-      flushPendingDeltaToLocalStorage(window.buildPendingDeltaPayload());
+      flushPendingDeltaToLocalStorage(
+        window.buildPendingDeltaPayload(),
+        window.buildPendingDeltaCoverage(),
+      );
     }
     return;
   }
@@ -85,7 +88,7 @@ function recoverPendingFlush(): void {
   const pending = readPendingDelta();
   if (pending === null) return;
   const replay = () => {
-    saveWithRetry(pending, 3)
+    saveWithRetry(pending.payload, 3)
       .then(() => clearPendingDelta())
       .catch((error) => console.error("pending-flush replay failed; will retry next boot", error));
   };

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -7,7 +7,7 @@ import { hydrateCurrentReaderText, loadBooksCatalog } from "./js/books.js";
 import { render, ensureCurrentText } from "./js/render.js";
 import { loadLocale, applyTranslations, t, getLocale, initialLocale } from "./js/i18n.js";
 import { applyBridgeSnapshotToState, flushFrontendStateBuffers, flushUiStateSync, saveState, state } from "./js/state.js";
-import { buildSavePayload, saveSyncXhr } from "./js/api.js";
+import { clearPendingDelta, flushPendingDeltaToLocalStorage, readPendingDelta, saveWithRetry } from "./js/api.js";
 import { bindLibraryEvents, renderLibrary } from "./js/views/library.js";
 import { renderReview, renderVocabulary } from "./js/views/vocabulary.js";
 import { applyPlatformUi, detectPlatform, isAndroidPlatform, openAndroidUrl } from "./js/platform.js";
@@ -65,13 +65,35 @@ function flushPendingStateBeforeExit() {
   flushFrontendStateBuffers();
   flushUiStateSync();
   if (isAndroidPlatform()) {
-    // The webview is being torn down: an ordinary async fetch is dropped
-    // mid-flight. saveSyncXhr uses keepalive so the final state reaches
-    // the backend even when the activity finishes right after this handler.
-    saveSyncXhr(JSON.stringify(buildSavePayload(state)));
+    // The webview is being torn down: keepalive fetches are capped at 64 KiB
+    // while the real save payload is multi-MB, so the final mutations could
+    // never reach the backend (issue #137). Persist the save delta to
+    // localStorage synchronously instead; the next boot replays it through
+    // the normal save path (recoverPendingFlush).
+    if (typeof window.hasPendingChanges === "function" && window.hasPendingChanges()) {
+      flushPendingDeltaToLocalStorage(window.buildPendingDeltaPayload());
+    }
     return;
   }
   if (typeof window.flushPendingSave === "function") window.flushPendingSave();
+}
+
+// Replay a pending Android teardown flush into the backend once the boot
+// snapshot has been applied (or after the load failed — the delta in
+// localStorage may then be the only copy of the last mutations).
+function recoverPendingFlush(): void {
+  const pending = readPendingDelta();
+  if (pending === null) return;
+  const replay = () => {
+    saveWithRetry(pending, 3)
+      .then(() => clearPendingDelta())
+      .catch((error) => console.error("pending-flush replay failed; will retry next boot", error));
+  };
+  if (window.__bridgeStatePromise) {
+    void window.__bridgeStatePromise.then(replay, replay);
+  } else {
+    replay();
+  }
 }
 
 window.addEventListener("beforeunload", flushPendingStateBeforeExit);
@@ -185,6 +207,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   try {
     cacheElements();
     startBridgeStateLoad();
+    recoverPendingFlush();
     await Promise.all([
       applyPreferences(),
       loadLocale(initialLocale(state.preferences?.locale, typeof navigator !== "undefined" ? navigator.language : "")),

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -7,6 +7,7 @@ import { hydrateCurrentReaderText, loadBooksCatalog } from "./js/books.js";
 import { render, ensureCurrentText } from "./js/render.js";
 import { loadLocale, applyTranslations, t, getLocale, initialLocale } from "./js/i18n.js";
 import { applyBridgeSnapshotToState, flushFrontendStateBuffers, flushUiStateSync, saveState, state } from "./js/state.js";
+import { buildSavePayload, saveSyncXhr } from "./js/api.js";
 import { bindLibraryEvents, renderLibrary } from "./js/views/library.js";
 import { renderReview, renderVocabulary } from "./js/views/vocabulary.js";
 import { applyPlatformUi, detectPlatform, isAndroidPlatform, openAndroidUrl } from "./js/platform.js";
@@ -64,7 +65,10 @@ function flushPendingStateBeforeExit() {
   flushFrontendStateBuffers();
   flushUiStateSync();
   if (isAndroidPlatform()) {
-    saveState();
+    // The webview is being torn down: an ordinary async fetch is dropped
+    // mid-flight. saveSyncXhr uses keepalive so the final state reaches
+    // the backend even when the activity finishes right after this handler.
+    saveSyncXhr(JSON.stringify(buildSavePayload(state)));
     return;
   }
   if (typeof window.flushPendingSave === "function") window.flushPendingSave();

--- a/src/web/js/api.ts
+++ b/src/web/js/api.ts
@@ -123,26 +123,25 @@ export function saveToLocalStorage(rawState: WhSaveStateInput): void {
 // every activity finish (issue #137). Instead the exit flush persists the
 // save *delta* (a few MB at most, well inside the localStorage quota) under a
 // dedicated key; the next boot replays it through the normal save path.
-// The envelope stores the delta's *coverage* (which languages and texts it
-// carries) so a later successful save can decide whether it truly supersedes
-// the pending delta before clearing it.
+// The envelope carries the mutation *sequence* of the session that froze the
+// delta, so a later save can decide whether it truly supersedes the pending
+// delta (payload built at sequence >= the delta's sequence covers its
+// content) before clearing it. A delta from a previous session is cleared
+// only by a successful replay — a fresh session's saves never contain its
+// mutations.
 const PENDING_FLUSH_KEY = "wordhunter.pendingFlush.v1";
 
-export interface DeltaCoverage {
-  langs: string[];
-  /** `true` means every text is covered. */
-  texts: true | string[];
-}
-
 export interface PendingDelta {
-  coverage: DeltaCoverage;
   payload: string;
+  /** Autosave session that froze this delta (module-load id). */
+  session: string;
+  /** Mutation sequence of that session at freeze time. */
+  sequence: number;
 }
 
-export function flushPendingDeltaToLocalStorage(payload: string, coverage: DeltaCoverage): void {
-  const envelope: PendingDelta = { coverage, payload };
+export function flushPendingDeltaToLocalStorage(delta: PendingDelta): void {
   try {
-    localStorage.setItem(PENDING_FLUSH_KEY, JSON.stringify(envelope));
+    localStorage.setItem(PENDING_FLUSH_KEY, JSON.stringify(delta));
   } catch (e) {
     console.error("pending-flush localStorage write failed", e);
   }
@@ -169,21 +168,6 @@ export function clearPendingDelta(): void {
   } catch (e) {
     console.error("pending-flush localStorage clear failed", e);
   }
-}
-
-/**
- * True when the coverage of a completed save includes everything the pending
- * delta holds — only then may the pending delta be cleared (its mutations
- * reached the backend with this save). A save whose payload was built before
- * the delta was frozen does not cover it.
- */
-export function coverageCovers(save: DeltaCoverage, pending: DeltaCoverage): boolean {
-  if (!pending.langs.every((lang) => save.langs.includes(lang))) return false;
-  if (pending.texts === true) return save.texts === true;
-  if (save.texts === true) return true;
-  const saveTexts: string[] = save.texts;
-  const pendingTexts: string[] = pending.texts;
-  return pendingTexts.every((id) => saveTexts.includes(id));
 }
 
 /** POST the payload to the backend bridge with retry. */

--- a/src/web/js/api.ts
+++ b/src/web/js/api.ts
@@ -123,20 +123,39 @@ export function saveToLocalStorage(rawState: WhSaveStateInput): void {
 // every activity finish (issue #137). Instead the exit flush persists the
 // save *delta* (a few MB at most, well inside the localStorage quota) under a
 // dedicated key; the next boot replays it through the normal save path.
+// The envelope stores the delta's *coverage* (which languages and texts it
+// carries) so a later successful save can decide whether it truly supersedes
+// the pending delta before clearing it.
 const PENDING_FLUSH_KEY = "wordhunter.pendingFlush.v1";
 
-export function flushPendingDeltaToLocalStorage(payload: string): void {
+export interface DeltaCoverage {
+  langs: string[];
+  /** `true` means every text is covered. */
+  texts: true | string[];
+}
+
+export interface PendingDelta {
+  coverage: DeltaCoverage;
+  payload: string;
+}
+
+export function flushPendingDeltaToLocalStorage(payload: string, coverage: DeltaCoverage): void {
+  const envelope: PendingDelta = { coverage, payload };
   try {
-    localStorage.setItem(PENDING_FLUSH_KEY, payload);
+    localStorage.setItem(PENDING_FLUSH_KEY, JSON.stringify(envelope));
   } catch (e) {
     console.error("pending-flush localStorage write failed", e);
   }
 }
 
 /** Peek at a pending flush left by a previous teardown (null when absent). */
-export function readPendingDelta(): string | null {
+export function readPendingDelta(): PendingDelta | null {
   try {
-    return localStorage.getItem(PENDING_FLUSH_KEY);
+    const raw = localStorage.getItem(PENDING_FLUSH_KEY);
+    if (raw === null) return null;
+    const parsed = JSON.parse(raw) as PendingDelta;
+    if (typeof parsed?.payload !== "string") return null;
+    return parsed;
   } catch (e) {
     console.error("pending-flush localStorage read failed", e);
     return null;
@@ -150,6 +169,21 @@ export function clearPendingDelta(): void {
   } catch (e) {
     console.error("pending-flush localStorage clear failed", e);
   }
+}
+
+/**
+ * True when the coverage of a completed save includes everything the pending
+ * delta holds — only then may the pending delta be cleared (its mutations
+ * reached the backend with this save). A save whose payload was built before
+ * the delta was frozen does not cover it.
+ */
+export function coverageCovers(save: DeltaCoverage, pending: DeltaCoverage): boolean {
+  if (!pending.langs.every((lang) => save.langs.includes(lang))) return false;
+  if (pending.texts === true) return save.texts === true;
+  if (save.texts === true) return true;
+  const saveTexts: string[] = save.texts;
+  const pendingTexts: string[] = pending.texts;
+  return pendingTexts.every((id) => saveTexts.includes(id));
 }
 
 /** POST the payload to the backend bridge with retry. */

--- a/src/web/js/api.ts
+++ b/src/web/js/api.ts
@@ -118,6 +118,40 @@ export function saveToLocalStorage(rawState: WhSaveStateInput): void {
   }
 }
 
+// Android teardown flush: the keepalive fetch is capped at 64 KiB while the
+// real state is multi-MB, so the final mutations were silently dropped on
+// every activity finish (issue #137). Instead the exit flush persists the
+// save *delta* (a few MB at most, well inside the localStorage quota) under a
+// dedicated key; the next boot replays it through the normal save path.
+const PENDING_FLUSH_KEY = "wordhunter.pendingFlush.v1";
+
+export function flushPendingDeltaToLocalStorage(payload: string): void {
+  try {
+    localStorage.setItem(PENDING_FLUSH_KEY, payload);
+  } catch (e) {
+    console.error("pending-flush localStorage write failed", e);
+  }
+}
+
+/** Peek at a pending flush left by a previous teardown (null when absent). */
+export function readPendingDelta(): string | null {
+  try {
+    return localStorage.getItem(PENDING_FLUSH_KEY);
+  } catch (e) {
+    console.error("pending-flush localStorage read failed", e);
+    return null;
+  }
+}
+
+/** Drop the pending flush once it has been replayed into the backend. */
+export function clearPendingDelta(): void {
+  try {
+    localStorage.removeItem(PENDING_FLUSH_KEY);
+  } catch (e) {
+    console.error("pending-flush localStorage clear failed", e);
+  }
+}
+
 /** POST the payload to the backend bridge with retry. */
 export async function saveWithRetry(body: string, maxRetries: number): Promise<WhBridgeSaveResult> {
   for (let attempt = 0; attempt <= maxRetries; attempt++) {

--- a/src/web/js/state.ts
+++ b/src/web/js/state.ts
@@ -268,15 +268,10 @@ function flushPendingSave(): void {
 }
 window.flushPendingSave = flushPendingSave;
 
-function buildPendingDeltaPayload(): string {
-  return autosave.buildPendingDeltaPayload();
+function buildPendingDeltaEnvelope() {
+  return autosave.buildPendingDeltaEnvelope();
 }
-window.buildPendingDeltaPayload = buildPendingDeltaPayload;
-
-function buildPendingDeltaCoverage() {
-  return autosave.buildPendingDeltaCoverage();
-}
-window.buildPendingDeltaCoverage = buildPendingDeltaCoverage;
+window.buildPendingDeltaEnvelope = buildPendingDeltaEnvelope;
 
 function hasPendingChanges(): boolean {
   return autosave.hasPendingChanges();

--- a/src/web/js/state.ts
+++ b/src/web/js/state.ts
@@ -268,6 +268,16 @@ function flushPendingSave(): void {
 }
 window.flushPendingSave = flushPendingSave;
 
+function buildPendingDeltaPayload(): string {
+  return autosave.buildPendingDeltaPayload();
+}
+window.buildPendingDeltaPayload = buildPendingDeltaPayload;
+
+function hasPendingChanges(): boolean {
+  return autosave.hasPendingChanges();
+}
+window.hasPendingChanges = hasPendingChanges;
+
 export function resetInitialVocabKeys(): void {
   initialVocabKeys.clear();
   Object.keys(state.vocab || {}).forEach((key) => initialVocabKeys.add(key));

--- a/src/web/js/state.ts
+++ b/src/web/js/state.ts
@@ -273,6 +273,11 @@ function buildPendingDeltaPayload(): string {
 }
 window.buildPendingDeltaPayload = buildPendingDeltaPayload;
 
+function buildPendingDeltaCoverage() {
+  return autosave.buildPendingDeltaCoverage();
+}
+window.buildPendingDeltaCoverage = buildPendingDeltaCoverage;
+
 function hasPendingChanges(): boolean {
   return autosave.hasPendingChanges();
 }

--- a/src/web/js/state/autosave.ts
+++ b/src/web/js/state/autosave.ts
@@ -1,4 +1,4 @@
-import { buildDeltaSavePayload, buildSavePayload, clearPendingDelta, coverageCovers, readPendingDelta, saveToLocalStorage, saveWithRetry, saveSyncXhr, type DeltaCoverage } from "../api.js";
+import { buildDeltaSavePayload, buildSavePayload, clearPendingDelta, readPendingDelta, saveToLocalStorage, saveWithRetry, saveSyncXhr, type PendingDelta } from "../api.js";
 
 type SaveResult = WhBridgeSaveResult | void;
 
@@ -45,6 +45,10 @@ export function createAutosave(getState: () => WhAppState) {
   let vocabularyRevision = 0;
   let mutationSequence = 0;
   let saveStartedMutationSequence = 0;
+  // Identity of this autosave session: the pending teardown delta is cleared
+  // by a later save only when both come from the same session (cross-session
+  // deltas are delivered exclusively by the boot replay).
+  const AUTOSAVE_SESSION = `wh-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
   let lastMutationAt = 0;
   let lastSaveSucceededAt = 0;
   // Incremental-save dirty tracking: which languages changed vocab (sent in
@@ -149,13 +153,19 @@ export function createAutosave(getState: () => WhAppState) {
       dirtyTextIds.clear();
       allTextsDirty = false;
       // A successful backend write makes the pending teardown delta redundant
-      // — but only when this save's payload actually covered everything the
-      // delta holds. A save that started before the delta was frozen does NOT
-      // cover it; clearing then would drop the delta's mutations forever
-      // (issue #137 class). The guarded clear keeps the stale-delta fix while
-      // preserving the in-flight-save case for the boot replay.
+      // — but only when this save's payload was built AFTER the delta was
+      // frozen in this same session: then its full-per-language snapshots
+      // necessarily contain every mutation the delta holds. A save built
+      // before the freeze (in-flight at hidden time) does NOT cover it, and a
+      // save from a later session never contains its mutations at all —
+      // clearing in either case would drop the delta's mutations forever
+      // (issue #137 class). A surviving cross-session delta is delivered by
+      // the boot replay, which clears it on its own success.
       const pending = readPendingDelta();
-      if (pending !== null && coverageCovers(payloadCoverage, pending.coverage)) {
+      if (pending !== null
+        && pending.session === AUTOSAVE_SESSION
+        && payloadHasRecords
+        && payloadSequence >= pending.sequence) {
         clearPendingDelta();
       }
       saveInFlight = false;
@@ -165,13 +175,14 @@ export function createAutosave(getState: () => WhAppState) {
       }
       return result;
     };
-    // Snapshot the coverage of this payload at build time (not the live dirty
-    // sets — markSucceeded clears them, and the guard needs the coverage of
-    // exactly what this save delivered).
-    const payloadCoverage: DeltaCoverage = {
-      langs: [...dirtyVocabLangs],
-      texts: allTextsDirty ? true : [...dirtyTextIds]
-    };
+    // Snapshot the mutation sequence of this payload at build time — a save
+    // built at sequence N necessarily contains every mutation up to N, which
+    // is the guarantee the pending-delta clear guard relies on.
+    const payloadSequence = mutationSequence;
+    // The save-pending follow-up (a save re-run right after markSucceeded
+    // cleared the dirty sets) builds an EMPTY payload: it carries no records,
+    // so it must not be allowed to clear the pending delta either.
+    const payloadHasRecords = dirtyVocabLangs.size > 0 || dirtyTextIds.size > 0 || allTextsDirty;
     const payload = buildDeltaSavePayload(current, dirtyVocabLangs, allTextsDirty ? true : dirtyTextIds);
     savePromise = saveWithRetry(JSON.stringify(payload), 3).then(markSucceeded).catch(async (error) => {
       // The backend may reject a delta payload (validation edge or an older
@@ -411,18 +422,14 @@ export function createAutosave(getState: () => WhAppState) {
     // Synchronous serialization of the save delta for the Android teardown
     // flush (see flushPendingDeltaToLocalStorage): reuses the same dirty
     // tracking as doSave so the replayed payload merges cleanly on next boot.
-    buildPendingDeltaPayload(): string {
+    buildPendingDeltaEnvelope(): PendingDelta {
       const current = rawState();
-      return JSON.stringify(
-        buildDeltaSavePayload(current, dirtyVocabLangs, allTextsDirty ? true : dirtyTextIds),
-      );
-    },
-    // Coverage of the pending delta, stored alongside it so a later save can
-    // decide whether it supersedes the pending copy (see coverageCovers).
-    buildPendingDeltaCoverage(): DeltaCoverage {
       return {
-        langs: [...dirtyVocabLangs],
-        texts: allTextsDirty ? true : [...dirtyTextIds]
+        payload: JSON.stringify(
+          buildDeltaSavePayload(current, dirtyVocabLangs, allTextsDirty ? true : dirtyTextIds),
+        ),
+        session: AUTOSAVE_SESSION,
+        sequence: mutationSequence
       };
     },
     hasPendingChanges,

--- a/src/web/js/state/autosave.ts
+++ b/src/web/js/state/autosave.ts
@@ -391,6 +391,15 @@ export function createAutosave(getState: () => WhAppState) {
       else if (window.__qtBridge) saveSyncXhr(JSON.stringify(buildSavePayload(current)));
       else saveToLocalStorage(current);
     },
+    // Synchronous serialization of the save delta for the Android teardown
+    // flush (see flushPendingDeltaToLocalStorage): reuses the same dirty
+    // tracking as doSave so the replayed payload merges cleanly on next boot.
+    buildPendingDeltaPayload(): string {
+      const current = rawState();
+      return JSON.stringify(
+        buildDeltaSavePayload(current, dirtyVocabLangs, allTextsDirty ? true : dirtyTextIds),
+      );
+    },
     hasPendingChanges,
     withoutAutoSave<T>(callback: () => T): T {
       suspendAutoSave++;

--- a/src/web/js/state/autosave.ts
+++ b/src/web/js/state/autosave.ts
@@ -1,4 +1,4 @@
-import { buildDeltaSavePayload, buildSavePayload, clearPendingDelta, saveToLocalStorage, saveWithRetry, saveSyncXhr } from "../api.js";
+import { buildDeltaSavePayload, buildSavePayload, clearPendingDelta, coverageCovers, readPendingDelta, saveToLocalStorage, saveWithRetry, saveSyncXhr, type DeltaCoverage } from "../api.js";
 
 type SaveResult = WhBridgeSaveResult | void;
 
@@ -148,17 +148,29 @@ export function createAutosave(getState: () => WhAppState) {
       dirtyVocabLangs.clear();
       dirtyTextIds.clear();
       allTextsDirty = false;
-      // A successful backend write covers everything the pending teardown
-      // delta holds (its mutations are still in the live state), so the
-      // pending copy is now redundant — and replaying it on a later boot
-      // could tombstone keys written after it was frozen (issue #137 class).
-      clearPendingDelta();
+      // A successful backend write makes the pending teardown delta redundant
+      // — but only when this save's payload actually covered everything the
+      // delta holds. A save that started before the delta was frozen does NOT
+      // cover it; clearing then would drop the delta's mutations forever
+      // (issue #137 class). The guarded clear keeps the stale-delta fix while
+      // preserving the in-flight-save case for the boot replay.
+      const pending = readPendingDelta();
+      if (pending !== null && coverageCovers(payloadCoverage, pending.coverage)) {
+        clearPendingDelta();
+      }
       saveInFlight = false;
       if (savePending) {
         savePending = false;
         return doSave();
       }
       return result;
+    };
+    // Snapshot the coverage of this payload at build time (not the live dirty
+    // sets — markSucceeded clears them, and the guard needs the coverage of
+    // exactly what this save delivered).
+    const payloadCoverage: DeltaCoverage = {
+      langs: [...dirtyVocabLangs],
+      texts: allTextsDirty ? true : [...dirtyTextIds]
     };
     const payload = buildDeltaSavePayload(current, dirtyVocabLangs, allTextsDirty ? true : dirtyTextIds);
     savePromise = saveWithRetry(JSON.stringify(payload), 3).then(markSucceeded).catch(async (error) => {
@@ -404,6 +416,14 @@ export function createAutosave(getState: () => WhAppState) {
       return JSON.stringify(
         buildDeltaSavePayload(current, dirtyVocabLangs, allTextsDirty ? true : dirtyTextIds),
       );
+    },
+    // Coverage of the pending delta, stored alongside it so a later save can
+    // decide whether it supersedes the pending copy (see coverageCovers).
+    buildPendingDeltaCoverage(): DeltaCoverage {
+      return {
+        langs: [...dirtyVocabLangs],
+        texts: allTextsDirty ? true : [...dirtyTextIds]
+      };
     },
     hasPendingChanges,
     withoutAutoSave<T>(callback: () => T): T {

--- a/src/web/js/state/autosave.ts
+++ b/src/web/js/state/autosave.ts
@@ -1,4 +1,4 @@
-import { buildDeltaSavePayload, buildSavePayload, saveToLocalStorage, saveWithRetry, saveSyncXhr } from "../api.js";
+import { buildDeltaSavePayload, buildSavePayload, clearPendingDelta, saveToLocalStorage, saveWithRetry, saveSyncXhr } from "../api.js";
 
 type SaveResult = WhBridgeSaveResult | void;
 
@@ -148,6 +148,11 @@ export function createAutosave(getState: () => WhAppState) {
       dirtyVocabLangs.clear();
       dirtyTextIds.clear();
       allTextsDirty = false;
+      // A successful backend write covers everything the pending teardown
+      // delta holds (its mutations are still in the live state), so the
+      // pending copy is now redundant — and replaying it on a later boot
+      // could tombstone keys written after it was frozen (issue #137 class).
+      clearPendingDelta();
       saveInFlight = false;
       if (savePending) {
         savePending = false;

--- a/types/wordhunter-browser.d.ts
+++ b/types/wordhunter-browser.d.ts
@@ -526,6 +526,7 @@ interface WhDomCache {
     WordHunterAndroid?: WhAndroidBridge;
     flushPendingSave?: () => void;
     buildPendingDeltaPayload?: () => string;
+    buildPendingDeltaCoverage?: () => { langs: string[]; texts: true | string[] };
     hasPendingChanges?: () => boolean;
     flushAllPendingFrontendState?: () => Promise<void>;
     requestWordHunterClose?: () => void;

--- a/types/wordhunter-browser.d.ts
+++ b/types/wordhunter-browser.d.ts
@@ -525,8 +525,7 @@ interface WhDomCache {
     __bridgeStatePromise?: Promise<WhBridgeSnapshot>;
     WordHunterAndroid?: WhAndroidBridge;
     flushPendingSave?: () => void;
-    buildPendingDeltaPayload?: () => string;
-    buildPendingDeltaCoverage?: () => { langs: string[]; texts: true | string[] };
+    buildPendingDeltaEnvelope?: () => { payload: string; session: string; sequence: number };
     hasPendingChanges?: () => boolean;
     flushAllPendingFrontendState?: () => Promise<void>;
     requestWordHunterClose?: () => void;

--- a/types/wordhunter-browser.d.ts
+++ b/types/wordhunter-browser.d.ts
@@ -525,6 +525,8 @@ interface WhDomCache {
     __bridgeStatePromise?: Promise<WhBridgeSnapshot>;
     WordHunterAndroid?: WhAndroidBridge;
     flushPendingSave?: () => void;
+    buildPendingDeltaPayload?: () => string;
+    hasPendingChanges?: () => boolean;
     flushAllPendingFrontendState?: () => Promise<void>;
     requestWordHunterClose?: () => void;
     flushWordFieldSave?: () => void;


### PR DESCRIPTION
Closes #137 (exit-flush item)

**Audit verdict:** CONFIRMED (wave-8: plain async saveState on exit; webview teardown drops it).

**Fix:** saveSyncXhr (keepalive) on the Android exit path.

**Verification:** check:frontend 0; 465/465 tests (harness api.js mock added).