### PR TITLE
Fix #93: /__open_dict hands arbitrary URL schemes to the OS/webview

### DIFF
--- a/src-tauri/src/popup.rs
+++ b/src-tauri/src/popup.rs
@@ -10,10 +10,20 @@ fn popup_close_url(base_url: &str) -> String {
     format!("{base_url}/__popup/close")
 }
 
+fn inline_javascript_string(value: &str) -> String {
+    serde_json::to_string(value)
+        .unwrap_or_else(|_| "\"\"".to_string())
+        .replace('&', "\\u0026")
+        .replace('<', "\\u003c")
+        .replace('>', "\\u003e")
+        .replace('\u{2028}', "\\u2028")
+        .replace('\u{2029}', "\\u2029")
+}
+
 fn popup_escape_script(base_url: &str) -> String {
-    let close_url = popup_close_url(base_url);
+    let close_url = inline_javascript_string(&popup_close_url(base_url));
     format!(
-        "window.addEventListener('keydown',e=>{{if(e.key==='Escape'){{e.preventDefault();e.stopImmediatePropagation();window.location.replace('{close_url}');}}}},true);"
+        "window.addEventListener('keydown',e=>{{if(e.key==='Escape'){{e.preventDefault();e.stopImmediatePropagation();window.location.replace({close_url});}}}},true);"
     )
 }
 
@@ -180,6 +190,16 @@ mod tests {
         assert!(script.contains("http://127.0.0.1:1234/__popup/close"));
         assert!(script.contains("window.location.replace"));
         assert!(!script.contains("new Image"));
+    }
+
+    #[test]
+    fn escape_script_encodes_javascript_and_script_terminators() {
+        let script =
+            popup_escape_script("http://127.0.0.1:1234/\");globalThis.pwned=1;//</script>");
+
+        assert!(!script.contains("</script>"));
+        assert!(script.contains("/\\\");globalThis.pwned=1"));
+        assert!(script.contains("\\u003c/script\\u003e"));
     }
 
     #[test]

--- a/src-tauri/src/popup.rs
+++ b/src-tauri/src/popup.rs
@@ -17,6 +17,15 @@ fn popup_escape_script(base_url: &str) -> String {
     )
 }
 
+/// Reject anything but http(s) targets for the OS/webview open paths.
+fn validated_open_target(target: &str) -> Result<String, String> {
+    let target = target.trim();
+    if !(target.starts_with("https://") || target.starts_with("http://")) {
+        return Err("refusing to open a non-http URL".to_string());
+    }
+    Ok(target.to_string())
+}
+
 fn is_popup_close_navigation(url: &Url, close_url: &str) -> bool {
     url.as_str() == close_url
 }
@@ -46,6 +55,14 @@ pub fn serve_open_dict(
             format!("{base_url}{url}")
         } else {
             url.to_string()
+        };
+        // Only http(s) targets may reach the OS browser or the
+        // webview: file:/custom-protocol URLs must never be handed
+        // out (audit #93). The internal popup legitimately shows
+        // third-party https pages (Youglish), so no host restriction.
+        let target = match validated_open_target(&target) {
+            Ok(ok) => ok,
+            Err(err) => return Err(err),
         };
         let mode = params.get("mode").map(String::as_str).unwrap_or("external");
         let title = params
@@ -136,8 +153,25 @@ pub fn serve_close_popup(request: Request, app_handle: &AppHandle) -> Result<(),
 
 #[cfg(test)]
 mod tests {
-    use super::{is_popup_close_navigation, popup_escape_script};
+    use super::{is_popup_close_navigation, popup_escape_script, validated_open_target};
     use url::Url;
+
+    #[test]
+    fn open_target_rejects_non_http_schemes() {
+        assert!(validated_open_target("file:///etc/passwd").is_err());
+        assert!(validated_open_target("javascript:alert(1)").is_err());
+        assert!(validated_open_target("custom-protocol://payload").is_err());
+        assert!(validated_open_target("").is_err());
+    }
+
+    #[test]
+    fn open_target_accepts_http_and_https() {
+        assert_eq!(
+            validated_open_target("https://youglish.com/pronounce/word"),
+            Ok("https://youglish.com/pronounce/word".to_string())
+        );
+        assert!(validated_open_target("http://127.0.0.1:38619/index.html").is_ok());
+    }
 
     #[test]
     fn escape_script_uses_navigation_instead_of_a_cross_site_request() {


### PR DESCRIPTION
Closes #93 (scheme part; interpolation part landed in #128)

**Audit verdict:** CONFIRMED (W1A-3/W2A-9: serve_open_dict never validated the scheme).

**Verification:** cargo build 0; 273/273 tests (2 new scheme tests); fmt clean.