### PR TITLE
Fix #120: remove guarded package extraction unwrap

### DIFF
--- a/src-tauri/src/offline_translator/translator/package.rs
+++ b/src-tauri/src/offline_translator/translator/package.rs
@@ -174,14 +174,16 @@ fn extract_package(data: &[u8], target: &Path) -> Result<(), String> {
         let mut output = fs::File::create(&destination).map_err(|e| e.to_string())?;
         std::io::copy(&mut file, &mut output).map_err(|e| e.to_string())?;
     }
-    let mut entries = fs::read_dir(staging.path())
+    let entries = fs::read_dir(staging.path())
         .map_err(|e| e.to_string())?
         .filter_map(Result::ok)
         .collect::<Vec<_>>();
-    if entries.len() != 1 || !entries[0].path().is_dir() {
-        return Err("model package must contain exactly one top-level directory".to_string());
-    }
-    let package = entries.pop().unwrap().path();
+    let package = match entries.as_slice() {
+        [entry] if entry.path().is_dir() => entry.path(),
+        _ => {
+            return Err("model package must contain exactly one top-level directory".to_string());
+        }
+    };
     let name = package
         .file_name()
         .ok_or_else(|| "invalid model package directory".to_string())?;


### PR DESCRIPTION
Addresses the offline-translator package robustness item from #120. This does not close the broader issue.\n\nReplaces the guard-then-unwrap with an exhaustive slice match while preserving valid extraction and existing error semantics.\n\nVerification: focused package tests 3/3; clippy all targets with -D warnings; cargo fmt --check; git diff --check.