### PR TITLE
Fix #120: preserve negative SRS day offsets

### DIFF
--- a/src-tauri/src/srs/date.rs
+++ b/src-tauri/src/srs/date.rs
@@ -10,7 +10,7 @@ pub fn today_iso(date: OffsetDateTime) -> String {
 }
 
 pub fn add_days_iso_from(days: i64, from: OffsetDateTime) -> String {
-    let next = from + TimeDuration::days(days.max(0));
+    let next = from + TimeDuration::days(days);
     today_iso(next)
 }
 
@@ -28,7 +28,7 @@ pub(crate) fn add_days_iso(today: &str, days: i64) -> String {
     ) else {
         return today.to_string();
     };
-    let next = date + TimeDuration::days(days.max(0));
+    let next = date + TimeDuration::days(days);
     format!(
         "{:04}-{:02}-{:02}",
         next.year(),

--- a/src-tauri/src/tests/srs/tests.rs
+++ b/src-tauri/src/tests/srs/tests.rs
@@ -112,7 +112,8 @@ fn add_days_iso_from_advances_date() {
     let dt = OffsetDateTime::parse("2026-06-16T12:00:00Z", &Rfc3339).unwrap();
     assert_eq!(add_days_iso_from(3, dt), "2026-06-19");
     assert_eq!(add_days_iso_from(0, dt), "2026-06-16");
-    assert_eq!(add_days_iso_from(-5, dt), "2026-06-16");
+    assert_eq!(add_days_iso_from(-5, dt), "2026-06-11");
+    assert_eq!(add_days_iso("2026-06-16", -5), "2026-06-11");
 }
 
 #[test]


### PR DESCRIPTION
Addresses the negative-day clamping item from #120. This does not close the broader issue.\n\nTDD: the updated regression failed while negative offsets were silently clamped to zero; both date helpers now preserve subtraction semantics.\n\nVerification: all 10 SRS tests; cargo fmt --check; git diff --check.