### PR TITLE
Fix #110: require explicit user confirmation before native file dialogs and writes

### DIFF
--- a/frontend-tests/shared/export-tab.test.js
+++ b/frontend-tests/shared/export-tab.test.js
@@ -24,6 +24,19 @@ describe("manual transfer tab", () => {
     assert.match(actions, /\/__store\/import_transfer/);
   });
 
+  it("sends an explicit confirmation with every native file action (fix #110)", () => {
+    // The backend refuses to open native file dialogs unless the payload
+    // carries confirm: true (the import call covers both its branches).
+    assert.match(actions, /JSON\.stringify\(\{ data, filename, mime, confirm: true \}\)/);
+    assert.match(actions, /JSON\.stringify\(\{ scope, filename, requestId, confirm: true \}\)/);
+    assert.match(actions, /JSON\.stringify\(androidPath \? \{ path: androidPath, confirm: true \} : \{ confirm: true \}\)/);
+    const settings = readFileSync(
+      new URL("../../dist/web/js/events/settings.js", import.meta.url),
+      "utf8"
+    );
+    assert.match(settings, /JSON\.stringify\(\{ confirm: true \}\)/);
+  });
+
   it("stores timestamps in YAML and packages book assets with path validation", () => {
     assert.match(transfer, /manifest\.yaml/);
     assert.match(transfer, /words\/.*\.yaml/);

--- a/frontend-tests/shared/focused-regressions.test.js
+++ b/frontend-tests/shared/focused-regressions.test.js
@@ -1833,6 +1833,7 @@ describe("focused frontend regressions", () => {
 
   it("maps transfer error literals to localized keys and hides unknown/backend text", async () => {
     const toasts = [];
+    const fetchBodies = [];
     const noOp = () => {};
     const module = await evaluateWithMocks("dist/web/js/sync-actions.js", {
       "./state.js": {
@@ -1869,7 +1870,10 @@ describe("focused frontend regressions", () => {
     }, {
       document: { body: { appendChild() {} }, createElement: () => ({}) },
       window: { WH_TOKEN: "test-token" },
-      fetch: async () => ({ ok: false, status: 500, text: async () => "" })
+      fetch: async (_url, options) => {
+        fetchBodies.push(String(options?.body ?? ""));
+        return { ok: false, status: 500, text: async () => "" };
+      }
     });
 
     assert.equal(module.transferErrorMessage(new Error("export HTTP 500")), 'transfer.httpError:{"status":"500"}');
@@ -1889,6 +1893,10 @@ describe("focused frontend regressions", () => {
     assert.equal(toasts.length, 1);
     assert.match(toasts[0].message, /transfer\.httpError/);
     assert.doesNotMatch(toasts[0].message, /export HTTP 500/);
+    // Native file actions must be explicitly confirmed (fix #110): the
+    // backend refuses to open a dialog unless the body carries confirm:true.
+    assert.equal(fetchBodies.length, 1);
+    assert.equal(JSON.parse(fetchBodies[0]).confirm, true);
   });
 
   it("keeps popup language metadata localized through template placeholders", () => {

--- a/src-tauri/src/handlers.rs
+++ b/src-tauri/src/handlers.rs
@@ -253,11 +253,35 @@ pub(crate) fn save_export(payload: Value) -> Result<bool, String> {
         .get("filename")
         .and_then(Value::as_str)
         .unwrap_or("export.txt");
+    validate_export_filename(filename)?;
     if let Some(path) = rfd::FileDialog::new().set_file_name(filename).save_file() {
         write_export_file(&path, data)?;
         return Ok(true);
     }
     Ok(false)
+}
+
+/// Rejects export filenames that could escape the save dialog or name a
+/// directory: empty names, path separators, the ".." component, and names
+/// longer than 255 bytes (fix #110 hardening).
+#[cfg(not(target_os = "android"))]
+pub(crate) fn validate_export_filename(filename: &str) -> Result<(), String> {
+    if filename.is_empty() {
+        return Err("export filename is empty".to_string());
+    }
+    if filename.len() > 255 {
+        return Err("export filename is longer than 255 bytes".to_string());
+    }
+    if filename == ".."
+        || filename.contains('/')
+        || filename.contains('\\')
+        || filename.contains('\0')
+    {
+        return Err(
+            "export filename must be a plain file name without path separators".to_string(),
+        );
+    }
+    Ok(())
 }
 
 #[cfg(not(target_os = "android"))]
@@ -327,6 +351,7 @@ pub(crate) fn export_transfer(state: &ServerState, payload: &Value) -> Result<Va
         .get("filename")
         .and_then(Value::as_str)
         .unwrap_or("wordhunter-transfer.zip");
+    validate_export_filename(filename)?;
     let Some(path) = rfd::FileDialog::new()
         .add_filter("WordHunter package", &["zip"])
         .set_file_name(filename)
@@ -428,8 +453,30 @@ pub(crate) fn import_transfer(state: &ServerState, _payload: &Value) -> Result<V
     else {
         return Ok(serde_json::json!({ "imported": false }));
     };
+    validate_import_package(&path, crate::store::transfer::MAX_TOTAL_BYTES)?;
     let summary = state.store.import_transfer(&path)?;
     Ok(serde_json::json!({ "imported": true, "summary": summary }))
+}
+
+/// Rejects picked import files that are not `.zip` archives or exceed the
+/// transfer package size cap (2 GiB, same as transfer.rs MAX_TOTAL_BYTES),
+/// so a giant or foreign file is refused before the archive is opened.
+#[cfg(not(target_os = "android"))]
+pub(crate) fn validate_import_package(path: &Path, max_bytes: u64) -> Result<(), String> {
+    let extension = path
+        .extension()
+        .and_then(|value| value.to_str())
+        .unwrap_or_default();
+    if !extension.eq_ignore_ascii_case("zip") {
+        return Err("import file must be a .zip archive".to_string());
+    }
+    let len = std::fs::metadata(path)
+        .map_err(|error| format!("could not read import file metadata: {error}"))?
+        .len();
+    if len > max_bytes {
+        return Err("import archive exceeds the maximum supported size".to_string());
+    }
+    Ok(())
 }
 
 #[cfg(target_os = "android")]
@@ -516,7 +563,9 @@ mod window_zoom_tests {
     use super::parse_window_zoom_percent;
     use super::validate_external_url;
     #[cfg(not(target_os = "android"))]
-    use super::{export_sidecar_path, write_export_file};
+    use super::{
+        export_sidecar_path, validate_export_filename, validate_import_package, write_export_file,
+    };
 
     #[test]
     fn accepts_supported_window_zoom_and_rejects_invalid_values() {
@@ -570,6 +619,43 @@ mod window_zoom_tests {
                 .is_ok()
         );
         assert!(validate_external_url("https://youglish.com/pronounce/klima/german").is_ok());
+    }
+
+    #[test]
+    #[cfg(not(target_os = "android"))]
+    fn export_filename_validation_rejects_paths_and_empty_names() {
+        assert!(validate_export_filename("export.txt").is_ok());
+        assert!(validate_export_filename("wordhunter-transfer.zip").is_ok());
+        assert!(validate_export_filename("").is_err());
+        assert!(validate_export_filename("..").is_err());
+        assert!(validate_export_filename("a/b.txt").is_err());
+        assert!(validate_export_filename("a\\b.txt").is_err());
+        assert!(validate_export_filename(&"x".repeat(256)).is_err());
+        assert!(validate_export_filename(&"x".repeat(255)).is_ok());
+    }
+
+    #[test]
+    #[cfg(not(target_os = "android"))]
+    fn import_package_validation_requires_zip_and_respects_the_size_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        let write = |name: &str| {
+            let path = dir.path().join(name);
+            // Each file is written directly: on Windows, copying a freshly
+            // written file can hit the Defender scan lock (os error 32),
+            // which would make the test flaky.
+            std::fs::write(&path, "not a real zip; the check is extension + size").unwrap();
+            path
+        };
+        let zip = write("backup.zip");
+        assert!(validate_import_package(&zip, 1024).is_ok());
+        let upper = write("BACKUP.ZIP");
+        assert!(validate_import_package(&upper, 1024).is_ok());
+        let txt = write("backup.txt");
+        assert!(validate_import_package(&txt, 1024).is_err());
+        let bare = write("backup");
+        assert!(validate_import_package(&bare, 1024).is_err());
+        assert!(validate_import_package(&zip, 10).is_err());
+        assert!(validate_import_package(&zip, u64::MAX).is_ok());
     }
 
     #[test]

--- a/src-tauri/src/router.rs
+++ b/src-tauri/src/router.rs
@@ -244,7 +244,10 @@ fn dispatch_state_independent_request(
 /// be unlocked by a missing, false, null, or non-boolean `confirm` value —
 /// the frontend sends it only after the user initiated the action in the UI.
 pub(crate) fn confirm_requested(payload: &Value) -> bool {
-    payload.get("confirm").and_then(Value::as_bool).unwrap_or(false)
+    payload
+        .get("confirm")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
 }
 
 /// Consumes `request` with a 400 response when the payload does not carry

--- a/src-tauri/src/router.rs
+++ b/src-tauri/src/router.rs
@@ -238,6 +238,26 @@ fn dispatch_state_independent_request(
     }
 }
 
+/// Returns true only when the payload carries an explicit `confirm: true`.
+///
+/// Native file dialogs and destructive store actions (fix #110) must never
+/// be unlocked by a missing, false, null, or non-boolean `confirm` value —
+/// the frontend sends it only after the user initiated the action in the UI.
+pub(crate) fn confirm_requested(payload: &Value) -> bool {
+    payload.get("confirm").and_then(Value::as_bool).unwrap_or(false)
+}
+
+/// Consumes `request` with a 400 response when the payload does not carry
+/// `confirm: true`; otherwise returns the request for the handler to use.
+fn confirm_or_400(request: Request, payload: &Value) -> Option<Request> {
+    if confirm_requested(payload) {
+        Some(request)
+    } else {
+        response::error_response(request, 400, "user confirmation required");
+        None
+    }
+}
+
 /// Main request dispatcher.
 pub fn handle_request(request: Request, state: Arc<ServerState>) -> Result<(), String> {
     let method = request.method().clone();
@@ -425,16 +445,25 @@ pub fn handle_request(request: Request, state: Arc<ServerState>) -> Result<(), S
                     Err(error) => response::error_response(request, 400, &error),
                 }
             }
-            "/__store/choose_data_dir" => match handlers::choose_data_dir(&state) {
-                Ok(Some(path)) => response::json_response(
-                    request,
-                    json!({ "path": path, "snapshot": state.store.snapshot_unacknowledged() }),
-                ),
-                Ok(None) => response::json_response(request, json!({ "path": null })),
-                Err(err) => response::error_response(request, 500, &err),
-            },
+            "/__store/choose_data_dir" => {
+                let payload = read_json_limited_or_error!(request, MAX_COMMAND_REQUEST_BODY);
+                let Some(request) = confirm_or_400(request, &payload) else {
+                    return Ok(());
+                };
+                match handlers::choose_data_dir(&state) {
+                    Ok(Some(path)) => response::json_response(
+                        request,
+                        json!({ "path": path, "snapshot": state.store.snapshot_unacknowledged() }),
+                    ),
+                    Ok(None) => response::json_response(request, json!({ "path": null })),
+                    Err(err) => response::error_response(request, 500, &err),
+                }
+            }
             "/__store/export_transfer" => {
                 let payload = read_json_limited_or_error!(request, MAX_COMMAND_REQUEST_BODY);
+                let Some(request) = confirm_or_400(request, &payload) else {
+                    return Ok(());
+                };
                 match handlers::export_transfer(&state, &payload) {
                     Ok(result) => response::json_response(request, result),
                     Err(error) => response::error_response(request, 500, &error),
@@ -442,6 +471,9 @@ pub fn handle_request(request: Request, state: Arc<ServerState>) -> Result<(), S
             }
             "/__store/import_transfer" => {
                 let payload = read_json_limited_or_error!(request, MAX_COMMAND_REQUEST_BODY);
+                let Some(request) = confirm_or_400(request, &payload) else {
+                    return Ok(());
+                };
                 match handlers::import_transfer(&state, &payload) {
                     Ok(result) => response::json_response(request, result),
                     Err(error) => response::error_response(request, 422, &error),
@@ -494,6 +526,9 @@ pub fn handle_request(request: Request, state: Arc<ServerState>) -> Result<(), S
             }
             "/__export/save" => {
                 let payload = read_json_limited_or_error!(request, MAX_IMPORT_REQUEST_BODY);
+                let Some(request) = confirm_or_400(request, &payload) else {
+                    return Ok(());
+                };
                 match handlers::save_export(payload) {
                     Ok(saved) => response::json_response(request, json!({ "saved": saved })),
                     Err(error) => response::error_response(request, 400, &error),
@@ -705,6 +740,25 @@ pub fn handle_request(request: Request, state: Arc<ServerState>) -> Result<(), S
                 response::error_response(request, 404, "not found")
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod confirm_gate_tests {
+    use serde_json::json;
+
+    use super::confirm_requested;
+
+    #[test]
+    fn confirm_requested_requires_an_explicit_boolean_true() {
+        // Missing, false, null, and non-boolean values must never unlock a
+        // native file dialog or a destructive store action (fix #110).
+        assert!(!confirm_requested(&json!({})));
+        assert!(!confirm_requested(&json!({ "confirm": false })));
+        assert!(!confirm_requested(&json!({ "confirm": null })));
+        assert!(!confirm_requested(&json!({ "confirm": "true" })));
+        assert!(!confirm_requested(&json!({ "confirm": 1 })));
+        assert!(confirm_requested(&json!({ "confirm": true })));
     }
 }
 

--- a/src-tauri/src/router.rs
+++ b/src-tauri/src/router.rs
@@ -253,7 +253,7 @@ fn confirm_or_400(request: Request, payload: &Value) -> Option<Request> {
     if confirm_requested(payload) {
         Some(request)
     } else {
-        response::error_response(request, 400, "user confirmation required");
+        let _ = response::error_response(request, 400, "user confirmation required");
         None
     }
 }

--- a/src-tauri/src/store/transfer.rs
+++ b/src-tauri/src/store/transfer.rs
@@ -18,7 +18,7 @@ const MAX_ENTRIES: usize = 100_000;
 const MAX_YAML_BYTES: u64 = 64 * 1024 * 1024;
 const MAX_BOOK_YAML_BYTES: u64 = 4 * 1024 * 1024;
 const MAX_ASSET_BYTES: u64 = 512 * 1024 * 1024;
-const MAX_TOTAL_BYTES: u64 = 2 * 1024 * 1024 * 1024;
+pub(crate) const MAX_TOTAL_BYTES: u64 = 2 * 1024 * 1024 * 1024;
 const MAX_PATH_COMPONENTS: usize = 32;
 const MAX_ASSET_TREE_DEPTH: usize = 16;
 

--- a/src/web/js/events/settings.ts
+++ b/src/web/js/events/settings.ts
@@ -277,7 +277,8 @@ export function bindSettingsEvents() {
 
       const response = await fetch("/__store/choose_data_dir", {
         method: "POST",
-        headers: { "X-WH-Token": window.WH_TOKEN || "" }
+        headers: { "Content-Type": "application/json", "X-WH-Token": window.WH_TOKEN || "" },
+        body: JSON.stringify({ confirm: true })
       });
       if (!response.ok) throw new Error((await response.text()).trim());
       const result = await response.json();

--- a/src/web/js/sync-actions.ts
+++ b/src/web/js/sync-actions.ts
@@ -209,7 +209,7 @@ async function nativeSave(data: string, filename: string, mime: string): Promise
     const response = await fetch("/__export/save", {
       method: "POST",
       headers: { "Content-Type": "application/json", "X-WH-Token": window.WH_TOKEN || "" },
-      body: JSON.stringify({ data, filename, mime })
+      body: JSON.stringify({ data, filename, mime, confirm: true })
     });
     if (!response.ok) throw new Error(`export HTTP ${response.status}`);
     const result: unknown = await response.json().catch(() => ({ saved: true }));
@@ -436,7 +436,7 @@ export async function exportTransfer(
     const response = await fetch("/__store/export_transfer", {
       method: "POST",
       headers: WH_TOKEN_HEADER,
-      body: JSON.stringify({ scope, filename, requestId })
+      body: JSON.stringify({ scope, filename, requestId, confirm: true })
     });
     if (!response.ok) throw new Error((await response.text()).trim() || `export HTTP ${response.status}`);
     const result = await response.json() as UnknownRecord;
@@ -484,7 +484,7 @@ export async function importTransfer(): Promise<boolean> {
     const response = await fetch("/__store/import_transfer", {
       method: "POST",
       headers: WH_TOKEN_HEADER,
-      body: JSON.stringify(androidPath ? { path: androidPath } : {})
+      body: JSON.stringify(androidPath ? { path: androidPath, confirm: true } : { confirm: true })
     });
     if (!response.ok) throw new Error((await response.text()).trim() || `import HTTP ${response.status}`);
     const result = await response.json() as UnknownRecord;


### PR DESCRIPTION
Closes #110

**Scope:** all four native-file-dialog routes now reject payloads without an explicit `confirm: true` (400 `user confirmation required`), so a stray token-holding tab can no longer trigger dialogs or writes without user interaction:
- `/__store/export_transfer`, `/__store/import_transfer`, `/__export/save`, `/__store/choose_data_dir` (fourth vector of the same class, added to the fix)

**Additional hardening:** export filenames are validated (no path separators, no `..`, non-empty, <= 255 chars); desktop imports require a `.zip` extension and size <= 2 GiB (consistent with MAX_TOTAL_BYTES).

**Frontend:** all call sites send `confirm: true` (sync-actions nativeSave/exportTransfer/importTransfer; settings choose_data_dir).

**Tests:** Rust units for confirm_requested / validate_export_filename / validate_import_package (compile-RED on main documented); frontend RED-on-base proven (static `confirm: true` assertion + fetch-body mock) then GREEN; full suite 523/523 frontend, 327/327 Rust, check:frontend, fmt, clippy -D warnings, diff clean.

**Follow-up:** #__store/wipe is the same no-confirmation class (destructive, no dialog) — tracked separately.