### PR TITLE
Fix #120: bound ebook data URL decoding

### DIFF
--- a/src-tauri/src/ebook/mod.rs
+++ b/src-tauri/src/ebook/mod.rs
@@ -9,10 +9,30 @@ use std::path::Path;
 use self::calibre::convert_with_calibre;
 use self::epub::parse_epub;
 
+const MAX_EBOOK_BYTES: usize = 64 * 1024 * 1024;
+
 #[cfg(test)]
 pub(crate) use self::epub::epub_href;
 #[cfg(test)]
 pub(crate) use self::text::strip_xhtml_to_text;
+
+fn decode_ebook_payload_with_limit(data_url: &str, max_bytes: usize) -> Result<Vec<u8>, String> {
+    let encoded = data_url
+        .split_once(',')
+        .map(|(_, data)| data)
+        .unwrap_or(data_url);
+    let max_encoded_bytes = (max_bytes.saturating_mul(4) / 3).saturating_add(4);
+    if encoded.len() > max_encoded_bytes {
+        return Err("ebook payload is too large".to_string());
+    }
+    let data = base64::engine::general_purpose::STANDARD
+        .decode(encoded)
+        .map_err(|e| e.to_string())?;
+    if data.len() > max_bytes {
+        return Err("ebook payload is too large".to_string());
+    }
+    Ok(data)
+}
 
 pub fn import(payload: Value) -> Result<Value, String> {
     let filename = payload
@@ -20,13 +40,7 @@ pub fn import(payload: Value) -> Result<Value, String> {
         .and_then(Value::as_str)
         .unwrap_or("");
     let data_url = payload.get("data").and_then(Value::as_str).unwrap_or("");
-    let encoded = data_url
-        .split_once(',')
-        .map(|(_, data)| data)
-        .unwrap_or(data_url);
-    let data = base64::engine::general_purpose::STANDARD
-        .decode(encoded)
-        .map_err(|e| e.to_string())?;
+    let data = decode_ebook_payload_with_limit(data_url, MAX_EBOOK_BYTES)?;
     let suffix = Path::new(filename)
         .extension()
         .and_then(|ext| ext.to_str())

--- a/src-tauri/src/tests/ebook/tests.rs
+++ b/src-tauri/src/tests/ebook/tests.rs
@@ -4,7 +4,7 @@ use base64::Engine;
 use serde_json::json;
 use zip::{ZipWriter, write::SimpleFileOptions};
 
-use super::{epub_href, import, strip_xhtml_to_text};
+use super::{decode_ebook_payload_with_limit, epub_href, import, strip_xhtml_to_text};
 
 #[test]
 fn normalizes_epub_hrefs() {
@@ -19,6 +19,13 @@ fn normalizes_epub_hrefs() {
 #[test]
 fn strips_basic_xhtml() {
     assert_eq!(strip_xhtml_to_text("<p>Hello<br>world</p>"), "Hello\nworld");
+}
+
+#[test]
+fn ebook_payload_enforces_decoded_and_encoded_size_limits() {
+    let encoded = base64::engine::general_purpose::STANDARD.encode(vec![b'x'; 9]);
+    assert!(decode_ebook_payload_with_limit(&encoded, 8).is_err());
+    assert!(decode_ebook_payload_with_limit(&"A".repeat(20), 8).is_err());
 }
 
 #[test]


### PR DESCRIPTION
Addresses the unbounded ebook data-URL item from #120. This does not close the broader issue.\n\nAdds a 64 MiB decoded limit plus an encoded-length precheck, preventing oversized base64 allocation before EPUB/MOBI/AZW parsing.\n\nTDD: the focused limit test initially failed to compile; current ebook suite is 8/8. Also verified cargo fmt --check and git diff --check.