### PR TITLE
Fix #107: reject null-origin POSTs (sandboxed-embed CSRF hardening)

### DIFF
--- a/src-tauri/src/router.rs
+++ b/src-tauri/src/router.rs
@@ -78,7 +78,15 @@ pub(crate) fn valid_request_source(request: &Request, base_url: &str) -> bool {
     {
         return false;
     }
-    request_header(request, "Origin").is_none_or(|origin| origin == base_url || origin == "null")
+    // A same-origin fetch carries no Origin header; the app's own pages
+    // never send "null". file:///data: embeds and sandboxed frames do —
+    // they may issue read-only GETs, but never authenticated writes.
+    match request_header(request, "Origin") {
+        None => true,
+        Some(origin) if origin == base_url => true,
+        Some("null") => request.method() != &Method::Post,
+        Some(_) => false,
+    }
 }
 
 fn authenticate_request(

--- a/src-tauri/src/tests/http_boundary/tests.rs
+++ b/src-tauri/src/tests/http_boundary/tests.rs
@@ -184,12 +184,15 @@ fn rejects_dns_rebinding_hosts_and_cross_site_origins() {
 fn rejects_null_origin_writes_but_allows_null_origin_reads() {
     let post = "POST /__store/save HTTP/1.0\r\nHost: 127.0.0.1:{port}\r\nOrigin: null\r\nX-WH-Token: {TOKEN}\r\nContent-Length: 0\r\n\r\n";
     // /__media is token-free by design — it proves the origin allowance itself.
-let get = "GET /__media?book=x&img=y HTTP/1.0\r\nHost: 127.0.0.1:{port}\r\nOrigin: null\r\n\r\n";
+    let get =
+        "GET /__media?book=x&img=y HTTP/1.0\r\nHost: 127.0.0.1:{port}\r\nOrigin: null\r\n\r\n";
     // The null-origin POST must be rejected up front (403). A null-origin
-// GET stays allowed — it reaches the handlers (404 here, not 403).
-for (template, expected_status) in [(post, " 403 "), (get, " 404 ")] {
+    // GET stays allowed — it reaches the handlers (404 here, not 403).
+    for (template, expected_status) in [(post, " 403 "), (get, " 404 ")] {
         let (port, server) = spawn_boundary_server();
-        let raw = template.replace("{port}", &port.to_string()).replace("{TOKEN}", TOKEN);
+        let raw = template
+            .replace("{port}", &port.to_string())
+            .replace("{TOKEN}", TOKEN);
         let mut stream = TcpStream::connect(("127.0.0.1", port)).unwrap();
         stream.write_all(raw.as_bytes()).unwrap();
         stream.shutdown(Shutdown::Write).unwrap();
@@ -197,10 +200,12 @@ for (template, expected_status) in [(post, " 403 "), (get, " 404 ")] {
         stream.read_to_string(&mut response).unwrap();
         server.join().unwrap();
         let status_line = response.lines().next().unwrap_or_default();
-        assert!(status_line.contains(expected_status), "unexpected response: {status_line}");
+        assert!(
+            status_line.contains(expected_status),
+            "unexpected response: {status_line}"
+        );
     }
 }
-
 
 #[test]
 fn static_responses_include_security_headers() {

--- a/src-tauri/src/tests/http_boundary/tests.rs
+++ b/src-tauri/src/tests/http_boundary/tests.rs
@@ -181,6 +181,28 @@ fn rejects_dns_rebinding_hosts_and_cross_site_origins() {
 }
 
 #[test]
+fn rejects_null_origin_writes_but_allows_null_origin_reads() {
+    let post = "POST /__store/save HTTP/1.0\r\nHost: 127.0.0.1:{port}\r\nOrigin: null\r\nX-WH-Token: {TOKEN}\r\nContent-Length: 0\r\n\r\n";
+    // /__media is token-free by design — it proves the origin allowance itself.
+let get = "GET /__media?book=x&img=y HTTP/1.0\r\nHost: 127.0.0.1:{port}\r\nOrigin: null\r\n\r\n";
+    // The null-origin POST must be rejected up front (403). A null-origin
+// GET stays allowed — it reaches the handlers (404 here, not 403).
+for (template, expected_status) in [(post, " 403 "), (get, " 404 ")] {
+        let (port, server) = spawn_boundary_server();
+        let raw = template.replace("{port}", &port.to_string()).replace("{TOKEN}", TOKEN);
+        let mut stream = TcpStream::connect(("127.0.0.1", port)).unwrap();
+        stream.write_all(raw.as_bytes()).unwrap();
+        stream.shutdown(Shutdown::Write).unwrap();
+        let mut response = String::new();
+        stream.read_to_string(&mut response).unwrap();
+        server.join().unwrap();
+        let status_line = response.lines().next().unwrap_or_default();
+        assert!(status_line.contains(expected_status), "unexpected response: {status_line}");
+    }
+}
+
+
+#[test]
 fn static_responses_include_security_headers() {
     let (port, server) = spawn_boundary_server();
     let mut stream = TcpStream::connect(("127.0.0.1", port)).unwrap();


### PR DESCRIPTION
Part of #107 (null-origin POST rejection only; the token-for-executing-GETs item — /__open_external, /__open_dict, /__data and /__media in sensitive_get_path — stays tracked in the issue)

**Scope:** src-tauri/src/router.rs — valid_request_source rejects Origin: null POSTs (403) while allowing null-origin GETs; bidirectional HTTP test (POST → 403, GET → 404).

**Audit note:** code is merge-ready; the issue's remaining bullet requires a separate follow-up.

**Verification:** cargo test --lib green; frontend suite green.