### PR TITLE
Fix #115 (part 2): performance hot spots — find, smart-suggest, review queue

### DIFF
--- a/frontend-tests/shared/smart-suggest-invalidation.test.js
+++ b/frontend-tests/shared/smart-suggest-invalidation.test.js
@@ -80,9 +80,16 @@ test("mutation sites invalidate the suggest index and the review-queue memo", ()
   assert.match(vocabActions, /export function deleteWord[\s\S]*?invalidateSuggestIndex\(\);[\s\S]*?invalidateReviewQueueCache\(\);/);
   // setWordStatus: queue depends on statuses -> memo invalidated.
   assert.match(vocabActions, /export function setWordStatus[\s\S]*?invalidateReviewQueueCache\(\);/);
+  // selectWord + autoLearnOnClick: fresh entry -> learning feeds the queue.
+  assert.match(vocabActions, /autoLearnOnClick[\s\S]*?setEntryStatus\(entry, "learning"\)[\s\S]*?invalidateReviewQueueCache\(\);/);
   // getOrCreateEntry: in-place add -> suggest index invalidated.
   assert.match(vocabularyView, /export function getOrCreateEntry[\s\S]*?invalidateSuggestIndex\(\);/);
-  // Word-editor dialog: status edits bypass gradeReview/removeFromSrs.
-  assert.match(wordEditor, /invalidateReviewQueueCache\(\);/);
-  assert.match(wordEditor, /invalidateSuggestIndex\(\);/);
+  // Word-editor dialog: status edits bypass gradeReview/removeFromSrs —
+  // BOTH branches (edit and add) invalidate both caches.
+  assert.match(wordEditor, /invalidateReviewQueueCache\(\);/g);
+  assert.match(wordEditor, /invalidateSuggestIndex\(\);/g);
+  assert.ok(
+    (wordEditor.match(/invalidateReviewQueueCache\(\);/g) || []).length >= 2,
+    "edit and add branches both invalidate the queue memo"
+  );
 });

--- a/frontend-tests/shared/smart-suggest-invalidation.test.js
+++ b/frontend-tests/shared/smart-suggest-invalidation.test.js
@@ -1,0 +1,88 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import vm from "node:vm";
+
+// PR #194 remediation: the smart-suggest prefix index and the review-queue
+// memo are lazily built and keyed by the vocab object reference. In-place
+// mutations (deleteWord, getOrCreateEntry, status edits) keep the reference,
+// so the index/memo would go stale: dead keys crash the word panel with a
+// TypeError, and the review queue shows phantoms. The remediation guards the
+// dead keys and invalidates both caches at every mutation site.
+
+async function evaluateWithMocks(file, importValues, globals = {}) {
+  const context = vm.createContext(globals);
+  const modules = new Map();
+  const createMock = (specifier, values) => new vm.SyntheticModule(
+    Object.keys(values),
+    function initialize() {
+      for (const [name, value] of Object.entries(values)) this.setExport(name, value);
+    },
+    { context, identifier: `mock:${specifier}` }
+  );
+  for (const [specifier, values] of Object.entries(importValues)) {
+    modules.set(specifier, createMock(specifier, values));
+  }
+  const getModule = (specifier) => {
+    const dependency = modules.get(specifier);
+    assert.ok(dependency, `unexpected import ${specifier} from ${file}`);
+    return dependency;
+  };
+  const module = new vm.SourceTextModule(readFileSync(new URL(file, import.meta.url), "utf8"), {
+    context,
+    identifier: new URL(file, import.meta.url).href,
+    importModuleDynamically: async (specifier) => {
+      const dependency = getModule(specifier);
+      if (dependency.status === "unlinked") await dependency.link(() => {});
+      if (dependency.status === "linked") await dependency.evaluate();
+      return dependency;
+    }
+  });
+  await module.link(getModule);
+  await module.evaluate();
+  return module.namespace;
+}
+
+test("smart-suggest skips dead index keys instead of crashing on a TypeError", async () => {
+  const vocab = { "rufe an": { status: "learning" } };
+  const mockState = {
+    vocab,
+    preferences: { learningLanguage: "de" },
+    selectedWord: "rufe"
+  };
+  const { getSmartSuggestion } = await evaluateWithMocks("../../dist/web/js/reader/smart-suggest.js", {
+    "../state.js": { state: mockState },
+    "../utils.js": { escapeHtml: (v) => v, escapeAttribute: (v) => v },
+    "../i18n.js": { t: (key) => key },
+    "../translator-preferences.js": { effectiveLearningLanguage: () => "de" }
+  }, {
+    window: {},
+    console
+  });
+
+  // First query builds the prefix index (tail "an" -> ["rufe an"]).
+  getSmartSuggestion("ich rufe an", "rufe");
+
+  // deleteWord removes entries in place — the index still holds the key.
+  delete vocab["rufe an"];
+
+  // The second query must not dereference the dead key (old code: TypeError
+  // on `state.vocab[vocabWord].status`).
+  assert.doesNotThrow(() => getSmartSuggestion("ich rufe an", "rufe"));
+});
+
+test("mutation sites invalidate the suggest index and the review-queue memo", () => {
+  const vocabActions = readFileSync(new URL("../../src/web/js/vocab-actions.ts", import.meta.url), "utf8");
+  const vocabularyView = readFileSync(new URL("../../src/web/js/views/vocabulary.ts", import.meta.url), "utf8");
+  const wordEditor = readFileSync(new URL("../../src/web/js/events/word-editor.ts", import.meta.url), "utf8");
+
+  // deleteWord: in-place delete -> both caches invalidated.
+  assert.match(vocabActions, /export function deleteWord[\s\S]*?invalidateSuggestIndex\(\);[\s\S]*?invalidateReviewQueueCache\(\);/);
+  // setWordStatus: queue depends on statuses -> memo invalidated.
+  assert.match(vocabActions, /export function setWordStatus[\s\S]*?invalidateReviewQueueCache\(\);/);
+  // getOrCreateEntry: in-place add -> suggest index invalidated.
+  assert.match(vocabularyView, /export function getOrCreateEntry[\s\S]*?invalidateSuggestIndex\(\);/);
+  // Word-editor dialog: status edits bypass gradeReview/removeFromSrs.
+  assert.match(wordEditor, /invalidateReviewQueueCache\(\);/);
+  assert.match(wordEditor, /invalidateSuggestIndex\(\);/);
+});

--- a/src/web/js/events/word-editor.ts
+++ b/src/web/js/events/word-editor.ts
@@ -7,6 +7,8 @@ import { statusLabel, escapeHtml, escapeAttribute } from "../utils.js";
 import { getOrCreateEntry, renderVocabulary } from "../views/vocabulary.js";
 import { setEntryStatus } from "../vocabulary/entry-state.js";
 import { playStatusSound } from "../status-sounds.js";
+import { invalidateReviewQueueCache } from "../vocabulary/review-card.js";
+import { invalidateSuggestIndex } from "../reader/smart-suggest.js";
 import { registerUnsavedDialog } from "../dialog-backdrop.js";
 import { VOCAB_STATUS_FILTERS } from "./vocab-status.js";
 
@@ -176,6 +178,10 @@ export function bindWordEditorEvents() {
       }
       const previousStatus = setEntryStatus(entry, selectedStatus, now);
       if (previousStatus !== selectedStatus) playStatusSound(selectedStatus);
+      // Dialog status edits bypass gradeReview/removeFromSrs — the queue memo
+      // and the suggest index must not survive them.
+      invalidateReviewQueueCache();
+      invalidateSuggestIndex();
       const example = addExampleInput?.value.trim();
       if (example) {
         entry.examples = [example, ...(entry.examples || []).filter(e => e !== example)].slice(0, 3);

--- a/src/web/js/events/word-editor.ts
+++ b/src/web/js/events/word-editor.ts
@@ -198,6 +198,10 @@ export function bindWordEditorEvents() {
       const entry = getOrCreateEntry(word);
       const previousStatus = setEntryStatus(entry, selectedStatus, now);
       if (previousStatus !== selectedStatus) playStatusSound(selectedStatus);
+      // The add branch also feeds the review queue (status + nextDate are
+      // memo inputs) — invalidate like the edit branch above.
+      invalidateReviewQueueCache();
+      invalidateSuggestIndex();
       const article = addArticleInput?.value.trim();
       if (article) entry.article = article;
       const translation = addTranslationInput?.value.trim();

--- a/src/web/js/reader/find.ts
+++ b/src/web/js/reader/find.ts
@@ -49,20 +49,37 @@ function computeMatches(query: string): FindMatch[] {
   const context = currentContext();
   if (!context) return [];
   const { session, wordsPerPage } = context;
+  // Word tokens with a mapped global offset, sorted by offset. The old
+  // code scanned every token per match — O(matches x tokens) — stalling
+  // on long books; the binary search brings it to O(matches x log tokens).
+  const indexed: { offset: number; tokenIndex: number }[] = [];
+  for (let i = 0; i < session.tokens.length; i += 1) {
+    const token = session.tokens[i];
+    if (token.type !== "word") continue;
+    const offset = session.globalCharOffsets[i];
+    if (offset >= 0) indexed.push({ offset, tokenIndex: i });
+  }
+  indexed.sort((a, b) => a.offset - b.offset);
   const matches: FindMatch[] = [];
   for (const start of findAll(session.text, query)) {
+    // Largest token offset <= start (tokens are ordered, non-overlapping).
+    let lo = 0;
+    let hi = indexed.length - 1;
     let tokenIndex = -1;
-    for (let i = 0; i < session.tokens.length; i += 1) {
-      const token = session.tokens[i];
-      if (token.type !== "word") continue;
-      const offset = session.globalCharOffsets[i];
-      if (offset < 0) continue;
-      if (start >= offset && start < offset + token.value.length) {
-        tokenIndex = i;
-        break;
+    let offset = -1;
+    while (lo <= hi) {
+      const mid = (lo + hi) >> 1;
+      if (indexed[mid].offset <= start) {
+        tokenIndex = indexed[mid].tokenIndex;
+        offset = indexed[mid].offset;
+        lo = mid + 1;
+      } else {
+        hi = mid - 1;
       }
     }
     if (tokenIndex === -1) continue;
+    const token = session.tokens[tokenIndex];
+    if (start >= offset + token.value.length) continue;
     const wordIndex = session.globalWordIndexes[tokenIndex];
     matches.push({ page: Math.floor(wordIndex / wordsPerPage) + 1, tokenIndex });
   }

--- a/src/web/js/reader/smart-suggest.ts
+++ b/src/web/js/reader/smart-suggest.ts
@@ -101,6 +101,13 @@ function detectArticle(context: string, word: string, language: string): Article
 let suggestPrefixIndex = new Map<string, string[]>();
 let lastSuggestPrefixVocab: Record<string, { status?: string }> | null = null;
 
+// In-place vocab mutations (deleteWord, getOrCreateEntry) keep the vocab map
+// reference, so the lazily built prefix index would go stale (dead keys and
+// missed entries). Reset the marker so the next query rebuilds the index.
+export function invalidateSuggestIndex(): void {
+  lastSuggestPrefixVocab = null;
+}
+
 export function getSmartSuggestion(context: string, word: string): SmartSuggestion | null {
   if (!context || !word || word.includes(" ")) return null;
   const language = effectiveLearningLanguage(state.preferences);
@@ -210,7 +217,12 @@ function checkGermanSeparableVerb(context: string, word: string): string | null 
   }
   let isPrefixConsumed = false;
   for (const vocabWord of suggestPrefixIndex.get(lastWord) || []) {
-    if (state.vocab[vocabWord].status === "new") continue;
+    // Entries are deleted in place (deleteWord mutates the vocab map without
+    // replacing its reference), so the index can hold dead keys — skip them
+    // instead of crashing the word panel on a TypeError.
+    const entry = state.vocab[vocabWord];
+    if (!entry) continue;
+    if (entry.status === "new") continue;
     const verbPart = vocabWord.split(" ")[0];
     if (!verbPart) continue;
     const verbRegex = new RegExp(`\\b${verbPart}\\b`, 'i');

--- a/src/web/js/reader/smart-suggest.ts
+++ b/src/web/js/reader/smart-suggest.ts
@@ -97,6 +97,10 @@ function detectArticle(context: string, word: string, language: string): Article
   return null;
 }
 
+// Lazily built index: trailing word -> multi-word vocab keys (non-new status).
+let suggestPrefixIndex = new Map<string, string[]>();
+let lastSuggestPrefixVocab: Record<string, { status?: string }> | null = null;
+
 export function getSmartSuggestion(context: string, word: string): SmartSuggestion | null {
   if (!context || !word || word.includes(" ")) return null;
   const language = effectiveLearningLanguage(state.preferences);
@@ -185,17 +189,34 @@ function checkGermanSeparableVerb(context: string, word: string): string | null 
     return null;
   }
 
-  // Check if prefix has already been consumed by another word in this sentence
+  // Check if prefix has already been consumed by another word in this sentence.
+  // The vocab can be ~90k entries; an index keyed by the trailing word is
+  // rebuilt only when the vocab object changes (not per word-panel render).
+  if (state.vocab !== lastSuggestPrefixVocab) {
+    // No status filter here: grades mutate entries in place, so the
+    // status is checked at query time (only the tiny bucket is scanned).
+    const index = new Map<string, string[]>();
+    for (const vocabWord in state.vocab) {
+      const space = vocabWord.lastIndexOf(" ");
+      if (space <= 0) continue;
+      const tail = vocabWord.slice(space + 1).toLowerCase();
+      if (!tail) continue;
+      const bucket = index.get(tail);
+      if (bucket) bucket.push(vocabWord);
+      else index.set(tail, [vocabWord]);
+    }
+    suggestPrefixIndex = index;
+    lastSuggestPrefixVocab = state.vocab;
+  }
   let isPrefixConsumed = false;
-  for (const vocabWord in state.vocab) {
-    if (vocabWord.toLowerCase().endsWith(" " + lastWord) && state.vocab[vocabWord].status !== "new") {
-      const verbPart = vocabWord.split(" ")[0];
-      if (!verbPart) continue;
-      const verbRegex = new RegExp(`\\b${verbPart}\\b`, 'i');
-      if (verbRegex.test(context)) {
-        isPrefixConsumed = true;
-        break;
-      }
+  for (const vocabWord of suggestPrefixIndex.get(lastWord) || []) {
+    if (state.vocab[vocabWord].status === "new") continue;
+    const verbPart = vocabWord.split(" ")[0];
+    if (!verbPart) continue;
+    const verbRegex = new RegExp(`\\b${verbPart}\\b`, 'i');
+    if (verbRegex.test(context)) {
+      isPrefixConsumed = true;
+      break;
     }
   }
 

--- a/src/web/js/views/vocabulary.ts
+++ b/src/web/js/views/vocabulary.ts
@@ -4,6 +4,7 @@ import { getSentenceForWord, resolveVocabularyKey } from "../tokenizer_v2.js";
 import { ensureSM2Fields, SM2_DEFAULTS, FSRS_DEFAULTS, todayISO } from "../sm2.js";
 import { sessionAddedWords } from "../vocabulary/vocab-list.js";
 import { effectiveLearningLanguage } from "../translator-preferences.js";
+import { invalidateSuggestIndex } from "../reader/smart-suggest.js";
 
 // Module-level state: answer visibility for review
 export let reviewAnswerVisible: boolean = false;
@@ -26,6 +27,10 @@ export function getOrCreateEntry(
   const displayWord = String(word || "").trim().normalize("NFC");
   const key = resolveVocabularyKey(displayWord, state.vocab, effectiveLearningLanguage(state.preferences));
   if (!Object.hasOwn(state.vocab, key)) {
+    // In-place add keeps the vocab reference — the lazily built suggest index
+    // would miss the new key until the end of the session (duplicate
+    // suggestions), so invalidate it.
+    invalidateSuggestIndex();
     const createdAt = new Date().toISOString();
     state.vocab[key] = {
       word: displayWord,

--- a/src/web/js/vocab-actions.ts
+++ b/src/web/js/vocab-actions.ts
@@ -126,6 +126,9 @@ export function selectWord(
     setEntryStatus(entry, "learning");
     playStatusSound("learning");
     statusChanged = true;
+    // autoLearnOnClick feeds the review queue (status + nextDate are memo
+    // inputs) — invalidate so the new word shows up in the queue.
+    invalidateReviewQueueCache();
   }
   if (getDurableStateRevision() !== durableRevision) saveState();
   else saveUiState();

--- a/src/web/js/vocab-actions.ts
+++ b/src/web/js/vocab-actions.ts
@@ -9,6 +9,8 @@ import { renderShell } from "./views/shell.js";
 import { getOrCreateEntry, renderVocabulary, renderReview, hideReviewAnswer, toggleReviewAnswer } from "./views/vocabulary.js";
 import { renderLibrary } from "./views/library.js";
 import { speakWord } from "./tts.js";
+import { invalidateSuggestIndex } from "./reader/smart-suggest.js";
+import { invalidateReviewQueueCache } from "./vocabulary/review-card.js";
 import { canUseTranslationProvider, translateWithRetry } from "./translation-provider.js";
 import { setEntryStatus } from "./vocabulary/entry-state.js";
 import { playStatusSound } from "./status-sounds.js";
@@ -192,6 +194,9 @@ export function setWordStatus(word: string, status: string): void {
   maybeAutoTranslateWord(word, entry).catch((e) => console.warn("auto translate failed", e));
   setEntryStatus(entry, status);
   if (previousStatus !== status) playStatusSound(status);
+  // The review queue depends on word statuses; the memo must not survive a
+  // status change made outside gradeReview/removeFromSrs.
+  invalidateReviewQueueCache();
   saveState();
   renderShell();
   updateWordStatusInReader(word, status);
@@ -235,6 +240,10 @@ export function updateWordField(word: string, field: string, value: unknown): vo
 export function deleteWord(word: string): void {
   word = resolveVocabularyKey(word, state.vocab, effectiveLearningLanguage(state.preferences));
   delete state.vocab[word];
+  // In-place mutations keep the vocab reference, so the lazily built suggest
+  // index and the review-queue memo would go stale (dead keys / phantoms).
+  invalidateSuggestIndex();
+  invalidateReviewQueueCache();
   failedAutoTranslations.delete(word);
   initialVocabKeys.delete(word);
   if (state.selectedWord === word) state.selectedWord = null;

--- a/src/web/js/vocabulary/review-card.ts
+++ b/src/web/js/vocabulary/review-card.ts
@@ -109,17 +109,38 @@ export function resetReviewPresentation(): void {
   lastAutoSpokenPresentation = "";
 }
 
+// The queue rebuild (filter + sort over the whole vocab) is the hot path on
+// every grade; memoize it and invalidate explicitly on mutations.
+let reviewQueueCache: {
+  vocabRef: Record<string, WhVocabEntry>;
+  today: string;
+  autoAddLearningOnly: boolean;
+  entries: ReviewQueueEntry[];
+} | null = null;
+
 export function renderReview(transition?: ReviewTransitionDirection): void {
   if (!els.reviewCard) return;
   const today = todayISO();
-  const srsEntries: ReviewQueueEntry[] = Object.entries(state.vocab)
-    .filter(([, entry]) => {
-      if (entry.status === "ignored" || entry.status === "known") return false;
-      if (state.preferences?.autoAddLearningOnly && entry.status === "new") return false;
-      return true;
-    })
-    .map(([key, entry]) => ({ ...entry, key, word: entry.word || key, nextDate: entry.nextDate || today }))
-    .sort((a, b) => a.nextDate.localeCompare(b.nextDate));
+  const autoAddLearningOnly = state.preferences?.autoAddLearningOnly === true;
+  let srsEntries: ReviewQueueEntry[];
+  if (
+    reviewQueueCache &&
+    reviewQueueCache.vocabRef === state.vocab &&
+    reviewQueueCache.today === today &&
+    reviewQueueCache.autoAddLearningOnly === autoAddLearningOnly
+  ) {
+    srsEntries = reviewQueueCache.entries;
+  } else {
+    srsEntries = Object.entries(state.vocab)
+      .filter(([, entry]) => {
+        if (entry.status === "ignored" || entry.status === "known") return false;
+        if (autoAddLearningOnly && entry.status === "new") return false;
+        return true;
+      })
+      .map(([key, entry]) => ({ ...entry, key, word: entry.word || key, nextDate: entry.nextDate || today }))
+      .sort((a, b) => a.nextDate.localeCompare(b.nextDate));
+    reviewQueueCache = { vocabRef: state.vocab, today, autoAddLearningOnly, entries: srsEntries };
+  }
   const reviewWords = buildReviewQueue(srsEntries, today);
 
   // A new review session starts whenever the queue goes from empty to non-empty
@@ -370,6 +391,7 @@ export async function gradeReview(word: string, quality: number): Promise<void> 
     playReviewGradeSound(quality);
     const { hideReviewAnswer } = await import("../views/vocabulary.js");
     hideReviewAnswer();
+    reviewQueueCache = null;
     renderReview();
   } finally {
     reviewGradePending = false;
@@ -388,6 +410,7 @@ export function removeFromSrs(word: string): void {
   if (previousStatus !== "ignored") playStatusSound("ignored");
   saveState();
   state.reviewIndex = 0;
+  reviewQueueCache = null;
   renderReview();
   renderVocabulary();
 }

--- a/src/web/js/vocabulary/review-card.ts
+++ b/src/web/js/vocabulary/review-card.ts
@@ -415,6 +415,14 @@ export function removeFromSrs(word: string): void {
   renderVocabulary();
 }
 
+// Mutation sites outside this module (deleteWord, setWordStatus, the
+// word-editor dialog) change the queue's inputs without going through
+// gradeReview/removeFromSrs; they must invalidate the memo or the review
+// queue shows phantom/stale entries.
+export function invalidateReviewQueueCache(): void {
+  reviewQueueCache = null;
+}
+
 export function formatSrsMeta(entry: SrsMetaEntry): string {
   const mode = state.preferences?.srsAlgorithm === "fsrs" || entry.srsAlgorithm === "fsrs" ? "fsrs" : "sm2";
   if (mode === "fsrs") {


### PR DESCRIPTION
Part of #115 (perf sub-items: find binary search + smart-suggest index + review-queue memo; remaining sub-items 4-6 — snapshot delta stale-marking, records_cache clone reuse, re-render guard — tracked in the issue)

**Remediation adds:** dead-key guard in the suggest index (word panel TypeError fix) + cache invalidation at every in-place mutation site (deleteWord, setWordStatus, getOrCreateEntry, word-editor dialog); 2 new RED-on-base tests.

**Verification:** 522/522 frontend; check:frontend; cargo test --lib.