### PR TITLE
Fix #120: retry failed TTS init; cache update check

### DIFF
--- a/src-tauri/src/tests/tts/tests.rs
+++ b/src-tauri/src/tests/tts/tests.rs
@@ -1,4 +1,41 @@
-use super::{SynthesisPermit, rate_for, voice_for};
+use super::{SynthesisPermit, cached_with, rate_for, voice_for};
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+#[test]
+fn failed_init_is_not_cached_and_the_next_call_retries() {
+    let cache: Mutex<Option<u32>> = Mutex::new(None);
+    let calls = AtomicUsize::new(0);
+    let init_fail = || {
+        calls.fetch_add(1, Ordering::Relaxed);
+        Err::<u32, _>("temporary failure".to_string())
+    };
+    let init_ok = || {
+        calls.fetch_add(1, Ordering::Relaxed);
+        Ok(7)
+    };
+    assert_eq!(
+        cached_with(&cache, init_fail),
+        Err("temporary failure".to_string())
+    );
+    // The failure must NOT be cached: the next call runs `init` again.
+    assert_eq!(cached_with(&cache, init_ok), Ok(7));
+    assert_eq!(calls.load(Ordering::Relaxed), 2);
+}
+
+#[test]
+fn successful_init_is_cached_across_calls() {
+    let cache: Mutex<Option<u32>> = Mutex::new(None);
+    let calls = AtomicUsize::new(0);
+    let init = || {
+        calls.fetch_add(1, Ordering::Relaxed);
+        Ok(7)
+    };
+    assert_eq!(cached_with(&cache, init), Ok(7));
+    assert_eq!(cached_with(&cache, || Ok(9)), Ok(7));
+    assert_eq!(cached_with(&cache, || Ok(9)), Ok(7));
+    assert_eq!(calls.load(Ordering::Relaxed), 1);
+}
 
 #[test]
 fn maps_only_supported_rate_presets() {

--- a/src-tauri/src/tests/tts/tests.rs
+++ b/src-tauri/src/tests/tts/tests.rs
@@ -1,6 +1,17 @@
-use super::{SynthesisPermit, cached_with, rate_for, voice_for};
+use super::{SynthesisPermit, cached_with, rate_for, runtime, voice_for};
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+#[test]
+fn runtime_stays_alive_after_initialization() {
+    // C15 regression: caching only a Handle drops the Runtime, so the next
+    // block_on panics with "A Tokio 1.x context was found, but it is being
+    // shutdown."
+    runtime()
+        .expect("runtime init should succeed")
+        .block_on(async { tokio::time::sleep(Duration::from_millis(1)).await });
+}
 
 #[test]
 fn failed_init_is_not_cached_and_the_next_call_retries() {

--- a/src-tauri/src/tests/update/tests.rs
+++ b/src-tauri/src/tests/update/tests.rs
@@ -1,4 +1,66 @@
 use super::*;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Instant;
+
+#[test]
+fn check_results_are_cached_within_the_ttl() {
+    let cache: Mutex<Option<(Instant, Value)>> = Mutex::new(None);
+    let calls = AtomicUsize::new(0);
+    let first = check_with(&cache, "test-agent", "1.0.8", |_, _| {
+        calls.fetch_add(1, Ordering::Relaxed);
+        json!({ "latest": "1.0.9", "current": "1.0.8" })
+    });
+    let second = check_with(&cache, "test-agent", "1.0.8", |_, _| {
+        calls.fetch_add(1, Ordering::Relaxed);
+        json!({ "latest": "1.0.9", "current": "1.0.8" })
+    });
+    assert_eq!(first, second);
+    assert_eq!(
+        calls.load(Ordering::Relaxed),
+        1,
+        "the second call must be served from the cache"
+    );
+}
+
+#[test]
+fn check_refetches_after_the_ttl_expires() {
+    let cache: Mutex<Option<(Instant, Value)>> = Mutex::new(None);
+    let calls = AtomicUsize::new(0);
+    check_with(&cache, "test-agent", "1.0.8", |_, _| {
+        calls.fetch_add(1, Ordering::Relaxed);
+        json!({ "latest": "1.0.9", "current": "1.0.8" })
+    });
+    std::thread::sleep(CHECK_CACHE_TTL * 2);
+    check_with(&cache, "test-agent", "1.0.8", |_, _| {
+        calls.fetch_add(1, Ordering::Relaxed);
+        json!({ "latest": "1.0.9", "current": "1.0.8" })
+    });
+    assert_eq!(
+        calls.load(Ordering::Relaxed),
+        2,
+        "expired cache entries must refetch"
+    );
+}
+
+#[test]
+fn check_does_not_cache_errors() {
+    let cache: Mutex<Option<(Instant, Value)>> = Mutex::new(None);
+    let calls = AtomicUsize::new(0);
+    check_with(&cache, "test-agent", "1.0.8", |_, _| {
+        calls.fetch_add(1, Ordering::Relaxed);
+        json!({ "error": "network unavailable", "current": "1.0.8" })
+    });
+    check_with(&cache, "test-agent", "1.0.8", |_, _| {
+        calls.fetch_add(1, Ordering::Relaxed);
+        json!({ "error": "network unavailable", "current": "1.0.8" })
+    });
+    assert_eq!(
+        calls.load(Ordering::Relaxed),
+        2,
+        "errors must not be cached"
+    );
+}
 
 #[test]
 fn normalizes_release_tags() {

--- a/src-tauri/src/tts.rs
+++ b/src-tauri/src/tts.rs
@@ -1,13 +1,13 @@
 use edge_tts_rust::{Boundary, EdgeTtsClient, SpeakOptions, SynthesisResult};
-use std::sync::OnceLock;
+use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 const MAX_CONCURRENT_SYNTHESIS: usize = 2;
 const SYNTHESIS_TIMEOUT_SECONDS: u64 = 14;
 static ACTIVE_SYNTHESIS: AtomicUsize = AtomicUsize::new(0);
-static RUNTIME: OnceLock<Result<tokio::runtime::Runtime, String>> = OnceLock::new();
-static CLIENT: OnceLock<Result<EdgeTtsClient, String>> = OnceLock::new();
+static RUNTIME: Mutex<Option<tokio::runtime::Handle>> = Mutex::new(None);
+static CLIENT: Mutex<Option<EdgeTtsClient>> = Mutex::new(None);
 
 struct SynthesisPermit;
 
@@ -28,31 +28,42 @@ impl Drop for SynthesisPermit {
     }
 }
 
-fn runtime() -> Result<&'static tokio::runtime::Runtime, String> {
-    RUNTIME
-        .get_or_init(|| {
-            tokio::runtime::Builder::new_multi_thread()
-                .worker_threads(MAX_CONCURRENT_SYNTHESIS)
-                .enable_all()
-                .build()
-                .map_err(|error| error.to_string())
-        })
-        .as_ref()
-        .map_err(Clone::clone)
+/// Returns the cached value when present, otherwise runs `init` and caches
+/// the result. Only successes are cached: a failed `init` is retried on the
+/// next call (unlike `OnceLock::get_or_init`, which would cache the error
+/// forever).
+fn cached_with<T: Clone>(
+    cache: &Mutex<Option<T>>,
+    init: impl FnOnce() -> Result<T, String>,
+) -> Result<T, String> {
+    if let Some(value) = cache.lock().unwrap().as_ref() {
+        return Ok(value.clone());
+    }
+    let built = init()?;
+    let mut guard = cache.lock().unwrap();
+    Ok(guard.get_or_insert(built).clone())
+}
+
+fn runtime() -> Result<tokio::runtime::Handle, String> {
+    cached_with(&RUNTIME, || {
+        tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(MAX_CONCURRENT_SYNTHESIS)
+            .enable_all()
+            .build()
+            .map(|runtime| runtime.handle().clone())
+            .map_err(|error| error.to_string())
+    })
 }
 
 fn client() -> Result<EdgeTtsClient, String> {
-    match CLIENT.get_or_init(|| {
+    cached_with(&CLIENT, || {
         EdgeTtsClient::builder()
             // Dropping a timed-out synthesis is not cancellation-safe for pooled sockets.
             .ws_pool_size(0)
             .ws_warmup(false)
             .build()
             .map_err(|error| error.to_string())
-    }) {
-        Ok(client) => Ok(client.clone()),
-        Err(error) => Err(error.clone()),
-    }
+    })
 }
 
 pub fn synthesize(text: &str, lang: &str, rate: &str) -> Result<SynthesisResult, String> {

--- a/src-tauri/src/tts.rs
+++ b/src-tauri/src/tts.rs
@@ -1,12 +1,13 @@
 use edge_tts_rust::{Boundary, EdgeTtsClient, SpeakOptions, SynthesisResult};
 use std::sync::Mutex;
+use std::sync::OnceLock;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 const MAX_CONCURRENT_SYNTHESIS: usize = 2;
 const SYNTHESIS_TIMEOUT_SECONDS: u64 = 14;
 static ACTIVE_SYNTHESIS: AtomicUsize = AtomicUsize::new(0);
-static RUNTIME: Mutex<Option<tokio::runtime::Handle>> = Mutex::new(None);
+static RUNTIME: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
 static CLIENT: Mutex<Option<EdgeTtsClient>> = Mutex::new(None);
 
 struct SynthesisPermit;
@@ -44,15 +45,19 @@ fn cached_with<T: Clone>(
     Ok(guard.get_or_insert(built).clone())
 }
 
-fn runtime() -> Result<tokio::runtime::Handle, String> {
-    cached_with(&RUNTIME, || {
-        tokio::runtime::Builder::new_multi_thread()
-            .worker_threads(MAX_CONCURRENT_SYNTHESIS)
-            .enable_all()
-            .build()
-            .map(|runtime| runtime.handle().clone())
-            .map_err(|error| error.to_string())
-    })
+fn runtime() -> Result<&'static tokio::runtime::Runtime, String> {
+    if let Some(runtime) = RUNTIME.get() {
+        return Ok(runtime);
+    }
+    let built = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(MAX_CONCURRENT_SYNTHESIS)
+        .enable_all()
+        .build()
+        .map_err(|error| error.to_string())?;
+    // Only successes are cached: a failed build is retried on the next call.
+    // The Runtime stays alive for the process lifetime, so `block_on` on the
+    // returned reference never touches a shut-down runtime.
+    Ok(RUNTIME.get_or_init(move || built))
 }
 
 fn client() -> Result<EdgeTtsClient, String> {

--- a/src-tauri/src/update.rs
+++ b/src-tauri/src/update.rs
@@ -1,35 +1,77 @@
 use regex::Regex;
 use serde_json::{Value, json};
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
 
 pub const LATEST_STABLE_RELEASE_URL: &str =
     "https://api.github.com/repos/Ironship/WordHunter/releases/latest";
+
+static CHECK_CACHE: Mutex<Option<(Instant, Value)>> = Mutex::new(None);
+
+#[cfg(not(test))]
+const CHECK_CACHE_TTL: Duration = Duration::from_secs(60 * 60);
+
+#[cfg(test)]
+const CHECK_CACHE_TTL: Duration = Duration::from_millis(100);
 
 pub fn display_version(version: &str) -> String {
     version.replace('+', ".")
 }
 
-pub fn check(user_agent: &str, app_version: &str) -> Value {
-    let display_version = display_version(app_version);
-    match crate::http::agent()
-        // GitHub's latest endpoint intentionally excludes drafts and prereleases.
-        .get(LATEST_STABLE_RELEASE_URL)
-        .set("User-Agent", user_agent)
-        .set("Accept", "application/vnd.github.v3+json")
-        .call()
+/// Runs `fetch` unless a successful result was cached within `CHECK_CACHE_TTL`.
+/// Failures are never cached, so a transient network problem is retried on
+/// the next call instead of being served stale for an hour.
+fn check_with(
+    cache: &Mutex<Option<(Instant, Value)>>,
+    user_agent: &str,
+    app_version: &str,
+    fetch: impl Fn(&str, &str) -> Value,
+) -> Value {
     {
-        Ok(response) => match response.into_json::<Value>() {
-            Ok(data) => {
-                let latest = data
-                    .get("tag_name")
-                    .and_then(Value::as_str)
-                    .unwrap_or("")
-                    .to_string();
-                json!({ "latest": normalize_release_version(&latest), "current": display_version })
-            }
-            Err(err) => json!({ "error": err.to_string(), "current": display_version }),
-        },
-        Err(err) => json!({ "error": err.to_string(), "current": display_version }),
+        let guard = cache.lock().unwrap();
+        if let Some((cached_at, cached)) = guard.as_ref()
+            && cached_at.elapsed() < CHECK_CACHE_TTL
+        {
+            return cached.clone();
+        }
     }
+    let result = fetch(user_agent, app_version);
+    if result.get("error").is_none() {
+        let mut guard = cache.lock().unwrap();
+        *guard = Some((Instant::now(), result.clone()));
+    }
+    result
+}
+
+pub fn check(user_agent: &str, app_version: &str) -> Value {
+    check_with(
+        &CHECK_CACHE,
+        user_agent,
+        app_version,
+        |user_agent, app_version| {
+            let display_version = display_version(app_version);
+            match crate::http::agent()
+                // GitHub's latest endpoint intentionally excludes drafts and prereleases.
+                .get(LATEST_STABLE_RELEASE_URL)
+                .set("User-Agent", user_agent)
+                .set("Accept", "application/vnd.github.v3+json")
+                .call()
+            {
+                Ok(response) => match response.into_json::<Value>() {
+                    Ok(data) => {
+                        let latest = data
+                            .get("tag_name")
+                            .and_then(Value::as_str)
+                            .unwrap_or("")
+                            .to_string();
+                        json!({ "latest": normalize_release_version(&latest), "current": display_version })
+                    }
+                    Err(err) => json!({ "error": err.to_string(), "current": display_version }),
+                },
+                Err(err) => json!({ "error": err.to_string(), "current": display_version }),
+            }
+        },
+    )
 }
 
 pub fn normalize_release_version(tag: &str) -> String {


### PR DESCRIPTION
Addresses C15+C16 from #120 (does not close the broader issue).

- C15 (tts.rs): failed engine init is no longer cached forever — only successful init is cached; the next call retries after an error. Public API unchanged (injectable factory under cfg(test)).
- C16 (update.rs): /__update/check results are cached with a 1h TTL (100ms under cfg(test)); cache only stores non-error responses; JSON shape unchanged.

TDD: both regression tests failed on base (RED), pass now (GREEN). tts 6/6, full cargo test --lib, clippy -D warnings, fmt, diff-check clean.