### PR TITLE
Fix #139: portable Android version bump (F-Droid, Linux CI)

### DIFF
--- a/.github/workflows/artifact-validation.yml
+++ b/.github/workflows/artifact-validation.yml
@@ -142,6 +142,9 @@ jobs:
           node scripts/inspect-artifact.mjs android outputs/Word.Hunter.Pocket.release.apk --abi arm64-v8a
           node scripts/inspect-artifact.mjs android outputs/Word.Hunter.Pocket.release.aab --abi arm64-v8a
 
+      - name: Verify on-disk gradle version identity
+        run: node scripts/android-version.mjs --check
+
       - name: Upload validated Android artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:

--- a/frontend-tests/shared/android-version-script.test.js
+++ b/frontend-tests/shared/android-version-script.test.js
@@ -1,0 +1,72 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { androidVersionFor, patchGradleVersion } from "../../scripts/android-version.mjs";
+
+const tauriConfig = JSON.parse(
+  readFileSync(new URL("../../src-tauri/tauri.conf.json", import.meta.url), "utf8"),
+);
+
+const gradleTemplate = `android {
+    namespace = "com.wordhunter.pocket"
+    compileSdk = 36
+
+    defaultConfig {
+        applicationId = "com.wordhunter.pocket"
+        minSdk = 24
+        targetSdk = 36
+        versionCode = 100000909
+        versionName = "1.0.9-rc.9"
+    }
+}
+`;
+
+describe("android-version.mjs portable version identity (F-Droid/CI patcher)", () => {
+  it("mirrors scripts/build.bat Get-AndroidVersionInfo for stable releases", () => {
+    assert.equal(androidVersionFor("1.0.10").code, 101001099);
+    assert.equal(androidVersionFor("1.0.10").name, "1.0.10");
+    assert.equal(androidVersionFor("1.0.9").code, 101000999);
+  });
+
+  it("maps -rc.N to the rc ordinal", () => {
+    assert.equal(androidVersionFor("1.0.10-rc.1").code, 101001001);
+    assert.equal(androidVersionFor("1.0.9-rc.9").code, 101000909);
+    assert.equal(androidVersionFor("1.0.10-rc.1").name, "1.0.10-rc.1");
+    assert.throws(() => androidVersionFor("1.0.10-rc.99"), /ordinal/);
+    assert.throws(() => androidVersionFor("1.0.10-rc.0"), /ordinal/);
+  });
+
+  it("maps the +1 hotfix to ordinal 100 and rewrites the versionName dot", () => {
+    assert.equal(androidVersionFor("1.0.10+1").code, 101001100);
+    assert.equal(androidVersionFor("1.0.10+1").name, "1.0.10.1");
+    assert.throws(() => androidVersionFor("1.0.10+2"), /hotfix/);
+  });
+
+  it("pins the tauri.conf.json contract the patcher reads from", () => {
+    assert.equal(tauriConfig.version, "1.0.10");
+    assert.equal(androidVersionFor(tauriConfig.version).code, 101001099);
+  });
+
+  it("rewrites versionCode/versionName in build.gradle.kts like Set-AndroidGradleVersion", () => {
+    const patched = patchGradleVersion(gradleTemplate, androidVersionFor("1.0.10"));
+    assert.match(patched, /^\s*versionCode = 101001099\s*$/m);
+    assert.match(patched, /^\s*versionName = "1\.0\.10"\s*$/m);
+    assert.doesNotMatch(patched, /100000909|1\.0\.9-rc\.9/);
+  });
+
+  it("hard-fails when the gradle identity lines are absent (committed template must carry them)", () => {
+    assert.throws(
+      () => patchGradleVersion("android { defaultConfig { } }", androidVersionFor("1.0.10")),
+      /versionCode\/versionName lines not found/,
+    );
+  });
+
+  it("stays consistent with the scripts/build.bat formula", () => {
+    const bat = readFileSync(new URL("../../scripts/build.bat", import.meta.url), "utf8");
+    assert.match(bat, /versionCodeGenerationOffset = 1000000/);
+    assert.match(bat, /\$code = \$versionCodeGenerationOffset \+ \(\$baseCode \* 100\) \+ \$releaseOrdinal/);
+    assert.match(bat, /\$releaseOrdinal = 99/, "stable ordinal");
+    assert.match(bat, /\$releaseOrdinal = 100/, "hotfix ordinal");
+    assert.match(bat, /\bName = \$version\.Replace\('\+'/, "hotfix versionName rewrites + to .");
+  });
+});

--- a/scripts/android-version.mjs
+++ b/scripts/android-version.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+// Portable Android version patcher (Linux/macOS/CI/F-Droid): computes the
+// versionCode from tauri.conf.json with the same formula as scripts/build.bat
+// (versionCode = 1_000_000 + base*100 + releaseOrdinal) and stamps it plus
+// versionName into the generated AndroidManifest.xml. Idempotent.
+import { readFileSync, writeFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const manifestPath = join(root, "src-tauri", "gen", "android", "app", "src", "main", "AndroidManifest.xml");
+
+const config = JSON.parse(readFileSync(join(root, "src-tauri", "tauri.conf.json"), "utf8"));
+const version = String(config.version ?? "").split("+")[0];
+const [major, minor, patch] = version.split(".").map((part) => Number.parseInt(part, 10));
+if (!Number.isInteger(major) || !Number.isInteger(minor) || !Number.isInteger(patch) || minor >= 1000 || patch >= 1000) {
+  throw new Error(`Invalid version for the Android versionCode formula: ${version}`);
+}
+const releaseOrdinal = Number.parseInt(process.env.WH_ANDROID_RELEASE_ORDINAL || "0", 10) || 0;
+// Same formula as scripts/build.bat: baseCode = major*1e6 + minor*1e3 + patch.
+const baseCode = major * 1_000_000 + minor * 1_000 + patch;
+const versionCode = 1_000_000 + baseCode * 100 + releaseOrdinal;
+if (versionCode < 1 || versionCode > 2_100_000_000) {
+  throw new Error(`versionCode out of range: ${versionCode}`);
+}
+
+const manifest = readFileSync(manifestPath, "utf8");
+const patched = manifest
+  .replace(/(android:versionCode=")\d+(")/, `$1${versionCode}$2`)
+  .replace(/(android:versionName=")[^"]*(")/, `$1${version}$2`);
+if (patched === manifest) {
+  throw new Error("AndroidManifest.xml: expected versionCode/versionName attributes not found");
+}
+writeFileSync(manifestPath, patched);
+console.log(`android versionCode=${versionCode} versionName=${version} -> ${manifestPath}`);

--- a/scripts/android-version.mjs
+++ b/scripts/android-version.mjs
@@ -1,35 +1,89 @@
 #!/usr/bin/env node
 // Portable Android version patcher (Linux/macOS/CI/F-Droid): computes the
-// versionCode from tauri.conf.json with the same formula as scripts/build.bat
-// (versionCode = 1_000_000 + base*100 + releaseOrdinal) and stamps it plus
-// versionName into the generated AndroidManifest.xml. Idempotent.
+// versionCode/versionName from src-tauri/tauri.conf.json with the same
+// formula as scripts/build.bat Get-AndroidVersionInfo and stamps them into
+// gen/android/app/build.gradle.kts — the same file Set-AndroidGradleVersion
+// patches on Windows (scripts/build.bat:550-566). Idempotent.
+//
+// The versionCode formula (see scripts/build.bat Get-AndroidVersionInfo and
+// scripts/inspect-artifact.mjs androidVersionCodeFor) is
+//   1000000 + ((major*1e6 + minor*1e3 + patch) * 100) + releaseOrdinal
+// where releaseOrdinal is 99 for a stable release, the rc number for
+// -rc.N, and 100 for a +1 hotfix. 1.0.10 -> 101001099.
+//
+// Usage:
+//   node scripts/android-version.mjs            # patch gen/android gradle
+//   node scripts/android-version.mjs --check    # verify, fail if stale
+// Run it after the Android project has been generated (`tauri android init`,
+// or any scripts/build.bat android invocation). `--check` is wired into
+// .github/workflows/artifact-validation.yml after the AAB build to verify the
+// on-disk gradle identity independently of Set-AndroidGradleVersion.
 import { readFileSync, writeFileSync } from "node:fs";
-import { join, dirname } from "node:path";
-import { fileURLToPath } from "node:url";
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { androidVersionCodeFor } from "./inspect-artifact.mjs";
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
-const manifestPath = join(root, "src-tauri", "gen", "android", "app", "src", "main", "AndroidManifest.xml");
+const gradlePath = join(root, "src-tauri", "gen", "android", "app", "build.gradle.kts");
 
-const config = JSON.parse(readFileSync(join(root, "src-tauri", "tauri.conf.json"), "utf8"));
-const version = String(config.version ?? "").split("+")[0];
-const [major, minor, patch] = version.split(".").map((part) => Number.parseInt(part, 10));
-if (!Number.isInteger(major) || !Number.isInteger(minor) || !Number.isInteger(patch) || minor >= 1000 || patch >= 1000) {
-  throw new Error(`Invalid version for the Android versionCode formula: ${version}`);
-}
-const releaseOrdinal = Number.parseInt(process.env.WH_ANDROID_RELEASE_ORDINAL || "0", 10) || 0;
-// Same formula as scripts/build.bat: baseCode = major*1e6 + minor*1e3 + patch.
-const baseCode = major * 1_000_000 + minor * 1_000 + patch;
-const versionCode = 1_000_000 + baseCode * 100 + releaseOrdinal;
-if (versionCode < 1 || versionCode > 2_100_000_000) {
-  throw new Error(`versionCode out of range: ${versionCode}`);
+// Mirrors scripts/build.bat Get-AndroidVersionInfo's Name derivation:
+// MAJOR.MINOR.PATCH+1 renders as versionName "MAJOR.MINOR.PATCH.1".
+export function androidVersionFor(version) {
+  return {
+    source: version,
+    name: version.replace("+", "."),
+    code: androidVersionCodeFor(version),
+  };
 }
 
-const manifest = readFileSync(manifestPath, "utf8");
-const patched = manifest
-  .replace(/(android:versionCode=")\d+(")/, `$1${versionCode}$2`)
-  .replace(/(android:versionName=")[^"]*(")/, `$1${version}$2`);
-if (patched === manifest) {
-  throw new Error("AndroidManifest.xml: expected versionCode/versionName attributes not found");
+// Mirrors scripts/build.bat Set-AndroidGradleVersion (build.bat:550-566):
+// rewrites the `versionCode = N` / `versionName = "..."` lines and hard-fails
+// when they are absent so a stale template can never silently ship. Returns
+// the input unchanged when the identity is already correct (idempotent).
+export function patchGradleVersion(gradleText, versionInfo) {
+  const codeLine = /^(\s*)versionCode\s*=\s*.+$/m.test(gradleText);
+  const nameLine = /^(\s*)versionName\s*=\s*.+$/m.test(gradleText);
+  if (!codeLine || !nameLine) {
+    throw new Error(
+      "gen/android/app/build.gradle.kts: expected versionCode/versionName lines not found",
+    );
+  }
+  return gradleText
+    .replace(/^(\s*)versionCode\s*=\s*.+$/m, `$1versionCode = ${versionInfo.code}`)
+    .replace(/^(\s*)versionName\s*=\s*.+$/m, `$1versionName = "${versionInfo.name}"`);
 }
-writeFileSync(manifestPath, patched);
-console.log(`android versionCode=${versionCode} versionName=${version} -> ${manifestPath}`);
+
+function readGradleOrFail() {
+  try {
+    return readFileSync(gradlePath, "utf8");
+  } catch (error) {
+    throw new Error(
+      `gen/android/app/build.gradle.kts not found (${gradlePath}): run 'tauri android init' or scripts/build.bat once to generate the Android project`,
+      { cause: error },
+    );
+  }
+}
+
+function main() {
+  const config = JSON.parse(readFileSync(join(root, "src-tauri", "tauri.conf.json"), "utf8"));
+  const versionInfo = androidVersionFor(String(config.version));
+  const gradleText = readGradleOrFail();
+  const patched = patchGradleVersion(gradleText, versionInfo);
+  if (process.argv.includes("--check")) {
+    if (patched !== gradleText) {
+      throw new Error(
+        `gen/android/app/build.gradle.kts is out of date: expected versionCode=${versionInfo.code} versionName="${versionInfo.name}"`,
+      );
+    }
+    console.log(
+      `android version identity OK: versionCode=${versionInfo.code} versionName=${versionInfo.name}`,
+    );
+  } else {
+    writeFileSync(gradlePath, patched);
+    console.log(`android versionCode=${versionInfo.code} versionName=${versionInfo.name} -> ${gradlePath}`);
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  main();
+}


### PR DESCRIPTION
Part of #139 — portable Android version bump for F-Droid and Linux CI (version-identity leg only; remaining bullets tracked in #209).

**What this PR fixes (audit wave-8 blockers B1/B2/B3):**
- `scripts/android-version.mjs` reads the version from `src-tauri/tauri.conf.json` (single source of truth) and derives the versionCode with the project formula `1000000 + ((major*1e6 + minor*1e3 + patch) * 100) + releaseOrdinal` — stable → 99, `-rc.N` → N, `+1` hotfix → 100 — reusing `androidVersionCodeFor` from `scripts/inspect-artifact.mjs`, the same formula `scripts/build.bat Get-AndroidVersionInfo` implements (1.0.10 → **101001099**, not 101001000).
- It patches the **right target**: `gen/android/app/build.gradle.kts` (`versionCode`/`versionName` lines), mirroring `Set-AndroidGradleVersion` (build.bat:550-566), with a hard failure when the identity lines are absent. The previous version patched `AndroidManifest.xml` attributes that no manifest in the project carries (ENOENT on the generated path / no-op on committed manifests).
- Wired into `.github/workflows/artifact-validation.yml` as `node scripts/android-version.mjs --check` right after the APK/AAB build: an independent verifier that the on-disk gradle identity matches tauri.conf.json (catches stale-identity regressions). Chosen over hooking `scripts/build.bat`, which already stamps the gradle file via `Set-AndroidGradleVersion` on every Windows run — no duplication; the JS script is the Linux/macOS/F-Droid-portable replacement.
- Tests (TDD, RED → GREEN): `frontend-tests/shared/android-version-script.test.js` — contract 101001099 (1.0.10), 101001001 (1.0.10-rc.1), 101001100 (1.0.10+1), gradle patching + hard-fail, plus a consistency test pinning the formula tokens in `scripts/build.bat`.

**Verification:** RED proven on the unfixed state (ENOENT on the missing manifest; 101001000 stamped into a manifest with the old formula) → GREEN after the fix (101001099 stamped into build.gradle.kts; `--check` passes on correct identity and fails on stale). Full suite: node tests 520/520, `npm run check:frontend`, `cargo test --lib` 323/323, `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `git diff --check`.

**Still open in #139 (tracked in #209):**
- (1) partial — `src-tauri/gen/` is still gitignored; F-Droid still cannot build the committed tree without `tauri android init`; this PR ships the portable patcher half.
- (2) versionCode/versionName not yet a committed gradle property with hard failure when absent (patcher hard-fails, but the property is generated, not committed).
- (3) `tauri.settings.gradle` hardcodes `C:\Users\Oleg\.cargo\registry\...` — non-relocatable.
- (4) `Ensure-AndroidProject` silently skips regeneration when gen/ exists (build.bat:433-437) — no template-version marker.
