### PR TITLE
Fix #120: fresh runner deadline per attempt + GPU re-probe

### DIFF
--- a/src-tauri/src/pdf_ocr/mod.rs
+++ b/src-tauri/src/pdf_ocr/mod.rs
@@ -692,9 +692,7 @@ pub fn cancel(payload: Value, jobs: &Mutex<OcrJobState>) -> Result<(), String> {
 }
 
 pub fn gpu_status(app_handle: &AppHandle) -> Value {
-    runner::GPU_STATUS
-        .get_or_init(|| runner::probe_gpu_status(app_handle))
-        .clone()
+    runner::cached_gpu_status(app_handle)
 }
 
 pub fn image_ocr_available(app_handle: &AppHandle) -> bool {
@@ -704,6 +702,8 @@ pub fn image_ocr_available(app_handle: &AppHandle) -> bool {
 #[cfg(test)]
 #[allow(clippy::items_after_test_module)]
 mod tests {
+    use std::fs;
+    use std::path::{Path, PathBuf};
     use std::sync::Mutex;
 
     #[cfg(test)]
@@ -918,6 +918,126 @@ mod tests {
             runner::platform_gpu_status_without_runner().unwrap()["status"],
             "unavailable"
         );
+    }
+
+    #[test]
+    fn gpu_status_reprobes_after_failed_probe_and_caches_success() {
+        runner::reset_gpu_status_cache();
+
+        let probe_calls = std::sync::atomic::AtomicUsize::new(0);
+        let probe = || {
+            let call = probe_calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
+            if call == 1 {
+                runner::gpu_status_value("failed")
+            } else {
+                runner::gpu_status_value("unavailable")
+            }
+        };
+
+        assert_eq!(runner::cached_gpu_status_with(probe)["status"], "failed");
+        assert_eq!(
+            runner::cached_gpu_status_with(probe)["status"],
+            "unavailable"
+        );
+        assert_eq!(
+            runner::cached_gpu_status_with(probe)["status"],
+            "unavailable"
+        );
+        assert_eq!(probe_calls.load(std::sync::atomic::Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn cpu_fallback_attempt_gets_a_fresh_deadline() {
+        let temp = tempfile::tempdir().unwrap();
+        let invocations = temp.path().join("invocations.txt");
+        let runner = write_deadline_runner(temp.path(), &invocations);
+        let input_path = temp.path().join("input.pdf");
+        let pages_dir = temp.path().join("pages");
+        let json_path = temp.path().join("ocr.json");
+        fs::write(&input_path, b"pdf").unwrap();
+        fs::create_dir_all(&pages_dir).unwrap();
+        let jobs = Mutex::new(OcrJobState::default());
+
+        runner::run_runner(
+            &runner,
+            runner::RunnerJob {
+                input_path: &input_path,
+                pages_dir: &pages_dir,
+                json_path: &json_path,
+                lang: "en",
+                max_pages: 1,
+                work_dir: temp.path(),
+                job_id: "job",
+                jobs: &jobs,
+            },
+        )
+        .unwrap();
+
+        let devices = fs::read_to_string(&invocations).unwrap();
+        assert_eq!(devices.lines().collect::<Vec<_>>(), ["auto", "cpu"]);
+    }
+
+    /// Fake OCR runner whose `auto` attempt fails after ~2s and whose `cpu` attempt
+    /// succeeds after ~2s, recording each requested device into `invocations`.
+    /// With the 3s test-only attempt timeout, a shared deadline would kill the
+    /// `cpu` fallback, while a fresh deadline lets it finish.
+    #[cfg(windows)]
+    fn write_deadline_runner(dir: &Path, invocations: &Path) -> PathBuf {
+        let path = dir.join("fake-runner.cmd");
+        let script = format!(
+            "@echo off\r\n\
+             setlocal\r\n\
+             set device=\r\n\
+             :loop\r\n\
+             if \"%~1\"==\"\" goto :run\r\n\
+             if \"%~1\"==\"--device\" set device=%~2\r\n\
+             shift\r\n\
+             goto :loop\r\n\
+             :run\r\n\
+             >>\"{}\" echo %device%\r\n\
+             if \"%device%\"==\"auto\" (\r\n\
+               ping -n 3 127.0.0.1 >nul\r\n\
+               exit /b 1\r\n\
+             )\r\n\
+             ping -n 3 127.0.0.1 >nul\r\n\
+             exit /b 0",
+            invocations.display()
+        );
+        fs::write(&path, script).unwrap();
+        path
+    }
+
+    #[cfg(not(windows))]
+    fn write_deadline_runner(dir: &Path, invocations: &Path) -> PathBuf {
+        let path = dir.join("fake-runner.sh");
+        let script = format!(
+            "#!/bin/sh\n\
+             set -eu\n\
+             device=\"\"\n\
+             while [ \"$#\" -gt 0 ]; do\n\
+               if [ \"$1\" = --device ]; then\n\
+                 device=\"$2\"\n\
+               fi\n\
+               shift\n\
+             done\n\
+             printf '%s\\n' \"$device\" >> '{}'\n\
+             if [ \"$device\" = auto ]; then\n\
+               sleep 2\n\
+               exit 1\n\
+             fi\n\
+             sleep 2\n\
+             exit 0",
+            invocations.display()
+        );
+        fs::write(&path, script).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut permissions = fs::metadata(&path).unwrap().permissions();
+            permissions.set_mode(0o755);
+            fs::set_permissions(&path, permissions).unwrap();
+        }
+        path
     }
 
     fn minimal_text_pdf(text: &str) -> Vec<u8> {

--- a/src-tauri/src/pdf_ocr/mod.rs
+++ b/src-tauri/src/pdf_ocr/mod.rs
@@ -705,6 +705,7 @@ mod tests {
     use std::fs;
     use std::path::{Path, PathBuf};
     use std::sync::Mutex;
+    use std::time::{Duration, Instant};
 
     #[cfg(test)]
     use base64::Engine;
@@ -958,7 +959,29 @@ mod tests {
         fs::create_dir_all(&pages_dir).unwrap();
         let jobs = Mutex::new(OcrJobState::default());
 
-        runner::run_runner(
+        // Scripted clock: reads #1 and #2 return `t0` (the moment the auto
+        // attempt starts); every later read jumps 2 hours ahead. The auto
+        // attempt consumes exactly two reads — its deadline (#1) and the
+        // first loop check (#2), which always fires because the fake runner
+        // process cannot have exited yet — and then fails immediately. The
+        // cpu fallback's reads all see the jumped time: with a fresh
+        // per-attempt deadline its own deadline is computed from the jumped
+        // time, so the loop finishes. With the old shared-deadline code the
+        // cpu fallback inherits the auto deadline (t0 + 3s in tests), the
+        // jumped time is already past it, and the loop kills the attempt with
+        // a fatal timeout -> the test fails.
+        let t0 = Instant::now();
+        let clock_calls = std::sync::atomic::AtomicUsize::new(0);
+        let clock = move || {
+            let call = clock_calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
+            if call <= 2 {
+                t0
+            } else {
+                t0 + Duration::from_secs(7200)
+            }
+        };
+
+        runner::run_runner_with_clock(
             &runner,
             runner::RunnerJob {
                 input_path: &input_path,
@@ -970,6 +993,7 @@ mod tests {
                 job_id: "job",
                 jobs: &jobs,
             },
+            clock,
         )
         .unwrap();
 
@@ -977,10 +1001,11 @@ mod tests {
         assert_eq!(devices.lines().collect::<Vec<_>>(), ["auto", "cpu"]);
     }
 
-    /// Fake OCR runner whose `auto` attempt fails after ~2s and whose `cpu` attempt
-    /// succeeds after ~2s, recording each requested device into `invocations`.
-    /// With the 3s test-only attempt timeout, a shared deadline would kill the
-    /// `cpu` fallback, while a fresh deadline lets it finish.
+    /// Fake OCR runner whose `auto` attempt fails immediately and whose `cpu`
+    /// attempt succeeds after ~1s, recording each requested device into
+    /// `invocations`. Combined with the scripted 2-hour clock jump in
+    /// `cpu_fallback_attempt_gets_a_fresh_deadline`, a shared deadline kills
+    /// the `cpu` fallback while a fresh per-attempt deadline lets it finish.
     #[cfg(windows)]
     fn write_deadline_runner(dir: &Path, invocations: &Path) -> PathBuf {
         let path = dir.join("fake-runner.cmd");
@@ -996,10 +1021,9 @@ mod tests {
              :run\r\n\
              >>\"{}\" echo %device%\r\n\
              if \"%device%\"==\"auto\" (\r\n\
-               ping -n 3 127.0.0.1 >nul\r\n\
                exit /b 1\r\n\
              )\r\n\
-             ping -n 3 127.0.0.1 >nul\r\n\
+             ping -n 2 127.0.0.1 >nul\r\n\
              exit /b 0",
             invocations.display()
         );
@@ -1022,10 +1046,9 @@ mod tests {
              done\n\
              printf '%s\\n' \"$device\" >> '{}'\n\
              if [ \"$device\" = auto ]; then\n\
-               sleep 2\n\
                exit 1\n\
              fi\n\
-             sleep 2\n\
+             sleep 1\n\
              exit 0",
             invocations.display()
         );

--- a/src-tauri/src/pdf_ocr/runner.rs
+++ b/src-tauri/src/pdf_ocr/runner.rs
@@ -261,18 +261,28 @@ const ATTEMPT_TIMEOUT: Duration = Duration::from_secs(60 * 60);
 #[cfg(test)]
 const ATTEMPT_TIMEOUT: Duration = Duration::from_secs(3);
 
-fn attempt_deadline() -> Instant {
-    Instant::now() + ATTEMPT_TIMEOUT
+fn attempt_deadline(now: impl Fn() -> Instant) -> Instant {
+    now() + ATTEMPT_TIMEOUT
 }
 
 pub(crate) fn run_runner(runner: &Path, job: RunnerJob<'_>) -> Result<(), String> {
-    match run_runner_attempt(runner, &job, "auto", attempt_deadline()) {
+    run_runner_with_clock(runner, job, Instant::now)
+}
+
+/// Like [`run_runner`], but with an injectable clock. Tests use this to
+/// simulate a long-running OCR attempt without sleeping for hours.
+pub(crate) fn run_runner_with_clock(
+    runner: &Path,
+    job: RunnerJob<'_>,
+    now: impl Fn() -> Instant,
+) -> Result<(), String> {
+    match run_runner_attempt(runner, &job, "auto", &now, attempt_deadline(&now)) {
         Ok(()) => Ok(()),
         Err(AttemptError::Fatal(error)) => Err(error),
         Err(AttemptError::Retryable(accelerated_error)) => {
             ensure_not_cancelled(&job)?;
             reset_attempt_output(&job)?;
-            match run_runner_attempt(runner, &job, "cpu", attempt_deadline()) {
+            match run_runner_attempt(runner, &job, "cpu", &now, attempt_deadline(&now)) {
                 Ok(()) => Ok(()),
                 Err(AttemptError::Fatal(error)) => Err(error),
                 Err(AttemptError::Retryable(cpu_error)) => Err(format!(
@@ -292,6 +302,7 @@ fn run_runner_attempt(
     runner: &Path,
     job: &RunnerJob<'_>,
     device: &str,
+    now: &dyn Fn() -> Instant,
     deadline: Instant,
 ) -> Result<(), AttemptError> {
     let stdout_path = job.work_dir.join(format!("paddleocr.{device}.stdout.log"));
@@ -357,7 +368,7 @@ fn run_runner_attempt(
                 log_excerpt(&stdout_path, &stderr_path)
             )));
         }
-        if Instant::now() >= deadline {
+        if now() >= deadline {
             let _ = child.kill();
             let _ = child.wait();
             return Err(AttemptError::Fatal(

--- a/src-tauri/src/pdf_ocr/runner.rs
+++ b/src-tauri/src/pdf_ocr/runner.rs
@@ -4,7 +4,7 @@ use std::{
     fs,
     path::{Path, PathBuf},
     process::{Command, Stdio},
-    sync::{Mutex, OnceLock},
+    sync::Mutex,
     thread,
     time::{Duration, Instant},
 };
@@ -15,7 +15,7 @@ use crate::server::OcrJobState;
 #[cfg(windows)]
 const CREATE_NO_WINDOW: u32 = 0x0800_0000;
 
-pub(crate) static GPU_STATUS: OnceLock<Value> = OnceLock::new();
+pub(crate) static GPU_STATUS: Mutex<Option<Value>> = Mutex::new(None);
 
 pub(crate) fn gpu_status_value(status: &str) -> Value {
     let provider = if status != "ready" {
@@ -107,6 +107,34 @@ pub(crate) fn probe_gpu_status(app_handle: &AppHandle) -> Value {
         .and_then(Value::as_str)
         .unwrap_or("cpu");
     gpu_status_value_with_provider(status, provider)
+}
+
+/// Returns the cached GPU status, probing once on first use. Failed probes are
+/// NOT cached — a subsequent call re-probes, so a transient failure (e.g. the
+/// runner not being installed yet) is retried instead of being remembered
+/// forever. Successful probes ("ready"/"unavailable") are cached.
+pub(crate) fn cached_gpu_status(app_handle: &AppHandle) -> Value {
+    cached_gpu_status_with(|| probe_gpu_status(app_handle))
+}
+
+pub(crate) fn cached_gpu_status_with(probe: impl Fn() -> Value) -> Value {
+    if let Some(cached) = GPU_STATUS.lock().ok().and_then(|state| state.clone()) {
+        return cached;
+    }
+    let status = probe();
+    if status.get("status").and_then(Value::as_str) != Some("failed")
+        && let Ok(mut state) = GPU_STATUS.lock()
+    {
+        *state = Some(status.clone());
+    }
+    status
+}
+
+#[cfg(test)]
+pub(crate) fn reset_gpu_status_cache() {
+    if let Ok(mut state) = GPU_STATUS.lock() {
+        *state = None;
+    }
 }
 
 fn runner_name() -> &'static str {
@@ -227,15 +255,24 @@ pub(crate) struct RunnerJob<'a> {
     pub jobs: &'a Mutex<OcrJobState>,
 }
 
+#[cfg(not(test))]
+const ATTEMPT_TIMEOUT: Duration = Duration::from_secs(60 * 60);
+
+#[cfg(test)]
+const ATTEMPT_TIMEOUT: Duration = Duration::from_secs(3);
+
+fn attempt_deadline() -> Instant {
+    Instant::now() + ATTEMPT_TIMEOUT
+}
+
 pub(crate) fn run_runner(runner: &Path, job: RunnerJob<'_>) -> Result<(), String> {
-    let deadline = Instant::now() + Duration::from_secs(60 * 60);
-    match run_runner_attempt(runner, &job, "auto", deadline) {
+    match run_runner_attempt(runner, &job, "auto", attempt_deadline()) {
         Ok(()) => Ok(()),
         Err(AttemptError::Fatal(error)) => Err(error),
         Err(AttemptError::Retryable(accelerated_error)) => {
             ensure_not_cancelled(&job)?;
             reset_attempt_output(&job)?;
-            match run_runner_attempt(runner, &job, "cpu", deadline) {
+            match run_runner_attempt(runner, &job, "cpu", attempt_deadline()) {
                 Ok(()) => Ok(()),
                 Err(AttemptError::Fatal(error)) => Err(error),
                 Err(AttemptError::Retryable(cpu_error)) => Err(format!(


### PR DESCRIPTION
Addresses C11+C12 from #120 (does not close the broader issue).

- C11: each attempt (auto and cpu) gets a fresh 60-minute deadline instead of sharing one computed before the first attempt.
- C12: GPU probe result is cached only on success; a failed probe is retried on next use, with a #[cfg(test)] reset hook.

TDD: both focused tests failed on base (RED), pass now (GREEN). Full cargo test --lib 296/296, clippy -D warnings, fmt, diff-check clean.