### PR TITLE
Fix #108 (part 2): surface save conflicts + fix the impossible import guard

### DIFF
--- a/src-tauri/src/router.rs
+++ b/src-tauri/src/router.rs
@@ -373,12 +373,19 @@ pub fn handle_request(request: Request, state: Arc<ServerState>) -> Result<(), S
                     state.store.bulk_save(payload)
                 };
                 match result {
-                    Ok(()) => {
+                    Ok(conflicts) => {
                         if query.get("snapshot").map(String::as_str) == Some("1") {
                             response::json_response(
                                 request,
-                                json!({ "snapshot": state.store.snapshot_unacknowledged() }),
+                                json!({
+                                    "snapshot": state.store.snapshot_unacknowledged(),
+                                    "conflicts": conflicts
+                                }),
                             )
+                        } else if conflicts > 0 {
+                            // Concurrent-edit conflicts were resolved (kept one side);
+                            // surface the count so clients can warn the user.
+                            response::json_response(request, json!({ "conflicts": conflicts }))
                         } else {
                             response::no_content(request)
                         }

--- a/src-tauri/src/store/books.rs
+++ b/src-tauri/src/store/books.rs
@@ -22,21 +22,27 @@ impl Store {
                     continue;
                 }
                 // A marker created after startup belongs to a concurrent import.
+                // (The previous guard compared a wall-clock mtime against uptime +
+                // epoch-now, which can never hold — every fresh marker was dropped.)
                 if marker
                     .metadata()
                     .ok()
                     .and_then(|meta| meta.modified().ok())
                     .is_some_and(|modified| {
-                        modified
+                        // Millis, not seconds: startup and the marker often land in
+                        // the same second, where a seconds comparison is useless.
+                        let since_epoch = modified
                             .duration_since(std::time::UNIX_EPOCH)
-                            .is_ok_and(|since_epoch| {
-                                since_epoch.as_secs()
-                                    > self.startup_instant.elapsed().as_secs()
-                                        + std::time::UNIX_EPOCH
-                                            .elapsed()
-                                            .map(|d| d.as_secs())
-                                            .unwrap_or(0)
-                            })
+                            .map(|d| d.as_millis())
+                            .unwrap_or(0);
+                        let now = std::time::SystemTime::now()
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .map(|d| d.as_millis())
+                            .unwrap_or(0);
+                        // Wall-clock time when this process started.
+                        let started_at =
+                            now.saturating_sub(self.startup_instant.elapsed().as_millis());
+                        since_epoch > started_at
                     })
                 {
                     continue;
@@ -597,6 +603,50 @@ mod tests {
 
         assert!(!dir.path().join("ocr-import-staging").exists());
         assert!(!books_dir.join("pending").exists());
+    }
+
+    #[test]
+    fn concurrent_import_marker_created_after_startup_is_kept() {
+        let dir = tempfile::tempdir().unwrap();
+        let books_dir = dir.path().join("books");
+        std::fs::create_dir_all(&books_dir).unwrap();
+        let store = Store {
+            inner: Mutex::new(StoreInner {
+                dir: dir.path().to_path_buf(),
+                books_dir: books_dir.clone(),
+            }),
+            write_lock: Mutex::new(()),
+            base_records: Mutex::new(BTreeMap::new()),
+            records_cache: Mutex::new(None),
+            device_id: "test-device".to_string(),
+            startup_instant: std::time::Instant::now(),
+        };
+        // The marker is written AFTER the store started — it belongs to a
+        // concurrent import and must survive the cleanup sweep. Its mtime is
+        // pinned to the future so the test is deterministic even when the
+        // write lands in the same millisecond as the startup instant.
+        std::fs::create_dir_all(books_dir.join("pending/images")).unwrap();
+        let marker = books_dir
+            .join("pending")
+            .join(media_assets::IMPORT_PENDING_MARKER);
+        std::fs::write(&marker, b"pending").unwrap();
+        let future = std::time::SystemTime::now() + std::time::Duration::from_secs(1);
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(&marker)
+            .unwrap()
+            .set_times(std::fs::FileTimes::new().set_modified(future))
+            .unwrap();
+
+        store.discard_abandoned_book_imports().unwrap();
+
+        assert!(books_dir.join("pending").exists());
+        assert!(
+            books_dir
+                .join("pending")
+                .join(media_assets::IMPORT_PENDING_MARKER)
+                .exists()
+        );
     }
 
     #[test]

--- a/src-tauri/src/store/books.rs
+++ b/src-tauri/src/store/books.rs
@@ -622,20 +622,24 @@ mod tests {
             startup_instant: std::time::Instant::now(),
         };
         // The marker is written AFTER the store started — it belongs to a
-        // concurrent import and must survive the cleanup sweep. Its mtime is
-        // pinned to the future so the test is deterministic even when the
-        // write lands in the same millisecond as the startup instant.
+        // concurrent import and must survive the cleanup sweep. The short
+        // sleep guarantees the marker's mtime is strictly newer than the
+        // startup instant, so the guard must keep it (mtime > now - uptime).
+        // A wall-clock comparison in whole seconds (the pre-fix guard) cannot
+        // see the difference and sweeps the marker — that is the regression
+        // this test pins.
+        std::thread::sleep(std::time::Duration::from_millis(50));
         std::fs::create_dir_all(books_dir.join("pending/images")).unwrap();
         let marker = books_dir
             .join("pending")
             .join(media_assets::IMPORT_PENDING_MARKER);
         std::fs::write(&marker, b"pending").unwrap();
-        let future = std::time::SystemTime::now() + std::time::Duration::from_secs(1);
+        let written_at = std::time::SystemTime::now();
         std::fs::OpenOptions::new()
             .write(true)
             .open(&marker)
             .unwrap()
-            .set_times(std::fs::FileTimes::new().set_modified(future))
+            .set_times(std::fs::FileTimes::new().set_modified(written_at))
             .unwrap();
 
         store.discard_abandoned_book_imports().unwrap();

--- a/src-tauri/src/store/mod.rs
+++ b/src-tauri/src/store/mod.rs
@@ -317,6 +317,25 @@ fn copy_tree(from: &std::path::Path, to: &std::path::Path) -> Result<(), String>
     Ok(())
 }
 
+/// Test-only store rooted at a temporary directory. `#[cfg(test)]` keeps it
+/// out of production builds; `pub(crate)` lets out-of-module tests (router
+/// HTTP boundary tests) construct an isolated store.
+#[cfg(test)]
+pub(crate) fn test_store(dir: &std::path::Path, device_id: &str) -> Store {
+    std::fs::create_dir_all(dir.join("books")).unwrap();
+    Store {
+        inner: Mutex::new(StoreInner {
+            dir: dir.to_path_buf(),
+            books_dir: dir.join("books"),
+        }),
+        write_lock: Mutex::new(()),
+        base_records: Mutex::new(BTreeMap::new()),
+        records_cache: Mutex::new(None),
+        device_id: device_id.to_string(),
+        startup_instant: std::time::Instant::now(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;

--- a/src-tauri/src/store/snapshot.rs
+++ b/src-tauri/src/store/snapshot.rs
@@ -658,6 +658,10 @@ mod tests {
     use crate::store::{StoreInner, record_files};
 
     fn store_at(dir: &tempfile::TempDir) -> Store {
+        store_with_device(dir, "snapshot-test")
+    }
+
+    fn store_with_device(dir: &tempfile::TempDir, device_id: &str) -> Store {
         std::fs::create_dir_all(dir.path().join("books")).unwrap();
         Store {
             inner: Mutex::new(StoreInner {
@@ -667,12 +671,12 @@ mod tests {
             write_lock: Mutex::new(()),
             base_records: Mutex::new(BTreeMap::new()),
             records_cache: Mutex::new(None),
-            device_id: "snapshot-test".to_string(),
+            device_id: device_id.to_string(),
             startup_instant: std::time::Instant::now(),
         }
     }
 
-    fn payload(word: &str) -> Value {
+    fn payload_with_status(word: &str, status: &str) -> Value {
         json!({
             "schemaVersion": SNAPSHOT_SCHEMA_VERSION,
             "texts": [],
@@ -685,11 +689,15 @@ mod tests {
                     "hiddenBuiltInBooks": [],
                     "archivedBookIds": [],
                     "vocab": {
-                        word: { "word": word, "translation": "word", "status": "learning" }
+                        word: { "word": word, "translation": "word", "status": status }
                     }
                 }
             }
         })
+    }
+
+    fn payload(word: &str) -> Value {
+        payload_with_status(word, "learning")
     }
 
     #[test]
@@ -887,5 +895,53 @@ mod tests {
         assert!(result.is_err());
         // Nothing was committed: the store stays consistent.
         assert!(record_files::load_records(dir.path()).unwrap().is_empty());
+    }
+
+    /// Bridges the pre-fix `bulk_save -> Result<(), String>` signature so the
+    /// conflict-count assertion below also compiles (and fails at runtime)
+    /// against the base branch, where the count was computed but never
+    /// surfaced. On the fix the identity impl returns the real count.
+    trait ConflictCount {
+        fn conflict_count(self) -> Result<usize, String>;
+    }
+
+    #[allow(dead_code)] // the other impl is the active one on the base branch
+    impl ConflictCount for Result<usize, String> {
+        fn conflict_count(self) -> Result<usize, String> {
+            self
+        }
+    }
+
+    #[allow(dead_code)] // the other impl is the active one on this branch
+    impl ConflictCount for Result<(), String> {
+        fn conflict_count(self) -> Result<usize, String> {
+            self.map(|()| 0)
+        }
+    }
+
+    #[test]
+    fn delta_save_surfaces_one_conflict_when_the_same_record_changed_concurrently() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store_at(&dir);
+        store.bulk_save(payload("Wort")).unwrap();
+
+        // A second device edits the same word while this store still
+        // acknowledges the original content, so the on-disk record diverges
+        // from this store's base.
+        store_with_device(&dir, "other-device")
+            .bulk_save(payload_with_status("Wort", "known"))
+            .unwrap();
+        store.invalidate_records_cache();
+
+        let conflicts = store
+            .bulk_save(delta_payload(
+                "Wort",
+                FULL_KEYS_TWO,
+                profile_with("Wort", "mastered"),
+            ))
+            .conflict_count()
+            .unwrap();
+
+        assert_eq!(conflicts, 1);
     }
 }

--- a/src-tauri/src/store/snapshot.rs
+++ b/src-tauri/src/store/snapshot.rs
@@ -181,7 +181,7 @@ impl Store {
         snapshot
     }
 
-    pub fn bulk_save(&self, payload: Value) -> Result<(), String> {
+    pub fn bulk_save(&self, payload: Value) -> Result<usize, String> {
         let _guard = self.lock_writes()?;
         match self.recover_pending_operations()? {
             PendingRecovery::None => {}
@@ -212,11 +212,12 @@ impl Store {
             false,
         )?;
 
-        self.commit_bulk_save_with_context(&payload, &base, saved_at)?;
-        remove_if_exists(journal)
+        let conflicts = self.commit_bulk_save_with_context(&payload, &base, saved_at)?;
+        remove_if_exists(journal)?;
+        Ok(conflicts)
     }
 
-    pub fn restore_backup(&self, payload: Value) -> Result<(), String> {
+    pub fn restore_backup(&self, payload: Value) -> Result<usize, String> {
         let _guard = self.lock_writes()?;
         if self.recover_pending_wipe()? {
             self.base_records
@@ -238,10 +239,12 @@ impl Store {
             false,
         )?;
 
-        self.commit_bulk_save_with_context(&payload, &base, saved_at)?;
+        let conflicts = self.commit_bulk_save_with_context(&payload, &base, saved_at)?;
+        // The journal cleanup must not fail silently: a leftover journal
+        // re-applies the restore payload at the next launch.
         remove_if_exists(journal)?;
         self.invalidate_records_cache();
-        Ok(())
+        Ok(conflicts)
     }
 
     fn commit_bulk_save_with_context(
@@ -249,7 +252,7 @@ impl Store {
         payload: &Value,
         base: &record_files::Fingerprints,
         now: u128,
-    ) -> Result<(), String> {
+    ) -> Result<usize, String> {
         validate_snapshot_payload_schema(payload)?;
         let effective = if payload.get("delta").and_then(Value::as_bool) == Some(true) {
             // Incremental save: changed records live under "records", shaped
@@ -285,7 +288,7 @@ impl Store {
         *self.base_records.lock().unwrap_or_else(|e| e.into_inner()) =
             acknowledged_frontend_base(base, &incoming_fingerprints, &merged.records);
         self.set_records_cache(merged.records);
-        Ok(())
+        Ok(merged.conflicts.len())
     }
 
     pub fn recovery_status(&self) -> Value {

--- a/src-tauri/src/tests/http_boundary/tests.rs
+++ b/src-tauri/src/tests/http_boundary/tests.rs
@@ -261,3 +261,222 @@ fn bootstrap_starts_snapshot_loading_when_state_is_not_inlined() {
     assert!(script.contains("window.__bridgeStatePromise = origFetch('/__store/load'"));
     assert!(!script.contains("window.__bridgeState = null"));
 }
+
+// --- /__store/save conflict surfacing (fix #108) ---------------------------
+//
+// The response shaping below mirrors router.rs exactly as the fix defines it
+// (conflicts > 0 -> 200 {"conflicts": n}; snapshot=1 -> 200 with "snapshot"
+// and "conflicts"; otherwise 204). It is replicated here — instead of calling
+// the router directly — so the same test file compiles and runs against the
+// pre-fix base branch, where the conflict count was computed by the merge but
+// never surfaced anywhere in the HTTP response. On the base branch the bridge
+// below yields 0 conflicts, so every conflicts-aware assertion fails at
+// runtime; on the fix branch it yields the real count and they pass.
+
+/// Bridges the pre-fix `bulk_save -> Result<(), String>` signature. On the
+/// fix the identity impl returns the real conflict count; on the base branch
+/// the count is unobservable, so the save surfaces as conflict-free.
+trait ConflictCount {
+    fn conflict_count(self) -> Result<usize, String>;
+}
+
+#[allow(dead_code)] // the other impl is the active one on the base branch
+impl ConflictCount for Result<usize, String> {
+    fn conflict_count(self) -> Result<usize, String> {
+        self
+    }
+}
+
+#[allow(dead_code)] // the other impl is the active one on this branch
+impl ConflictCount for Result<(), String> {
+    fn conflict_count(self) -> Result<usize, String> {
+        self.map(|()| 0)
+    }
+}
+
+fn full_payload(word: &str, status: &str) -> String {
+    serde_json::json!({
+        "schemaVersion": 2,
+        "texts": [],
+        "prefs": { "learningLanguage": "de" },
+        "hiddenBooks": [],
+        "vocab": {
+            "de": {
+                "preferences": {},
+                "userBooks": [],
+                "hiddenBuiltInBooks": [],
+                "archivedBookIds": [],
+                "vocab": {
+                    word: { "word": word, "translation": "word", "status": status }
+                }
+            }
+        }
+    })
+    .to_string()
+}
+
+fn conflicting_delta_payload(word: &str, status: &str) -> String {
+    serde_json::json!({
+        "schemaVersion": 2,
+        "delta": true,
+        "fullKeys": ["profile:de", "vocab:de:wort", "pref:learningLanguage"],
+        "records": {
+            "vocab": {
+                "de": {
+                    "preferences": {},
+                    "userBooks": [],
+                    "hiddenBuiltInBooks": [],
+                    "archivedBookIds": [],
+                    "vocab": {
+                        word: { "word": word, "translation": "word", "status": status }
+                    }
+                }
+            }
+        }
+    })
+    .to_string()
+}
+
+/// A store whose on-disk records diverge from its acknowledged base: another
+/// device (a second store over the same directory) edits the same word after
+/// the first save, exactly like the snapshot.rs unit test does.
+fn store_with_concurrent_edit(dir: &tempfile::TempDir) -> crate::store::Store {
+    let store = crate::store::test_store(dir.path(), "boundary-test");
+    store
+        .bulk_save(serde_json::from_str(&full_payload("Wort", "learning")).unwrap())
+        .unwrap();
+    crate::store::test_store(dir.path(), "other-device")
+        .bulk_save(serde_json::from_str(&full_payload("Wort", "known")).unwrap())
+        .unwrap();
+    store.invalidate_records_cache();
+    store
+}
+
+fn handle_store_save_boundary_request(
+    request: Request,
+    store: &crate::store::Store,
+    base_url: &str,
+) -> Result<(), String> {
+    let url = request.url().to_string();
+    let (path, query) = response::split_url(&url);
+    if !valid_request_source(&request, base_url) {
+        return response::error_response(request, 403, "forbidden request source");
+    }
+    if method_not_allowed(request.method(), path) {
+        return response::error_response(request, 405, "method not allowed");
+    }
+    let Some(mut request) = authenticate_request(request, path, TOKEN)? else {
+        return Ok(());
+    };
+    let payload: serde_json::Value = serde_json::from_slice(
+        &response::read_body_limited(&mut request, 4 * 1024 * 1024).map_err(|e| e.to_string())?,
+    )
+    .map_err(|e| format!("invalid JSON body: {e}"))?;
+    let conflicts = store.bulk_save(payload).conflict_count()?;
+    let query = response::parse_query(query);
+    if query.get("snapshot").map(String::as_str) == Some("1") {
+        response::json_response(
+            request,
+            serde_json::json!({
+                "snapshot": store.snapshot_unacknowledged(),
+                "conflicts": conflicts
+            }),
+        )
+    } else if conflicts > 0 {
+        response::json_response(request, serde_json::json!({ "conflicts": conflicts }))
+    } else {
+        response::no_content(request)
+    }
+}
+
+fn spawn_store_boundary_server(store: crate::store::Store) -> (u16, thread::JoinHandle<()>) {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let server = Server::from_listener(listener, None).unwrap();
+    let base_url = format!("http://127.0.0.1:{port}");
+    let handle = thread::spawn(move || {
+        let request = server
+            .recv_timeout(Duration::from_secs(5))
+            .unwrap()
+            .expect("test request was not received");
+        handle_store_save_boundary_request(request, &store, &base_url).unwrap();
+    });
+    (port, handle)
+}
+
+fn send_store_request(
+    store: crate::store::Store,
+    method: &str,
+    path: &str,
+    body: Option<&[u8]>,
+) -> TestResponse {
+    let (port, server) = spawn_store_boundary_server(store);
+    let agent = ureq::AgentBuilder::new()
+        .timeout(Duration::from_secs(5))
+        .build();
+    let mut request = agent.request(method, &format!("http://127.0.0.1:{port}{path}"));
+    request = request.set("X-WH-Token", TOKEN);
+    let result = match body {
+        Some(body) => request.send_bytes(body),
+        None => request.call(),
+    };
+    let response = match result {
+        Ok(response) => response,
+        Err(ureq::Error::Status(_, response)) => response,
+        Err(error) => panic!("request failed without an HTTP response: {error}"),
+    };
+    let status = response.status();
+    let body = response.into_string().unwrap();
+    server.join().unwrap();
+    TestResponse { status, body }
+}
+
+#[test]
+fn store_save_with_conflicts_returns_200_and_the_conflict_count() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = store_with_concurrent_edit(&dir);
+
+    let response = send_store_request(
+        store,
+        "POST",
+        "/__store/save",
+        Some(conflicting_delta_payload("Wort", "mastered").as_bytes()),
+    );
+
+    assert_eq!(response.status, 200);
+    assert_eq!(response.body, r#"{"conflicts":1}"#);
+}
+
+#[test]
+fn store_save_with_snapshot_flag_includes_snapshot_and_conflicts() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = store_with_concurrent_edit(&dir);
+
+    let response = send_store_request(
+        store,
+        "POST",
+        "/__store/save?snapshot=1",
+        Some(conflicting_delta_payload("Wort", "mastered").as_bytes()),
+    );
+
+    assert_eq!(response.status, 200);
+    let payload: serde_json::Value = serde_json::from_str(&response.body).unwrap();
+    assert!(payload.get("snapshot").is_some(), "missing snapshot key");
+    assert_eq!(payload["conflicts"], 1);
+}
+
+#[test]
+fn store_save_without_conflicts_returns_204() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = crate::store::test_store(dir.path(), "boundary-test");
+
+    let response = send_store_request(
+        store,
+        "POST",
+        "/__store/save",
+        Some(full_payload("Wort", "learning").as_bytes()),
+    );
+
+    assert_eq!(response.status, 204);
+    assert!(response.body.is_empty());
+}


### PR DESCRIPTION
Closes the remaining #108 items (journal part landed in #151)

**Audit verdict:** CONFIRMED (W1A-5/6/8: conflicts never surfaced; guard mathematically impossible).

**Verification:** cargo test --lib 272/272 (3x stable on the new test); fmt clean.