### PR TITLE
Fix #120: count translator limit in Unicode characters

### DIFF
--- a/src-tauri/src/external_translator.rs
+++ b/src-tauri/src/external_translator.rs
@@ -31,10 +31,7 @@ pub fn translate(payload: Value) -> Result<Value, String> {
     let to = payload.get("to").and_then(Value::as_str).unwrap_or("pl");
     let key = payload.get("key").and_then(Value::as_str).unwrap_or("");
 
-    if text.is_empty() {
-        return Ok(json!({ "translated": "", "engine": provider }));
-    }
-    if text.len() > MAX_TEXT_LEN {
+    if text.chars().count() > MAX_TEXT_LEN {
         return Err("text too long".to_string());
     }
 
@@ -227,8 +224,10 @@ fn is_local_lmstudio_url(url: &Url) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{deepl_lang, google_lang, is_local_lmstudio_url};
+    use serde_json::json;
     use url::Url;
+
+    use super::{deepl_lang, google_lang, is_local_lmstudio_url, translate};
 
     #[test]
     fn deepl_uses_target_specific_english_code() {
@@ -257,5 +256,22 @@ mod tests {
         assert!(!is_local_lmstudio_url(
             &Url::parse("https://example.com/v1/chat/completions").unwrap()
         ));
+    }
+
+    #[test]
+    fn text_limit_counts_unicode_characters_instead_of_utf8_bytes() {
+        let accepted = translate(json!({
+            "provider": "unsupported",
+            "text": "ż".repeat(5_000),
+        }))
+        .unwrap_err();
+        assert_eq!(accepted, "unknown translation provider");
+
+        let rejected = translate(json!({
+            "provider": "unsupported",
+            "text": "ż".repeat(5_001),
+        }))
+        .unwrap_err();
+        assert_eq!(rejected, "text too long");
     }
 }


### PR DESCRIPTION
Addresses the external-translator character-limit item from #120. This does not close the broader issue.\n\nTDD: a 5,000-character non-ASCII payload was incorrectly rejected by the byte limit; the regression now passes, while 5,001 characters remain rejected. Also removes the unreachable duplicate empty-text branch.\n\nVerification: focused regression; cargo fmt --check; git diff --check.