### PR TITLE
Fix #120: reject NTFS alternate-stream ids

### DIFF
--- a/src-tauri/src/paths.rs
+++ b/src-tauri/src/paths.rs
@@ -110,7 +110,7 @@ pub fn device_id(app_name: &str) -> Result<String, String> {
 }
 
 pub fn sanitize_id(id: &str) -> Result<String, String> {
-    if id.contains('/') || id.contains('\\') {
+    if id.contains('/') || id.contains('\\') || id.contains(':') {
         return Err("invalid id".to_string());
     }
     let path = Path::new(id);

--- a/src-tauri/src/tests/paths/tests.rs
+++ b/src-tauri/src/tests/paths/tests.rs
@@ -39,6 +39,7 @@ fn sanitizes_ids_to_file_names() {
     assert_eq!(sanitize_id("book-1").unwrap(), "book-1");
     assert!(sanitize_id("../book-1").is_err());
     assert!(sanitize_id("folder\\book-1").is_err());
+    assert!(sanitize_id("book:alternate-stream").is_err());
     assert!(sanitize_id("..").is_err());
 }
 


### PR DESCRIPTION
Addresses the sanitize_id NTFS alternate-data-stream item from #120. This does not close the broader issue.\n\nTDD: the new colon-id regression failed on the integration base, then passed after sanitize_id rejected colons.\n\nVerification: focused paths test; cargo fmt --check; git diff --check.