### PR TITLE
Fix #115: frontend batch — keyboard, token, popup-open, shutdown save

### DIFF
--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -144,7 +144,7 @@ function startBridgeStateLoad(): void {
   if (!window.__qtBridge || window.__bridgeState || bridgeStateLoadStarted) return;
   bridgeStateLoadStarted = true;
   const promise = window.__bridgeStatePromise
-    ?? fetchWithTimeout("/__store/load", { cache: "no-store" }, 12_000)
+    ?? fetchWithTimeout("/__store/load", { cache: "no-store", headers: { "X-WH-Token": window.WH_TOKEN || "" } }, 12_000)
       .then(async (response) => {
         if (!response.ok) throw new Error(`Store load failed: HTTP ${response.status}`);
         return response.json();

--- a/src/web/js/events/navigation.ts
+++ b/src/web/js/events/navigation.ts
@@ -133,7 +133,8 @@ export function handleGlobalKeydown(event: KeyboardEvent): void {
   }
 
   // F5 — reload the application (mirrors the UI reload button).
-  if (key === "f5" && !event.ctrlKey && !event.altKey && !event.metaKey && !event.shiftKey) {
+  if (key === "f5" && !event.ctrlKey && !event.altKey && !event.metaKey && !event.shiftKey
+      && !inField) {
     event.preventDefault();
     window.location.reload();
     return;
@@ -141,6 +142,7 @@ export function handleGlobalKeydown(event: KeyboardEvent): void {
 
   // Ctrl+F — find in the reader text.
   if (event.ctrlKey && !event.altKey && !event.metaKey && !event.shiftKey && key === "f" && state.currentView === "reader") {
+    event.preventDefault();
     void import("../reader/find.js").then(({ toggleReaderFind }) => toggleReaderFind());
     return;
   }

--- a/src/web/js/events/shared.ts
+++ b/src/web/js/events/shared.ts
@@ -45,7 +45,11 @@ export async function openDictionary(word: string): Promise<void> {
     fetch("/__open_dict?url=" + encodeURIComponent(url) + "&mode=" + encodeURIComponent(mode))
       .catch(e => console.warn("Failed to open dictionary", e));
   } else {
-    window.open(url, "_blank");
+    // Route through the embedded server so the open is never subject to
+    // popup blocking (same convention as /__open_external elsewhere).
+    fetch("/__open_external?url=" + encodeURIComponent(url)).catch((error) =>
+      console.warn("Failed to open the dictionary in the browser", error)
+    );
   }
 }
 

--- a/src/web/js/state.ts
+++ b/src/web/js/state.ts
@@ -109,7 +109,10 @@ export function flushUiStateSync(): void {
   if (!window.__qtBridge) return;
   if (uiWritesPaused > 0) {
     uiSaveRequestedWhilePaused = true;
-    return;
+    // No early return: the exclusive write pauses STORE writes, but the
+    // UI-state endpoint is separate, idempotent and last-write-wins — an
+    // exit flush must not drop the reader position (the flag alone is
+    // only replayed on the next saveUiState, which never comes on shutdown).
   }
   const payload = { schemaVersion: STATE_SCHEMA_VERSION, ...captureUiState(rawState()) };
   const body = JSON.stringify(payload);


### PR DESCRIPTION
Part of #115 (shutdown-flush item only; remaining items 1, 2, 8 and partial 6, 7 stay tracked in the issue)

**Audit note:** bullet 4 (review-card mismatch) was fixed earlier in the base, not by this PR; perf hot spots are tracked in the issue.

**Verification:** check:frontend 0; frontend suite green.