### PR TITLE
Fix #112: CI gates — soft-fail frontend validation, SDK 35 vs 36, canonical drift

### DIFF
--- a/.github/workflows/artifact-validation.yml
+++ b/.github/workflows/artifact-validation.yml
@@ -63,7 +63,6 @@ jobs:
         run: npm run check:frontend
 
       - name: Validate frontend behavior and repository data
-        continue-on-error: true
         run: |
           node scripts/validate-json-i18n.mjs
           node --experimental-vm-modules --test frontend-tests/shared/*.test.js frontend-tests/desktop/*.test.js
@@ -97,7 +96,7 @@ jobs:
       - name: Install Android SDK and NDK packages
         shell: pwsh
         run: |
-          sdkmanager "platform-tools" "platforms;android-35" "build-tools;35.0.0" "ndk;27.0.12077973"
+          sdkmanager "platform-tools" "platforms;android-36" "build-tools;36.0.0" "ndk;27.0.12077973"
           "NDK_HOME=$env:ANDROID_HOME\ndk\27.0.12077973" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Set up Rust

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Install Android SDK and NDK packages
         shell: pwsh
         run: |
-          sdkmanager "platform-tools" "platforms;android-35" "build-tools;35.0.0" "ndk;27.0.12077973"
+          sdkmanager "platform-tools" "platforms;android-36" "build-tools;36.0.0" "ndk;27.0.12077973"
           "NDK_HOME=$env:ANDROID_HOME\ndk\27.0.12077973" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Set up Rust

--- a/frontend-tests/android/pocket-bridges.test.js
+++ b/frontend-tests/android/pocket-bridges.test.js
@@ -157,7 +157,7 @@ describe("Android Pocket bridges", () => {
     assert.match(activity, /fun stopTts\(\) \{[\s\S]*textToSpeech\?\.stop\(\)[\s\S]*hideTtsNotification\(\)/);
     assert.match(activity, /fun endTtsSession\(\) \{[\s\S]*hideTtsNotification\(\)[\s\S]*clearKeepScreenOn\(\)/);
     assert.match(activity, /setOngoing\(true\)/);
-    assert.match(activity, /addAction\(android\.R\.drawable\.ic_media_pause, "Stop", stopPendingIntent\)/);
+    assert.match(activity, /addAction\(android\.R\.drawable\.ic_media_pause, "Stop", stopPendingIntent\)|Notification\.Action\.Builder\([\s\S]*ic_media_pause[\s\S]*"Stop"[\s\S]*stopPendingIntent[\s\S]{0,40}\.build\(\)/);
     assert.doesNotMatch(activity, /\bMediaSession\b|startForeground\(|startForegroundService\(|class \w+ : Service/);
   });
 

--- a/src-tauri/platforms/android/MainActivity.kt
+++ b/src-tauri/platforms/android/MainActivity.kt
@@ -763,7 +763,13 @@ class MainActivity : TauriActivity() {
           .setOnlyAlertOnce(true)
           .setCategory(Notification.CATEGORY_TRANSPORT)
           .setVisibility(Notification.VISIBILITY_PRIVATE)
-          .addAction(android.R.drawable.ic_media_pause, "Stop", stopPendingIntent)
+          .addAction(
+            Notification.Action.Builder(
+              android.R.drawable.ic_media_pause,
+              "Stop",
+              stopPendingIntent
+            ).build()
+          )
           .build()
       )
     }


### PR DESCRIPTION
Closes #112

**Audit verdict:** CONFIRMED (W2C-3/4/5: continue-on-error gate, SDK mismatch, canonical/gen MainActivity drift).

**Verification:** YAML parses; canonical now matches the gen notification code; repo-validation 7/7 (local).