### PR TITLE
Fix #120: drop dead server URL pin from Android config

### DIFF
--- a/frontend-tests/android/pocket-packaging.test.js
+++ b/frontend-tests/android/pocket-packaging.test.js
@@ -123,7 +123,9 @@ describe("Android Pocket packaging", () => {
     assert.equal(androidConfig.bundle.android.minSdkVersion, 24);
     assert.equal(androidConfig.app.windows.length, 1);
     assert.equal(androidConfig.app.windows[0].create, false);
-    assert.equal(androidConfig.app.windows[0].url, "http://127.0.0.1:38619/index.html");
+    // The webview URL is decided at runtime (android.rs overrides it with the
+    // actually-bound port); the config must not pin a URL or port.
+    assert.equal(Object.hasOwn(androidConfig.app.windows[0], "url"), false);
     assert.equal(JSON.stringify(androidConfig).includes("ocr-runtime"), false);
     assert.equal(JSON.stringify(baseConfig).includes("ocr-runtime"), false);
     for (const resource of [

--- a/frontend-tests/shared/repo-validation.test.js
+++ b/frontend-tests/shared/repo-validation.test.js
@@ -244,6 +244,22 @@ describe("repository validation wiring", () => {
     assert.match(buildScript, /WordHunter-\$\{release_version\}-aarch64\.dmg/);
   });
 
+  it("keeps the Android webview URL out of the config (the runtime override is the single source of truth)", () => {
+    const source = read("../../src-tauri/tauri.android.conf.json");
+    const androidConfig = JSON.parse(source);
+    const android = read("../../src-tauri/src/platform/android.rs");
+
+    // The window must stay declared (android.rs builds it from this config),
+    // but the URL is decided at runtime: the backend binds a port with a
+    // fallback range and android.rs overrides the window URL before building.
+    assert.equal(androidConfig.app.windows.length, 1);
+    assert.equal(androidConfig.app.windows[0].create, false);
+    assert.doesNotMatch(source, /"url"\s*:/);
+    assert.doesNotMatch(source, /127\.0\.0\.1:\d+|localhost:\d+|3861\d/);
+    assert.match(android, /ANDROID_SERVER_PORT/);
+    assert.match(android, /WebviewUrl::External/);
+  });
+
   it("opens external URLs on Windows without passing them through cmd.exe", () => {
     const cargo = read("../../src-tauri/Cargo.toml");
     const handlers = read("../../src-tauri/src/handlers.rs");

--- a/src-tauri/tauri.android.conf.json
+++ b/src-tauri/tauri.android.conf.json
@@ -7,7 +7,6 @@
         "label": "main",
         "create": false,
         "title": "Word Hunter Pocket",
-        "url": "http://127.0.0.1:38619/index.html",
         "width": 395,
         "height": 880
       }


### PR DESCRIPTION
Addresses the C17 config sub-item from #120 (does not close the broader issue).

After #180 (port fallback + runtime WebviewUrl::External override) the URL pin in tauri.android.conf.json is dead weight and a second source of truth. This removes it; the single source of truth is ANDROID_SERVER_PORT + the runtime override. Adds a repo-validation contract asserting the config contains no hardcoded server URL/port.

TDD: contract test failed on base (RED), passes now (GREEN). repo-validation 13/13, pocket-packaging 3/3, check:frontend and cargo check clean.