### PR TITLE
fix(#129): CSS verifiability P0-P2 — inline-style sweep, z-index scale, duplication contracts

### DIFF
--- a/frontend-tests/android/pocket-layout.test.js
+++ b/frontend-tests/android/pocket-layout.test.js
@@ -117,9 +117,9 @@ describe("Android Pocket layout", () => {
     const css = readFileSync(new URL("../../dist/web/platforms/android-pocket.css", import.meta.url), "utf8");
 
     assertDeclarations(css, ".pocket-mode .view.active", { animation: "none !important" });
-    assertDeclarations(css, ".pocket-mode .import-panel", { "z-index": "80", visibility: "hidden", "pointer-events": "none" });
+    assertDeclarations(css, ".pocket-mode .import-panel", { "z-index": "var(--z-pocket-sidebar)", visibility: "hidden", "pointer-events": "none" });
     assertDeclarations(css, ".pocket-mode.pocket-import-open .import-panel", { visibility: "visible", "pointer-events": "auto" });
-    assertDeclarations(css, ".pocket-mode.pocket-import-open body::after", { "z-index": "75" });
+    assertDeclarations(css, ".pocket-mode.pocket-import-open body::after", { "z-index": "var(--z-pocket-scrim)" });
     assertDeclarations(css, ".pocket-mode .pocket-import-toggle", { position: "fixed", right: "0" });
     assert.match(declarationBlock(css, ".pocket-mode .pocket-import-toggle::before").mask, /M15%2018l-6-6%206-6/);
     assertDeclarations(css, '.pocket-mode[data-view="library"] .pocket-import-toggle', { display: "inline-flex" });
@@ -146,7 +146,7 @@ describe("Android Pocket layout", () => {
   it("defines the hidden and open Pocket navigation drawer", () => {
     const css = readFileSync(new URL("../../dist/web/platforms/android-pocket.css", import.meta.url), "utf8");
 
-    assertDeclarations(css, ".pocket-mode .sidebar", { "z-index": "80", visibility: "hidden", "pointer-events": "none" });
+    assertDeclarations(css, ".pocket-mode .sidebar", { "z-index": "var(--z-pocket-sidebar)", visibility: "hidden", "pointer-events": "none" });
     assertDeclarations(css, ".pocket-mode.pocket-navigation-open .sidebar", { visibility: "visible", "pointer-events": "auto" });
     assertDeclarations(css, ".pocket-mode .pocket-navigation-toggle", { position: "fixed", display: "inline-flex", bottom: "calc(0.35rem + var(--pocket-navbar-safe-bottom))", background: "var(--sidebar-bg)" });
     assertDeclarations(css, '.pocket-mode[data-view="reader"] #pocket-navigation-toggle', { display: "none" });

--- a/frontend-tests/shared/css-verifiability.test.js
+++ b/frontend-tests/shared/css-verifiability.test.js
@@ -1,0 +1,252 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = fileURLToPath(new URL("../..", import.meta.url));
+const read = (path) => readFileSync(join(ROOT, path), "utf8");
+
+const CSS_FILES = [
+  "src/web/styles.css",
+  "src/web/platforms/android-pocket.css",
+  "src/web/theme.css"
+];
+const HTML_FILES = [
+  "src/web/index.html",
+  "src/web/templates/translator-popup.html"
+];
+
+function tsFiles() {
+  const out = [];
+  const walk = (dir) => {
+    for (const entry of readdirSync(join(ROOT, dir), { withFileTypes: true })) {
+      const child = join(dir, entry.name);
+      if (entry.isDirectory()) walk(child);
+      else if (entry.name.endsWith(".ts")) out.push(child);
+    }
+  };
+  walk("src/web/js");
+  return out;
+}
+
+/* T2: TS inline styles may only be runtime-interpolated (`style="...${...}..."`).
+   Static one-off values must live in the stylesheet as utility classes. */
+const TS_STYLE_ATTR_PIN = 17;
+
+/* T2: runtime element-style writes are allowed only for these layout/animation
+   properties (values are computed at runtime — not representable as classes). */
+const TS_STYLE_PROP_WHITELIST = new Set([
+  "background", "colorScheme", "cursor", "display", "fontSize", "gap",
+  "height", "justifyContent", "left", "margin", "marginTop", "maxWidth",
+  "opacity", "padding", "pointerEvents", "position", "top", "width", "zoom"
+]);
+const TS_STYLE_PROP_PIN = 65;
+
+/* T3: z-index declarations must reference the named --z-* scale; bare numerics
+   are allowed only from the small legacy whitelist. */
+const Z_INDEX_WHITELIST = new Set(["0", "1", "2", "3", "4", "5", "10", "50", "100", "1000"]);
+
+/* T4: identical-declaration groups (>=2 rules sharing one declaration block)
+   budget — baseline 47 (post-utility-sweep baseline, 2026-08). */
+const DUP_GROUP_PIN = 47;
+
+describe("T1 — stylelint gate pins", () => {
+  const pkg = JSON.parse(read("package.json"));
+
+  it("pins lint:css to zero warnings", () => {
+    assert.match(pkg.scripts["lint:css"], /--max-warnings\s+0/,
+      "lint:css must fail the build on any stylelint warning");
+  });
+
+  it("runs lint:css inside check:frontend", () => {
+    assert.match(pkg.scripts["check:frontend"], /lint:css/,
+      "check:frontend must invoke lint:css");
+  });
+
+  it("documents why the max-warnings pin lives in package.json", () => {
+    // stylelint 16.x exposes maxWarnings only on the CLI and the JS API
+    // (LinterOptions); the config-file schema has no maxWarnings key, so the
+    // package.json script is the only place the gate can be pinned.
+    const config = read("stylelint.config.mjs");
+    assert.doesNotMatch(config, /\bmaxWarnings\b/,
+      "stylelint config cannot pin maxWarnings (CLI/API only)");
+  });
+});
+
+describe("T2 — inline style sweep", () => {
+  it("sweeps static HTML free of style= attributes", () => {
+    for (const file of HTML_FILES) {
+      const text = read(file);
+      const matches = [...text.matchAll(/style\s*=\s*(["'])([^"']*)\1/g)];
+      assert.equal(matches.length, 0,
+        `${file} still has ${matches.length} inline style attribute(s): ` +
+        matches.slice(0, 5).map((m) => m[0]).join(" | "));
+    }
+  });
+
+  it("keeps TS style= attributes strictly dynamic", () => {
+    const offenders = [];
+    let count = 0;
+    for (const file of tsFiles()) {
+      const text = read(file);
+      for (const m of text.matchAll(/style\s*=\s*"([^"]*)"/g)) {
+        count += 1;
+        if (!m[1].includes("${")) {
+          offenders.push(`${relative(ROOT, file)}: style="${m[1]}"`);
+        }
+      }
+    }
+    assert.equal(offenders.length, 0,
+      `static TS inline styles (must become utility classes): ${offenders.join("; ")}`);
+    assert.ok(count <= TS_STYLE_ATTR_PIN,
+      `TS style= count ${count} exceeds pin ${TS_STYLE_ATTR_PIN}`);
+  });
+
+  it("keeps runtime .style.<prop> writes on the property whitelist", () => {
+    const offenders = [];
+    let count = 0;
+    for (const file of tsFiles()) {
+      const text = read(file);
+      for (const m of text.matchAll(/\.style\.([A-Za-z]+)\s*=/g)) {
+        count += 1;
+        if (!TS_STYLE_PROP_WHITELIST.has(m[1])) {
+          offenders.push(`${relative(ROOT, file)}: .style.${m[1]}`);
+        }
+      }
+    }
+    assert.equal(offenders.length, 0,
+      `.style.<prop> writes outside the whitelist: ${offenders.join("; ")}`);
+    assert.ok(count <= TS_STYLE_PROP_PIN,
+      `.style.<prop> write count ${count} exceeds pin ${TS_STYLE_PROP_PIN}`);
+  });
+
+  it("keeps setProperty writes limited to CSS custom properties", () => {
+    const offenders = [];
+    for (const file of tsFiles()) {
+      const text = read(file);
+      for (const m of text.matchAll(/\.setProperty\(\s*(["'])([^"']+)\1/g)) {
+        if (!m[2].startsWith("--")) {
+          offenders.push(`${relative(ROOT, file)}: setProperty("${m[2]}")`);
+        }
+      }
+    }
+    assert.equal(offenders.length, 0,
+      `non-custom-property setProperty writes: ${offenders.join("; ")}`);
+  });
+});
+
+describe("T3 — z-index scale", () => {
+  it("uses only named scale variables or whitelisted numerics", () => {
+    for (const file of CSS_FILES) {
+      const text = read(file);
+      for (const m of text.matchAll(/z-index\s*:\s*([^;]+);/g)) {
+        const value = m[1].trim();
+        assert.ok(
+          /^var\(--z-[a-z0-9-]+\)$/.test(value) || Z_INDEX_WHITELIST.has(value),
+          `${file}: z-index: ${value} is outside the named scale/whitelist`
+        );
+      }
+    }
+  });
+
+  it("defines every --z-* variable it references", () => {
+    for (const file of CSS_FILES) {
+      const text = read(file);
+      const used = new Set(
+        [...text.matchAll(/var\((--z-[a-z0-9-]+)\)/g)].map((m) => m[1])
+      );
+      const missing = [...used].filter((name) => !text.includes(`${name}:`));
+      assert.deepEqual(missing, [],
+        `${file} references undefined z-scale variables: ${missing.join(", ")}`);
+    }
+  });
+});
+
+describe("T4 — stylesheet duplication", () => {
+  function cssRules(text) {
+    /* Brace-walking parser: collects every rule (selector, normalized decls)
+       at any nesting depth; @keyframes bodies are opaque. */
+    const rules = [];
+    const n = text.length;
+    const skipComment = (i) => {
+      const end = text.indexOf("*/", i + 2);
+      return end === -1 ? n : end + 2;
+    };
+    const walk = (start, end) => {
+      let i = start;
+      while (i < end) {
+        const c = text[i];
+        if (c === "/" && text[i + 1] === "*") { i = skipComment(i); continue; }
+        if (c === "}") { i += 1; continue; }
+        if (c === "@") {
+          const brace = text.indexOf("{", i);
+          const semi = text.indexOf(";", i);
+          if (semi !== -1 && (brace === -1 || semi < brace)) { i = semi + 1; continue; }
+          if (brace === -1 || brace >= end) break;
+          const head = text.slice(i + 1, brace);
+          let depth = 1;
+          let p = brace + 1;
+          while (p < end && depth > 0) {
+            if (text[p] === "{") depth += 1;
+            else if (text[p] === "}") depth -= 1;
+            else if (text[p] === "/" && text[p + 1] === "*") p = skipComment(p) - 1;
+            p += 1;
+          }
+          if (!/keyframes/i.test(head)) walk(brace + 1, Math.min(p - 1, end));
+          i = p;
+          continue;
+        }
+        const brace = text.indexOf("{", i);
+        if (brace === -1 || brace >= end) break;
+        let depth = 1;
+        let p = brace + 1;
+        while (p < end && depth > 0) {
+          if (text[p] === "{") depth += 1;
+          else if (text[p] === "}") depth -= 1;
+          else if (text[p] === "/" && text[p + 1] === "*") p = skipComment(p) - 1;
+          p += 1;
+        }
+        const decls = text.slice(brace + 1, p - 1)
+          .replace(/\s+/g, " ").trim().replace(/;?\s*$/, "");
+        rules.push({ selector: text.slice(i, brace).trim(), decls });
+        i = p;
+      }
+    };
+    walk(0, n);
+    return rules;
+  }
+
+  it("keeps @media preludes unique within each stylesheet", () => {
+    for (const file of CSS_FILES) {
+      const preludes = [...read(file).matchAll(/@media\s+([^{]+)\{/g)].map((m) => m[1].trim());
+      const duplicates = preludes.filter((p, i) => preludes.indexOf(p) !== i);
+      assert.deepEqual([...new Set(duplicates)], [],
+        `${file} has duplicate @media preludes — merge the blocks: ${[...new Set(duplicates)].join(", ")}`);
+    }
+  });
+
+  it("keeps identical-declaration groups within the pinned budget", () => {
+    /* Groups are counted per stylesheet (a group = >=2 rules inside one file
+       sharing an identical declaration block), matching the audit baseline
+       37 + 8 = 45. */
+    let groups = 0;
+    let largest = 0;
+    for (const file of CSS_FILES) {
+      const byDecl = new Map();
+      for (const rule of cssRules(read(file))) {
+        if (!rule.decls) continue;
+        if (!byDecl.has(rule.decls)) byDecl.set(rule.decls, []);
+        byDecl.get(rule.decls).push(rule.selector);
+      }
+      for (const selectors of byDecl.values()) {
+        if (selectors.length >= 2) {
+          groups += 1;
+          largest = Math.max(largest, selectors.length);
+        }
+      }
+    }
+    assert.ok(groups <= DUP_GROUP_PIN,
+      `identical-declaration groups ${groups} exceed pin ${DUP_GROUP_PIN} (largest: ${largest} rules)`);
+  });
+});

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -25,12 +25,12 @@
     </button>
     <aside class="sidebar" id="app-navigation" data-i18n-attr="aria-label=app.navAriaLabel" aria-label="Navigation">
       <div class="brand">
-        <div style="width: 100%;">
+        <div class="w-100">
           <strong data-i18n="app.title">Word Hunter</strong>
-          <div class="lang-selectors" style="display: flex; align-items: center; gap: 0.5rem; margin-top: 0.5rem; justify-content: flex-start;">
-            <div style="position: relative; display: flex; align-items: center;" data-i18n-attr="title=settings.interfaceLanguageTitle">
-              <div id="app-lang-flag" style="display: flex; align-items: center;"></div>
-              <select id="pref-locale-sidebar" aria-label="App interface language" data-i18n-attr="aria-label=settings.interfaceLanguageTitle" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; opacity: 0; cursor: pointer;">
+          <div class="lang-selectors row-start-m-t-05">
+            <div data-i18n-attr="title=settings.interfaceLanguageTitle" class="rel-row">
+              <div id="app-lang-flag" class="row-nogap"></div>
+              <select id="pref-locale-sidebar" aria-label="App interface language" data-i18n-attr="aria-label=settings.interfaceLanguageTitle" class="abs-fill">
                 <option value="pl" data-i18n="languages.pl">Polish</option>
                 <option value="en" data-i18n="languages.en">English</option>
                 <option value="de" data-i18n="languages.de">German</option>
@@ -44,11 +44,11 @@
               </select>
             </div>
             
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width: 1rem; height: 1rem; color: var(--sidebar-muted);"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon-sidebar"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
             
-            <div style="position: relative; display: flex; align-items: center;" data-i18n-attr="title=settings.learningLanguageTitle">
-              <div id="learning-lang-flag" style="display: flex; align-items: center;"></div>
-              <select id="pref-learning-language-sidebar" aria-label="Learning language (profile)" data-i18n-attr="aria-label=settings.learningLanguageTitle" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; opacity: 0; cursor: pointer;">
+            <div data-i18n-attr="title=settings.learningLanguageTitle" class="rel-row">
+              <div id="learning-lang-flag" class="row-nogap"></div>
+              <select id="pref-learning-language-sidebar" aria-label="Learning language (profile)" data-i18n-attr="aria-label=settings.learningLanguageTitle" class="abs-fill">
                 <option value="en" data-i18n="languages.en">English</option>
                 <option value="de" data-i18n="languages.de">German</option>
                 <option value="es" data-i18n="languages.es">Spanish</option>
@@ -136,7 +136,7 @@
           <span class="metric-pill metric-new" id="pill-new" data-i18n-attr="title=topbar.newTooltip"></span>
           <span class="metric-pill" id="overall-count" data-i18n-attr="title=topbar.totalTooltip"></span>
           <button class="icon-button" type="button" id="app-reload" aria-label="Reload application" data-i18n-attr="title=app.reload,aria-label=app.reload">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width: 18px; height: 18px;"><polyline points="23 4 23 10 17 10"></polyline><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"></path></svg>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-18"><polyline points="23 4 23 10 17 10"></polyline><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"></path></svg>
           </button>
           <button class="icon-button" type="button" id="theme-toggle" data-i18n-attr="title=topbar.themeToggle,aria-label=topbar.themeToggle">
             <svg class="theme-toggle-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round" aria-hidden="true"><path d="m12 3 5 5-5 5-5-5 5-5Z" fill="currentColor" opacity=".28"></path><path d="m12 11 5 5-5 5-5-5 5-5Z"></path></svg>
@@ -188,8 +188,8 @@
                 </label>
                 <label class="library-sort-field">
                   <span data-i18n="library.sort">Sort</span>
-                  <div style="display: flex; align-items: center; gap: 0.35rem;">
-                    <select id="library-sort" style="flex: 1;">
+                  <div class="row-tight">
+                    <select id="library-sort" class="flex-1">
                       <option value="title" data-i18n="library.sortByTitle">By title</option>
                       <option value="author" data-i18n="library.sortByAuthor">By author</option>
                       <option value="length" data-i18n="library.sortByLength">By length</option>
@@ -262,17 +262,17 @@
                   <span data-i18n="import.text">Text</span>
                   <textarea id="import-text" rows="10" spellcheck="false" data-i18n-attr="placeholder=import.textPlaceholder" required></textarea>
                 </label>
-                <div class="form-group" style="margin-bottom: 1.5rem; text-align: center;">
-                  <label for="import-cover" class="import-cover-dropzone" id="import-cover-dropzone" style="display: flex; flex-direction: column; align-items: center; justify-content: center; border: 2px dashed var(--line); border-radius: 8px; padding: 1.5rem; cursor: pointer; transition: background 0.2s, border-color 0.2s;" data-i18n-attr="title=import.cover">
-                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width: 32px; height: 32px; color: var(--muted); margin-bottom: 0.5rem;"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect><circle cx="8.5" cy="8.5" r="1.5"></circle><polyline points="21 15 16 10 5 21"></polyline></svg>
-                    <span style="font-size: 0.9rem; color: var(--muted);" data-i18n="import.coverPasteHint">Click to select or paste</span>
+                <div class="form-group m-b-15-center">
+                  <label for="import-cover" class="import-cover-dropzone dropzone" id="import-cover-dropzone" data-i18n-attr="title=import.cover">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-32-muted-m-b-05"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect><circle cx="8.5" cy="8.5" r="1.5"></circle><polyline points="21 15 16 10 5 21"></polyline></svg>
+                    <span data-i18n="import.coverPasteHint" class="fs-09-muted">Click to select or paste</span>
                     <input id="import-cover" type="file" accept="image/*" class="visually-hidden">
                   </label>
                 </div>
-                <div id="import-cover-preview" class="import-cover-preview" hidden style="margin-bottom: 1.5rem; position: relative; width: max-content;">
-                  <img id="import-cover-img" data-i18n-attr="alt=import.coverPreviewAlt" alt="Cover preview" style="max-height: 150px; border-radius: 6px; border: 1px solid var(--line);">
-                  <button type="button" id="import-cover-clear" data-i18n-attr="title=editBook.deleteCover" style="position: absolute; top: -10px; right: -10px; width: 24px; height: 24px; border-radius: 50%; display: flex; align-items: center; justify-content: center; padding: 0; border: none; background: var(--red); color: var(--red-ink); cursor: pointer;">
-                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width: 14px; height: 14px;"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
+                <div id="import-cover-preview" class="import-cover-preview m-b-15-w-max" hidden>
+                  <img id="import-cover-img" data-i18n-attr="alt=import.coverPreviewAlt" alt="Cover preview" class="max-h-150">
+                  <button type="button" id="import-cover-clear" data-i18n-attr="title=editBook.deleteCover" class="badge-remove">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-14"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
                   </button>
                 </div>
                 <button class="primary-button" type="submit" id="import-submit" data-i18n="import.submit">Add to library</button>
@@ -301,7 +301,7 @@
           <section class="panel reader-panel" aria-labelledby="reader-heading">
             <div class="reader-toolbar">
               <label>
-                <span style="display: flex; align-items: center; gap: 0.5rem;"><span data-i18n="reader.textLabel">Text</span> <span class="shortcut-badge">Ctrl+B</span></span>
+                <span class="row"><span data-i18n="reader.textLabel">Text</span> <span class="shortcut-badge">Ctrl+B</span></span>
                 <select id="text-select"></select>
               </label>
               <div class="toolbar-buttons" role="group" data-i18n-attr="aria-label=reader.controlsLabel">
@@ -321,13 +321,13 @@
                 </div>
                 <button type="button" data-font="up" data-i18n-attr="title=reader.fontUp">A+</button>
                 <button type="button" id="tts-play-text" class="secondary-button" aria-label="Read text" data-i18n-attr="title=reader.ttsPlayTitle,aria-label=reader.ttsPlayTitle">
-                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width: 16px; height: 16px;"><polygon points="5 3 19 12 5 21 5 3"></polygon></svg>
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-16"><polygon points="5 3 19 12 5 21 5 3"></polygon></svg>
                 </button>
                 <button type="button" id="tts-stop-text" class="danger-button" hidden data-i18n-attr="title=reader.ttsStopTitle,aria-label=reader.ttsStopTitle">
-                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width: 16px; height: 16px;"><rect x="4" y="4" width="16" height="16"></rect></svg>
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-16"><rect x="4" y="4" width="16" height="16"></rect></svg>
                 </button>
                 <button type="button" id="reader-highlight-toggle" class="icon-button" aria-pressed="true" data-i18n-attr="title=settings.highlight,aria-label=settings.highlight">
-                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width: 16px; height: 16px;"><path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"></path><line x1="1" y1="1" x2="23" y2="23"></line></svg>
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-16"><path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"></path><line x1="1" y1="1" x2="23" y2="23"></line></svg>
                 </button>
                 <button type="button" id="reader-bookmarks-button" class="icon-button reader-bookmarks-button" aria-haspopup="dialog" aria-controls="reader-bookmarks-dialog" data-i18n-attr="title=reader.bookmarks,aria-label=reader.bookmarks">
                   <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M6 3h12v18l-6-4-6 4V3z"></path></svg>
@@ -405,9 +405,9 @@
             <div class="translator-controls">
               <label>
                 <span data-i18n="translator.from">From language</span>
-                <div style="display: flex; align-items: center; gap: 0.5rem;">
-                  <img id="translator-from-flag" class="flag-icon" src="" alt="" style="width: 1.5rem; height: 1.5rem; border-radius: 3px; object-fit: cover; flex-shrink: 0; box-shadow: 0 1px 3px rgba(0,0,0,0.1); display: none;">
-                  <select id="translator-from" style="flex: 1;"></select>
+                <div class="row">
+                  <img id="translator-from-flag" class="flag-icon cover-thumb" src="" alt="">
+                  <select id="translator-from" class="flex-1"></select>
                 </div>
               </label>
               <button class="icon-button translator-swap" type="button" id="translator-swap" aria-label="Swap languages" data-i18n-attr="title=translator.swap,aria-label=translator.swap">
@@ -415,9 +415,9 @@
               </button>
               <label>
                 <span data-i18n="translator.to">To language</span>
-                <div style="display: flex; align-items: center; gap: 0.5rem;">
-                  <img id="translator-to-flag" class="flag-icon" src="" alt="" style="width: 1.5rem; height: 1.5rem; border-radius: 3px; object-fit: cover; flex-shrink: 0; box-shadow: 0 1px 3px rgba(0,0,0,0.1); display: none;">
-                  <select id="translator-to" style="flex: 1;"></select>
+                <div class="row">
+                  <img id="translator-to-flag" class="flag-icon cover-thumb" src="" alt="">
+                  <select id="translator-to" class="flex-1"></select>
                 </div>
               </label>
             </div>
@@ -428,9 +428,9 @@
               </label>
               <label class="translator-field">
                 <span data-i18n="translator.result">Translation</span>
-                <div style="display: flex; gap: 0.5rem; align-items: stretch; flex: 1; min-height: 0;">
-                  <textarea id="translator-result" readonly spellcheck="false" data-i18n-attr="placeholder=translator.resultPlaceholder" style="flex: 1;"></textarea>
-                  <button type="button" id="translator-copy" class="secondary-button" data-i18n="translator.copy" data-i18n-attr="title=translator.copy,aria-label=translator.copy" style="align-self: flex-end; flex-shrink: 0;">Copy</button>
+                <div class="row-stretch-flex-1">
+                  <textarea id="translator-result" readonly spellcheck="false" data-i18n-attr="placeholder=translator.resultPlaceholder" class="flex-1"></textarea>
+                  <button type="button" id="translator-copy" class="secondary-button self-end-noshrink" data-i18n="translator.copy" data-i18n-attr="title=translator.copy,aria-label=translator.copy">Copy</button>
                 </div>
               </label>
             </div>
@@ -514,13 +514,13 @@
       <section class="view" id="flashcards-view" data-title-key="nav.flashcards">
         <div class="workspace-grid flashcards-layout">
           <aside class="panel review-panel" aria-labelledby="review-heading">
-            <div class="panel-header" style="display: flex; justify-content: space-between; align-items: center; width: 100%;">
+            <div class="panel-header row-between">
               <div>
                 <p class="eyebrow" data-i18n="vocab.reviewEyebrow">Review</p>
                 <h2 id="review-heading" data-i18n="vocab.reviewHeading">Flashcard</h2>
               </div>
-              <button class="secondary-button" type="button" id="review-reverse-toggle" style="font-size: 0.85rem; padding: 0.4rem 0.6rem; display: flex; align-items: center; gap: 0.3rem;" data-i18n-attr="title=vocab.reverseTooltip">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width: 14px; height: 14px;"><polyline points="23 4 23 10 17 10"></polyline><polyline points="1 20 1 14 7 14"></polyline><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"></path></svg>
+              <button class="secondary-button chip" type="button" id="review-reverse-toggle" data-i18n-attr="title=vocab.reverseTooltip">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-14"><polyline points="23 4 23 10 17 10"></polyline><polyline points="1 20 1 14 7 14"></polyline><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"></path></svg>
                 <span id="review-reverse-label" data-i18n="vocab.normalOrder">Foreign → Native</span>
               </button>
             </div>
@@ -618,13 +618,13 @@
 
       <section class="view" id="graphs-view" data-title-key="nav.graphs">
         <div class="workspace-grid graphs-layout">
-          <section class="panel" aria-labelledby="graphs-heading" style="flex: 1;">
+          <section class="panel flex-1" aria-labelledby="graphs-heading">
             <div class="panel-header">
               <div>
                 <p class="eyebrow" data-i18n="graphs.eyebrow">Statistics</p>
                 <h2 id="graphs-heading" data-i18n="graphs.heading">Charts</h2>
               </div>
-              <div style="display: flex; gap: 0.5rem; align-items: center;">
+              <div class="row">
                 <label>
                   <span data-i18n="graphs.range">Range</span>
                   <select id="graphs-range">
@@ -940,7 +940,7 @@
               <label class="setting-row toggle-row desktop-only-setting">
                 <span>
                   <span data-i18n="settings.useEdgeTts">Edge Neural TTS (online)</span>
-                  <small data-i18n="settings.useEdgeTtsHint" style="color: var(--muted); font-weight: 400;"></small>
+                  <small data-i18n="settings.useEdgeTtsHint" class="muted-fw-400"></small>
                 </span>
                 <input id="pref-use-edge-tts" type="checkbox" data-pref="useEdgeTts">
               </label>
@@ -1004,14 +1004,14 @@
             </div>
             <div class="settings-body">
               <div id="pref-translation-language-settings" hidden>
-                <label class="setting-row" style="flex-direction: column; align-items: stretch; gap: 0.25rem;">
+                <label class="setting-row stack">
                   <span>
                     <span data-i18n="settings.translationSourceLanguage">Translation source language</span>
                     <small data-i18n="settings.translationLanguageHint">Enter a language code such as nl, pt-BR, or eo. The pair is shared by every translation engine in this profile.</small>
                   </span>
                   <input id="pref-translation-source-language" type="text" list="translation-language-codes" autocomplete="off" spellcheck="false" data-i18n-attr="placeholder=settings.translationSourceLanguagePlaceholder" class="input">
                 </label>
-                <label class="setting-row" style="flex-direction: column; align-items: stretch; gap: 0.25rem;">
+                <label class="setting-row stack">
                   <span data-i18n="settings.translationTargetLanguage">Translation target language</span>
                   <input id="pref-translation-target-language" type="text" list="translation-language-codes" autocomplete="off" spellcheck="false" data-i18n-attr="placeholder=settings.translationTargetLanguagePlaceholder" class="input">
                 </label>
@@ -1046,26 +1046,26 @@
                   <option value="lmstudio" data-i18n="settings.translationProviderLmStudio">LM Studio</option>
                 </select>
               </label>
-              <label id="pref-deepl-key-row" class="setting-row" hidden style="flex-direction: column; align-items: stretch; gap: 0.25rem;">
+              <label id="pref-deepl-key-row" class="setting-row stack" hidden>
                 <span data-i18n="settings.deeplApiKey">DeepL API key</span>
                 <input id="pref-deepl-api-key" type="password" data-i18n-attr="placeholder=settings.deeplApiKeyPlaceholder" class="input">
               </label>
-              <label id="pref-lmstudio-endpoint-row" class="setting-row desktop-only-setting" hidden style="flex-direction: column; align-items: stretch; gap: 0.25rem;">
+              <label id="pref-lmstudio-endpoint-row" class="setting-row desktop-only-setting stack" hidden>
                 <span data-i18n="settings.lmStudioEndpoint">LM Studio endpoint</span>
                 <input id="pref-lmstudio-endpoint" type="text" class="input">
               </label>
-              <label id="pref-lmstudio-model-row" class="setting-row desktop-only-setting" hidden style="flex-direction: column; align-items: stretch; gap: 0.25rem;">
+              <label id="pref-lmstudio-model-row" class="setting-row desktop-only-setting stack" hidden>
                 <span data-i18n="settings.lmStudioModel">LM Studio model</span>
                 <input id="pref-lmstudio-model" type="text" data-i18n-attr="placeholder=settings.lmStudioModelPlaceholder" class="input">
               </label>
-              <label id="pref-auto-translate-row" class="setting-row toggle-row" style="opacity: 0.5; pointer-events: none; transition: opacity 0.2s;">
+              <label id="pref-auto-translate-row" class="setting-row toggle-row dimmed">
                 <span>
                   <span data-i18n="settings.autoTranslate">Auto-fill translation</span>
                   <small data-i18n="settings.autoTranslateHint">When a saved word has an empty translation, fills it with the selected translation engine. Manual translations stay untouched.</small>
                 </span>
                 <input id="pref-auto-translate" type="checkbox" data-pref="autoTranslateWords">
               </label>
-              <label id="pref-argos-as-dict-row" class="setting-row toggle-row desktop-only-setting" style="opacity: 0.5; pointer-events: none; transition: opacity 0.2s;">
+              <label id="pref-argos-as-dict-row" class="setting-row toggle-row desktop-only-setting dimmed">
                 <span>
                   <span data-i18n="settings.argosAsDict">Dictionary button opens translator</span>
                   <small data-i18n="settings.argosAsDictHint">Makes the dictionary button (M) open the built-in offline translator for the selected word instead of your dictionary URL.</small>
@@ -1086,7 +1086,7 @@
                   <option value="external" data-i18n="settings.dictModeExternal">External browser</option>
                 </select>
               </label>
-              <label class="setting-row" style="flex-direction: column; align-items: stretch; gap: 0.25rem;">
+              <label class="setting-row stack">
                 <span data-i18n="settings.dictionaryUrl">Dictionary URL (use {{word}})</span>
                 <input id="pref-dictionary-url" type="text" data-pref="dictionaryUrl" data-i18n-attr="placeholder=settings.dictionaryUrlPlaceholder" placeholder="https://en.wiktionary.org/wiki/{{word}}" class="input">
               </label>
@@ -1108,19 +1108,19 @@
                 </span>
                 <input id="pref-ai-explanations" type="checkbox">
               </label>
-              <label id="pref-ai-endpoint-row" class="setting-row" hidden style="flex-direction: column; align-items: stretch; gap: 0.25rem;">
+              <label id="pref-ai-endpoint-row" class="setting-row stack" hidden>
                 <span data-i18n="settings.aiEndpoint">Endpoint (OpenAI-compatible)</span>
                 <input id="pref-ai-endpoint" type="text" class="input">
               </label>
-              <label id="pref-ai-model-row" class="setting-row" hidden style="flex-direction: column; align-items: stretch; gap: 0.25rem;">
+              <label id="pref-ai-model-row" class="setting-row stack" hidden>
                 <span data-i18n="settings.aiModel">Model</span>
                 <input id="pref-ai-model" type="text" data-i18n-attr="placeholder=settings.aiModelPlaceholder" class="input">
               </label>
-              <label id="pref-ai-key-row" class="setting-row" hidden style="flex-direction: column; align-items: stretch; gap: 0.25rem;">
+              <label id="pref-ai-key-row" class="setting-row stack" hidden>
                 <span data-i18n="settings.aiApiKey">API key</span>
                 <input id="pref-ai-api-key" type="password" data-i18n-attr="placeholder=settings.aiApiKeyPlaceholder" class="input">
               </label>
-              <label id="pref-ai-effort-row" class="setting-row" hidden style="flex-direction: column; align-items: stretch; gap: 0.25rem;">
+              <label id="pref-ai-effort-row" class="setting-row stack" hidden>
                 <span>
                   <span data-i18n="settings.aiEffort">Reasoning effort</span>
                   <small data-i18n="settings.aiEffortHint">How much effort the model should put into reasoning. Empty = do not send — the endpoint uses its own default.</small>
@@ -1290,12 +1290,12 @@
               <p class="eyebrow" data-i18n="help.eyebrow">Help</p>
               <h2 id="help-heading" data-i18n="help.heading">Help and shortcuts</h2>
             </div>
-            <div class="settings-body" style="gap: 2rem;">
+            <div class="settings-body gap-2">
               <p class="muted-copy" data-i18n="help.shortcutScope"></p>
               <div>
-                <h3 data-i18n="help.navTitle" style="margin-top: 0;"></h3>
-                <div style="line-height: 2;">
-                  <ul style="margin: 0;">
+                <h3 data-i18n="help.navTitle" class="m-t-0"></h3>
+                <div class="lh-2">
+                  <ul class="m-0">
                     <li data-i18n-html="help.navKeys.library"></li>
                     <li data-i18n-html="help.navKeys.reader"></li>
                     <li data-i18n-html="help.navKeys.translator"></li>
@@ -1315,9 +1315,9 @@
               </div>
 
               <div>
-                <h3 data-i18n="help.readerTitle" style="margin-top: 0;"></h3>
-                <div style="line-height: 2; margin-bottom: 1rem;">
-                  <ul style="margin: 0;">
+                <h3 data-i18n="help.readerTitle" class="m-t-0"></h3>
+                <div class="lh-2-m-b-1">
+                  <ul class="m-0">
                     <li data-i18n-html="help.readerKeys.select"></li>
                     <li data-i18n-html="help.readerKeys.font"></li>
                     <li data-i18n-html="help.readerKeys.focus"></li>
@@ -1330,9 +1330,9 @@
                   </ul>
                 </div>
                 
-                <h3 data-i18n="help.focusTitle" style="margin-top: 1rem;"></h3>
-                <div style="line-height: 2; margin-bottom: 1rem;">
-                  <ul style="margin: 0;">
+                <h3 data-i18n="help.focusTitle" class="m-t-1"></h3>
+                <div class="lh-2-m-b-1">
+                  <ul class="m-0">
                     <li data-i18n-html="help.focusKeys.prevNext"></li>
                     <li data-i18n-html="help.focusKeys.line"></li>
                     <li data-i18n-html="help.focusKeys.escape"></li>
@@ -1342,9 +1342,9 @@
                   </ul>
                 </div>
                 
-                <h3 data-i18n="help.actionTitle" style="margin-top: 1rem;"></h3>
-                <div style="line-height: 2;">
-                  <ul style="margin: 0;">
+                <h3 data-i18n="help.actionTitle" class="m-t-1"></h3>
+                <div class="lh-2">
+                  <ul class="m-0">
                     <li data-i18n-html="help.actionKeys.merge"></li>
                     <li data-i18n-html="help.actionKeys.smartSuggest"></li>
                     <li data-i18n-html="help.actionKeys.ttsWord"></li>
@@ -1357,9 +1357,9 @@
                     <li data-i18n-html="help.actionKeys.removeStatus"></li>
                   </ul>
                 </div>
-                <h3 data-i18n="help.flashcardsTitle" style="margin-top: 1rem;"></h3>
-                <div style="line-height: 2;">
-                  <ul style="margin: 0;">
+                <h3 data-i18n="help.flashcardsTitle" class="m-t-1"></h3>
+                <div class="lh-2">
+                  <ul class="m-0">
                     <li data-i18n-html="help.flashcardsKeys.flip"></li>
                     <li data-i18n-html="help.flashcardsKeys.prevNext"></li>
                     <li data-i18n-html="help.flashcardsKeys.score"></li>
@@ -1370,9 +1370,9 @@
                     <li data-i18n-html="help.flashcardsKeys.searchImage"></li>
                   </ul>
                 </div>
-                <h3 data-i18n="help.editorTitle" style="margin-top: 1rem;"></h3>
-                <div style="line-height: 2;">
-                  <ul style="margin: 0;">
+                <h3 data-i18n="help.editorTitle" class="m-t-1"></h3>
+                <div class="lh-2">
+                  <ul class="m-0">
                     <li data-i18n-html="help.editorKeys.word"></li>
                     <li data-i18n-html="help.editorKeys.book"></li>
                   </ul>
@@ -1387,10 +1387,10 @@
               <h2 id="help-sm2" data-i18n="help.sm2Title">Spaced Repetition (FSRS / SM-2)</h2>
             </div>
             <div class="settings-body">
-              <p style="color: var(--muted); line-height: 1.6; margin-bottom: 1rem;" data-i18n-html="help.sm2Body1"></p>
-              <p style="color: var(--muted); line-height: 1.6; margin-bottom: 1rem;" data-i18n-html="help.sm2BodyFsrs"></p>
-              <p style="color: var(--muted); line-height: 1.6; margin-bottom: 0.5rem;" data-i18n-html="help.sm2Body2"></p>
-              <ul style="padding-left: 1.2rem; line-height: 1.8; margin: 0; color: var(--muted); display: flex; flex-direction: column; gap: 0.5rem;">
+              <p data-i18n-html="help.sm2Body1" class="muted-lh-1-6-m-b-1"></p>
+              <p data-i18n-html="help.sm2BodyFsrs" class="muted-lh-1-6-m-b-1"></p>
+              <p data-i18n-html="help.sm2Body2" class="muted-lh-1-6-m-b-05"></p>
+              <ul class="note-list-g-05">
                 <li data-i18n-html="help.sm2Grade02"></li>
                 <li data-i18n-html="help.sm2Grade3"></li>
                 <li data-i18n-html="help.sm2Grade4"></li>
@@ -1405,7 +1405,7 @@
               <h2 id="help-tips" data-i18n="help.tipsTitle">Useful Tips</h2>
             </div>
             <div class="settings-body">
-              <ul style="padding-left: 1.2rem; line-height: 1.8; margin: 0; color: var(--muted); display: flex; flex-direction: column; gap: 1rem;">
+              <ul class="note-list-g-1">
                 <li data-i18n-html="help.tip1"></li>
                 <li data-i18n-html="help.tip2"></li>
                 <li data-i18n-html="help.tip3"></li>
@@ -1424,7 +1424,7 @@
               <h2 id="help-credits" data-i18n="help.creditsTitle">Open Source, APIs &amp; Model Sources</h2>
             </div>
             <div class="settings-body">
-              <ul style="padding-left: 1.2rem; line-height: 1.8; margin: 0; color: var(--muted); display: flex; flex-direction: column; gap: 0.8rem;">
+              <ul class="note-list">
                 <li data-i18n-html="help.creditGutenberg"></li>
                 <li data-i18n-html="help.creditWikipedia"></li>
                 <li data-i18n-html="help.creditYouglish"></li>
@@ -1444,13 +1444,13 @@
               <h2 id="help-contact" data-i18n="help.contactTitle">About the App</h2>
             </div>
             <div class="settings-body">
-              <ul style="padding-left: 1.2rem; line-height: 1.8; margin: 0; color: var(--muted); display: flex; flex-direction: column; gap: 0.8rem;">
+              <ul class="note-list">
                 <li data-i18n-html="help.contactGithub"></li>
                 <li data-i18n-html="help.contactDiscussions"></li>
                 <li data-i18n-html="help.contactIssues"></li>
                 <li data-i18n-html="help.contactAuthor"></li>
                 <li data-i18n-html="help.contactLicense"></li>
-                <li data-i18n-html="help.whatsNew" style="color: var(--accent-ink);"></li>
+                <li data-i18n-html="help.whatsNew" class="text-accent-ink"></li>
                 <li data-i18n-html="help.version"></li>
               </ul>
             </div>
@@ -1513,12 +1513,12 @@
     </div>
   </dialog>
 
-  <dialog id="youglish-modal" class="panel" style="max-width: 700px; padding: 0;" aria-labelledby="youglish-modal-title">
-    <div style="display: flex; justify-content: space-between; align-items: center; padding: 1rem; border-bottom: 1px solid var(--line);">
-      <h2 id="youglish-modal-title" data-i18n="reader.youglishModalTitle" style="margin: 0; font-size: 1.25rem;">Pronunciation (YouGlish)</h2>
+  <dialog id="youglish-modal" class="panel max-w-700" aria-labelledby="youglish-modal-title">
+    <div class="dialog-header">
+      <h2 id="youglish-modal-title" data-i18n="reader.youglishModalTitle" class="dialog-title">Pronunciation (YouGlish)</h2>
       <button type="button" id="youglish-close" class="icon-button" data-i18n-attr="title=reader.close">×</button>
     </div>
-    <div id="youglish-modal-body" style="padding: 1rem; display: flex; justify-content: center;">
+    <div id="youglish-modal-body" class="flex-center-p-1">
       <div id="youglish-widget"></div>
     </div>
   </dialog>
@@ -1573,10 +1573,10 @@
     <div class="panel-header">
       <h2 id="move-book-title" data-i18n="moveBook.title">Move Book</h2>
     </div>
-    <div class="settings-body" style="padding: 1.5rem; gap: 1rem;">
+    <div class="settings-body p-15-g-1">
       <p class="muted-copy" data-i18n="moveBook.hint">Select the target language profile for this book:</p>
       <select id="move-book-select" class="input" data-i18n-attr="aria-label=library.moveBook"></select>
-      <div style="display: flex; gap: 0.5rem; justify-content: flex-end; margin-top: 1rem;">
+      <div class="justify-end-m-t-1">
         <button id="move-book-cancel" class="secondary-button" data-i18n="moveBook.cancel">Cancel</button>
         <button id="move-book-confirm" class="primary-button" data-i18n="moveBook.confirm">Move</button>
       </div>
@@ -1602,19 +1602,19 @@
     <div class="settings-body edit-book-body">
       <label class="setting-row edit-book-field">
         <span data-i18n="editBook.titleLabel">Title</span>
-        <input id="edit-book-title" type="text" class="input" style="width: 100%;">
+        <input id="edit-book-title" type="text" class="input w-100">
       </label>
       <label class="setting-row edit-book-field">
         <span data-i18n="editBook.authorLabel">Author</span>
-        <input id="edit-book-author" type="text" class="input" style="width: 100%;">
+        <input id="edit-book-author" type="text" class="input w-100">
       </label>
       <label class="setting-row edit-book-field">
         <span data-i18n="editBook.tagsLabel">Tags</span>
-        <input id="edit-book-tags" type="text" class="input" data-i18n-attr="placeholder=import.tagsPlaceholder" style="width: 100%;">
+        <input id="edit-book-tags" type="text" class="input w-100" data-i18n-attr="placeholder=import.tagsPlaceholder">
       </label>
       <label class="setting-row edit-book-field">
         <span data-i18n="editBook.levelLabel">Level</span>
-        <select id="edit-book-level" class="input" style="width: 100%;">
+        <select id="edit-book-level" class="input w-100">
           <option value="" data-i18n="library.levelAny">Any</option>
           <option value="A1">A1</option>
           <option value="A2">A2</option>
@@ -1630,12 +1630,12 @@
           <div id="edit-book-cover-preview" class="edit-book-cover-preview" hidden>
             <img id="edit-book-cover-img" src="" data-i18n-attr="alt=editBook.coverPreviewAlt" alt="Cover preview">
             <button id="edit-book-cover-clear" class="edit-book-cover-clear" type="button" data-i18n-attr="title=editBook.deleteCover">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width: 14px; height: 14px;"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-14"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
             </button>
           </div>
           <label for="edit-book-cover" class="edit-book-cover-dropzone" id="edit-book-cover-dropzone" data-i18n-attr="title=editBook.changeCover">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width: 28px; height: 28px; color: var(--muted); margin-bottom: 0.5rem;"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect><circle cx="8.5" cy="8.5" r="1.5"></circle><polyline points="21 15 16 10 5 21"></polyline></svg>
-            <span style="font-size: 0.85rem; color: var(--muted); text-align: center;" data-i18n="import.coverPasteHint">Click to select or paste</span>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-28-muted-m-b-05"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect><circle cx="8.5" cy="8.5" r="1.5"></circle><polyline points="21 15 16 10 5 21"></polyline></svg>
+            <span data-i18n="import.coverPasteHint" class="fs-085-muted-center">Click to select or paste</span>
             <input id="edit-book-cover" type="file" accept="image/*" class="visually-hidden">
           </label>
         </div>
@@ -1651,56 +1651,56 @@
     </div>
   </dialog>
 
-  <dialog id="argos-download-dialog" class="panel" style="width: 90vw; max-width: 500px;" aria-labelledby="argos-download-title">
+  <dialog id="argos-download-dialog" class="panel dialog-500" aria-labelledby="argos-download-title">
     <div class="panel-header">
       <h2 id="argos-download-title" data-i18n="settings.argosDownloadTitle">Download offline models</h2>
     </div>
-    <div class="settings-body" style="padding: 1.5rem; gap: 1rem;">
+    <div class="settings-body p-15-g-1">
       <p class="muted-copy" data-i18n="settings.argosDownloadHint">Downloads local translation packages for the selected languages, including pairs with English and your learning language when available.</p>
-      <div id="argos-languages-list" style="display: flex; flex-direction: column; gap: 0.5rem;">
-        <label class="status-check" style="justify-content: flex-start; gap: 0.5rem;">
+      <div id="argos-languages-list" class="stack-g-05">
+        <label class="status-check justify-start">
           <input type="checkbox" value="en" checked>
           <span data-i18n="languages.en">English</span>
         </label>
-        <label class="status-check" style="justify-content: flex-start; gap: 0.5rem;">
+        <label class="status-check justify-start">
           <input type="checkbox" value="pl" checked>
           <span data-i18n="languages.pl">Polish</span>
         </label>
-        <label class="status-check" style="justify-content: flex-start; gap: 0.5rem;">
+        <label class="status-check justify-start">
           <input type="checkbox" value="de">
           <span data-i18n="languages.de">German</span>
         </label>
-        <label class="status-check" style="justify-content: flex-start; gap: 0.5rem;">
+        <label class="status-check justify-start">
           <input type="checkbox" value="es">
           <span data-i18n="languages.es">Spanish</span>
         </label>
-        <label class="status-check" style="justify-content: flex-start; gap: 0.5rem;">
+        <label class="status-check justify-start">
           <input type="checkbox" value="fr">
           <span data-i18n="languages.fr">French</span>
         </label>
-        <label class="status-check" style="justify-content: flex-start; gap: 0.5rem;">
+        <label class="status-check justify-start">
           <input type="checkbox" value="zh">
           <span data-i18n="languages.zh">Chinese (Simplified)</span>
         </label>
       </div>
-      <p style="color: var(--red); font-size: 0.85rem; margin-top: 1rem;" data-i18n="settings.argosDownloadWarning">Note: downloading models will take a while. Do not close the app during the process.</p>
-      <div style="display: flex; gap: 0.5rem; justify-content: flex-end; margin-top: 1rem;">
+      <p data-i18n="settings.argosDownloadWarning" class="error-text">Note: downloading models will take a while. Do not close the app during the process.</p>
+      <div class="justify-end-m-t-1">
         <button id="argos-download-cancel" class="secondary-button" data-i18n="moveBook.cancel">Cancel</button>
         <button id="argos-download-confirm" class="primary-button" data-i18n="settings.argosDownloadConfirm">Download</button>
       </div>
     </div>
   </dialog>
 
-  <dialog id="update-dialog" class="panel" style="width: 90vw; max-width: 500px;" aria-labelledby="update-title">
+  <dialog id="update-dialog" class="panel dialog-500" aria-labelledby="update-title">
     <div class="panel-header">
-      <h2 style="display: flex; align-items: center; gap: 0.5rem;">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width: 20px; height: 20px; flex-shrink: 0; color: var(--green);"><polyline points="23 6 13.5 15.5 8.5 10.5 1 18"></polyline><polyline points="17 6 23 6 23 12"></polyline></svg>
+      <h2 class="row">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-20-green"><polyline points="23 6 13.5 15.5 8.5 10.5 1 18"></polyline><polyline points="17 6 23 6 23 12"></polyline></svg>
         <span id="update-title" data-i18n="update.title">Update Available</span>
       </h2>
     </div>
-    <div class="settings-body" style="padding: 1.5rem; gap: 1rem;">
-      <p id="update-message" data-i18n="update.message" style="margin: 0; font-size: 0.9rem; line-height: 1.5; color: var(--muted);">Word Hunter {version} is available! (You have {current})</p>
-      <div style="display: flex; flex-wrap: wrap; gap: 0.5rem; justify-content: flex-end; margin-top: 1rem;">
+    <div class="settings-body p-15-g-1">
+      <p id="update-message" data-i18n="update.message" class="m-0-fs-09-lh-15-muted">Word Hunter {version} is available! (You have {current})</p>
+      <div class="justify-end-wrap-m-t-1">
         <button id="update-dismiss" class="ghost-button" data-i18n="update.dismiss">Later</button>
         <button id="update-skip" class="secondary-button" data-i18n="update.skipLabel">Skip this version</button>
         <button id="update-disable" class="secondary-button" data-i18n="update.disableUpdates">Don't remind me again</button>
@@ -1709,7 +1709,7 @@
     </div>
   </dialog>
 
-  <dialog id="add-word-dialog" class="panel word-editor-dialog" style="width: 92vw; max-width: 680px;" aria-labelledby="add-word-dialog-title">
+  <dialog id="add-word-dialog" class="panel word-editor-dialog dialog-680" aria-labelledby="add-word-dialog-title">
     <div class="panel-header">
       <h2 id="add-word-dialog-title" data-i18n="vocab.addWordTitle">Add word</h2>
     </div>

--- a/src/web/js/events/image-search.ts
+++ b/src/web/js/events/image-search.ts
@@ -24,24 +24,24 @@ function isImageSearchPage(page: unknown): page is ImageSearchPage {
 }
 
 function imageSearchMessage(key: string): string {
-  return `<div style="font-size: 11px; color: var(--muted); padding: 0.25rem;">${t(key)}</div>`;
+  return `<div class="caption-tiny">${t(key)}</div>`;
 }
 
 function uploadImageCardHtml(safeWord: string): string {
-  return `<div class="search-img-suggestion" role="button" tabindex="0" style="cursor: pointer; text-align: center; border: 2px dashed var(--line); padding: 0.25rem; border-radius: 6px; display: flex; flex-direction: column; align-items: center; justify-content: center; width: 180px;" data-action="upload-image" data-word="${safeWord}" title="${t("vocab.uploadOwnImage")}" aria-label="${t("vocab.uploadOwnImage")}">
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width: 32px; height: 32px; color: var(--muted);"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect><circle cx="8.5" cy="8.5" r="1.5"></circle><polyline points="21 15 16 10 5 21"></polyline></svg>
-      <div style="font-size: 12px; margin-top: 0.25rem; color: var(--blue); font-weight: 500;">${t("vocab.uploadOwnImage")} <span class="shortcut-badge">Ctrl+4</span></div>
-      <input type="file" accept="image/*" style="display:none" data-upload-image="${safeWord}">
+  return `<div class="search-img-suggestion tile-add" role="button" tabindex="0" data-action="upload-image" data-word="${safeWord}" title="${t("vocab.uploadOwnImage")}" aria-label="${t("vocab.uploadOwnImage")}">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-32-muted"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect><circle cx="8.5" cy="8.5" r="1.5"></circle><polyline points="21 15 16 10 5 21"></polyline></svg>
+      <div class="hint-blue">${t("vocab.uploadOwnImage")} <span class="shortcut-badge">Ctrl+4</span></div>
+      <input type="file" accept="image/*" data-upload-image="${safeWord}" class="display-none">
     </div>`;
 }
 
 function uploadImageHtml(safeWord: string): string {
-  return `<div style="display: flex; gap: 0.5rem; justify-content: center; flex-wrap: wrap; margin-top: 0.5rem;">${uploadImageCardHtml(safeWord)}</div>`;
+  return `<div class="justify-center-wrap-m-t-05">${uploadImageCardHtml(safeWord)}</div>`;
 }
 
 function imageSuggestionHtml(page: ImageSearchPage, index: number, safeWord: string): string {
   const imageUrl = escapeAttribute(page.thumbnail.source);
-  return `<button class="search-img-suggestion" type="button" style="cursor: pointer; text-align: center; border: 1px solid var(--line); padding: 0.25rem; border-radius: 6px; display: flex; flex-direction: column; align-items: center; justify-content: space-between; width: 180px;" data-action="save-image" data-word="${safeWord}" data-img-url="${imageUrl}" title="${t("vocab.clickToSave")}"><img src="${imageUrl}" alt="" style="height: 120px; width: 100%; object-fit: cover; border-radius: 4px;" /><span style="font-size: 12px; margin-top: 0.25rem; color: var(--blue); font-weight: 500;">${t("vocab.selectImage")} <span class="shortcut-badge">Ctrl+${index + 1}</span></span></button>`;
+  return `<button class="search-img-suggestion tile-solid" type="button" data-action="save-image" data-word="${safeWord}" data-img-url="${imageUrl}" title="${t("vocab.clickToSave")}"><img src="${imageUrl}" alt=""  class="thumb-120" /><span class="hint-blue">${t("vocab.selectImage")} <span class="shortcut-badge">Ctrl+${index + 1}</span></span></button>`;
 }
 
 function renderImageSuggestions(container: HTMLElement, word: string, pages?: Record<string, unknown>): void {
@@ -51,7 +51,7 @@ function renderImageSuggestions(container: HTMLElement, word: string, pages?: Re
     container.innerHTML = imageSearchMessage(pages ? "toast.imageSearchNoImages" : "toast.imageSearchNoResults") + uploadImageHtml(safeWord);
     return;
   }
-  container.innerHTML = `<div style="display: flex; gap: 0.5rem; justify-content: center; flex-wrap: wrap; margin-top: 0.5rem;">${suggestions.map((page, index) => imageSuggestionHtml(page, index, safeWord)).join("")}${uploadImageCardHtml(safeWord)}</div>`;
+  container.innerHTML = `<div class="justify-center-wrap-m-t-05">${suggestions.map((page, index) => imageSuggestionHtml(page, index, safeWord)).join("")}${uploadImageCardHtml(safeWord)}</div>`;
 }
 
 export function renderImageSearch(container: HTMLElement, word: string): void {

--- a/src/web/js/events/settings.ts
+++ b/src/web/js/events/settings.ts
@@ -535,7 +535,7 @@ export function bindSettingsEvents() {
         
         if (els.argosLanguagesList) {
           els.argosLanguagesList.innerHTML = supported.map(lang => `
-            <label class="status-check" style="justify-content: flex-start; gap: 0.5rem;">
+            <label class="status-check justify-start">
               <input type="checkbox" value="${lang}" ${lang === pair.fromCode || lang === pair.toCode ? "checked" : ""}>
               <span>${translate(`languages.${lang}`) === `languages.${lang}` ? lang.toUpperCase() : translate(`languages.${lang}`)} (${lang.toUpperCase()})</span>
             </label>

--- a/src/web/js/preferences.ts
+++ b/src/web/js/preferences.ts
@@ -190,14 +190,14 @@ export function syncSettingsControls() {
   const appFlagKey = setFlagImages("locale", locale, APP_LOCALES, "pl");
   const appFlagEl = document.getElementById("app-lang-flag");
   if (appFlagEl) {
-    appFlagEl.innerHTML = `<img src="flags/${appFlagKey}.svg" alt="${escapeHtml(t(`languages.${appFlagKey}`))}" style="width: 1.5rem; height: 1.5rem; border-radius: 4px; object-fit: cover; flex-shrink: 0; display: block; pointer-events: none;">`;
+    appFlagEl.innerHTML = `<img src="flags/${appFlagKey}.svg" alt="${escapeHtml(t(`languages.${appFlagKey}`))}" class="cover-thumb-block">`;
   }
 
   const lang = state.preferences.learningLanguage || "en";
   const learnFlagKey = setFlagImages("learning", lang, LEARNING_LANGUAGES, "en");
   const learnFlagEl = document.getElementById("learning-lang-flag");
   if (learnFlagEl) {
-    learnFlagEl.innerHTML = `<img src="flags/${learnFlagKey}.svg" alt="${escapeHtml(t(`languages.${learnFlagKey}`))}" style="width: 1.5rem; height: 1.5rem; border-radius: 4px; object-fit: cover; flex-shrink: 0; display: block; pointer-events: none;">`;
+    learnFlagEl.innerHTML = `<img src="flags/${learnFlagKey}.svg" alt="${escapeHtml(t(`languages.${learnFlagKey}`))}" class="cover-thumb-block">`;
   }
 
   const prefs: Partial<WhPreferences> = state.preferences || {};

--- a/src/web/js/reader/pagination.ts
+++ b/src/web/js/reader/pagination.ts
@@ -106,14 +106,14 @@ export function paginationHtml(textId: string, currentPage: number, totalPages: 
     <div class="pagination-controls">
       <button class="secondary-button" id="btn-prev-page" ${currentPage <= 1 ? "disabled" : ""} title="${escapeAttribute(tFn("reader.prevPageTitle"))}">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>
-        <kbd style="font-size:0.6rem; padding: 1px 3px; margin-left: 4px;">${escapeHtml(tFn("reader.keyPageUp"))}</kbd>
+        <kbd class="page-badge">${escapeHtml(tFn("reader.keyPageUp"))}</kbd>
       </button>
       <span class="page-jump">
         <input type="number" id="page-jump-input" class="page-jump-input" min="1" max="${totalPages}" value="${currentPage}" aria-label="${escapeAttribute(tFn("reader.pageJumpLabel"))}">
         <span class="page-jump-total">/&thinsp;${totalPages}</span>
       </span>
       <button class="secondary-button" id="btn-next-page" ${currentPage >= totalPages ? "disabled" : ""} title="${escapeAttribute(tFn("reader.nextPageTitle"))}">
-        <kbd style="font-size:0.6rem; padding: 1px 3px; margin-right: 4px;">${escapeHtml(tFn("reader.keyPageDown"))}</kbd>
+        <kbd class="page-badge-r">${escapeHtml(tFn("reader.keyPageDown"))}</kbd>
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"></polyline></svg>
       </button>
     </div>

--- a/src/web/js/reader/renderer.ts
+++ b/src/web/js/reader/renderer.ts
@@ -235,7 +235,7 @@ export function renderReader(): void {
     return;
   }
 
-  els.readerText.innerHTML = `<div class="reader-loading" role="status" aria-live="polite" aria-atomic="true" style="padding: 2rem; text-align: center;"><div class="spinner" aria-hidden="true" style="margin: 0 auto 1rem;"></div><p class="muted-copy">${escapeHtml(t("reader.loadingHint"))}</p></div>`;
+  els.readerText.innerHTML = `<div class="reader-loading empty-pad" role="status" aria-live="polite" aria-atomic="true"><div class="spinner m-0-auto-1" aria-hidden="true"></div><p class="muted-copy">${escapeHtml(t("reader.loadingHint"))}</p></div>`;
 
   setTimeout(() => {
     if (generation !== readerRenderGeneration || state.currentTextId !== current.id) return;

--- a/src/web/js/reader/text-renderer.ts
+++ b/src/web/js/reader/text-renderer.ts
@@ -64,7 +64,7 @@ export function renderPlainText({ current, tokens, globalWordIndexes, globalChar
     while (i < pageTokens.length && tokensProcessed < CHUNK_SIZE) {
       const part = pageTokens[i];
       if (part.type === "image") {
-        htmlChunk += `<img src="/__media?book=${encodeURIComponent(current.id)}&img=${encodeURIComponent(part.value)}" style="max-width: 100%; height: auto; display: block; margin: 1rem auto; border-radius: 6px;" alt="${escapeHtml(t("reader.imageAlt"))}">`;
+        htmlChunk += `<img src="/__media?book=${encodeURIComponent(current.id)}&img=${encodeURIComponent(part.value)}" alt="${escapeHtml(t("reader.imageAlt"))}" class="img-block-center">`;
         i++;
         tokensProcessed++;
         continue;

--- a/src/web/js/reader/word-panel.ts
+++ b/src/web/js/reader/word-panel.ts
@@ -158,8 +158,8 @@ function renderArticleEditor(
 function renderTranslationEditor(entry: WordPanelEntry, word: string, marginTop = "0"): string {
   return `
     <label style="margin-top: ${marginTop};">
-      <span style="display: flex; align-items: center; justify-content: space-between; width: 100%;">
-        ${escapeHtml(t("reader.translationLabel"))} <span class="shortcut-badge" style="font-size: 0.65rem; padding: 0.1rem 0.3rem;">E</span>
+      <span class="row-between">
+        ${escapeHtml(t("reader.translationLabel"))} <span class="shortcut-badge badge-tiny">E</span>
       </span>
       <input type="text" value="${escapeAttribute(entry.translation || "")}" data-word="${escapeHtml(word)}" data-word-field="translation" placeholder="${escapeAttribute(t("reader.translationPlaceholder"))}">
     </label>
@@ -554,8 +554,8 @@ function renderContentItem(
   if (id === "note") {
     return `
       <label data-word-panel-item="note">
-        <span style="display: flex; align-items: center; justify-content: space-between; width: 100%;">
-          ${escapeHtml(t("reader.noteLabel"))} <span class="shortcut-badge" style="font-size: 0.65rem; padding: 0.1rem 0.3rem;">N</span>
+        <span class="row-between">
+          ${escapeHtml(t("reader.noteLabel"))} <span class="shortcut-badge badge-tiny">N</span>
         </span>
         <textarea rows="4" spellcheck="false" data-word="${escapeAttribute(word)}" data-word-field="note" placeholder="${escapeAttribute(t("reader.notePlaceholder"))}">${escapeHtml(entry.note || "")}</textarea>
       </label>
@@ -563,18 +563,18 @@ function renderContentItem(
   }
   if (id === "image") {
     return entry.imageUrl ? `
-      <div class="word-image-preview" data-word-panel-item="image" style="margin-top: 1rem; text-align: center; position: relative; display: inline-block; width: 100%;">
-        <img src="${escapeAttribute(entry.imageUrl)}" alt="${escapeAttribute(t("reader.imageAlt"))}" style="max-height: 120px; max-width: 100%; border-radius: 6px; border: 1px solid var(--line);" />
+      <div class="word-image-preview upload-zone" data-word-panel-item="image">
+        <img src="${escapeAttribute(entry.imageUrl)}" alt="${escapeAttribute(t("reader.imageAlt"))}"  class="thumb-bordered" />
         <button class="word-image-remove" type="button" data-action="remove-image" data-word="${escapeAttribute(word)}" aria-label="${escapeAttribute(t("reader.removeImage"))}" title="${escapeAttribute(t("reader.removeImage"))}">×</button>
       </div>
     ` : `
-      <div class="word-image-search" data-word-panel-item="image" style="margin-top: 1rem; text-align: center;">
+      <div class="word-image-search m-t-1-center" data-word-panel-item="image">
         <button class="secondary-button button-xs image-action-button" type="button" data-action="search-image" data-word="${escapeAttribute(word)}" title="${escapeAttribute(t("vocab.addImage"))}">
           ${icon("image", 14)}
           ${escapeHtml(t("vocab.addImage"))}
           <span class="shortcut-badge">I</span>
         </button>
-        <div id="image-search-results-${escapeAttribute(word)}" style="margin-top: 0.25rem;"></div>
+        <div id="image-search-results-${escapeAttribute(word)}" class="m-t-025"></div>
       </div>
     `;
   }

--- a/src/web/js/views/discover.ts
+++ b/src/web/js/views/discover.ts
@@ -205,7 +205,7 @@ function renderResults(data?: DiscoverSearchResult): void {
     const coverBlock = showCover
       ? (cover
         ? `<div class="book-cover" aria-hidden="true"><img src="${escapeAttribute(cover)}" alt="" loading="lazy" onerror="this.parentElement.style.display='none'"></div>`
-        : `<div class="book-cover" aria-hidden="true"><div style="width:100%;height:100%;background:var(--line);border-radius:4px;"></div></div>`)
+        : `<div class="book-cover" aria-hidden="true"><div class="img-placeholder"></div></div>`)
       : "";
 
     let sourceTag = t("discover.sourceGutenberg", { id: escapeHtml(id) });
@@ -229,12 +229,12 @@ function renderResults(data?: DiscoverSearchResult): void {
             <p>${escapeHtml(author)}${authorYears ? ` · ${escapeHtml(authorYears)}` : ""}</p>
           </div>
           ${summary ? `<p class="book-summary">${escapeHtml(summary.slice(0, 200))}${summary.length > 200 ? "…" : ""}</p>` : ""}
-          <div class="book-actions" style="flex-direction: row; justify-content: space-between; align-items: center; gap: 0.5rem; width: 100%;">
-            <label class="discover-check" style="margin: 0;">
+          <div class="book-actions row-between-g-05">
+            <label class="discover-check m-0">
               <input type="checkbox" data-discover-check="${escapeAttribute(id)}" ${isSelected ? "checked" : ""}>
               <span>${escapeHtml(t("discover.selectLabel"))}</span>
             </label>
-            <div style="display: flex; gap: 0.5rem;">
+            <div class="flex-gap-05">
               <button class="primary-button icon-button" type="button" data-discover-add="${escapeAttribute(id)}" ${inLibrary ? "disabled" : ""} title="${escapeAttribute(inLibrary ? t("discover.added") : t("discover.add"))}" aria-label="${escapeAttribute(inLibrary ? t("discover.added") : t("discover.add"))}">
                 ${inLibrary
                   ? `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"></polyline></svg>`

--- a/src/web/js/views/graphs.ts
+++ b/src/web/js/views/graphs.ts
@@ -104,7 +104,7 @@ export function renderGraphs() {
   if (!Object.keys(state.vocab).length) {
     delete graphArea.dataset.graphSignature;
     delete graphArea.dataset.graphRendered;
-    graphArea.innerHTML = `<div class="empty-state" style="padding:3rem"><p>${t("graphs.empty")}</p></div>`;
+    graphArea.innerHTML = `<div class="empty-state p-3"><p>${t("graphs.empty")}</p></div>`;
     const heat = document.getElementById("graphs-heatmap");
     if (heat) heat.innerHTML = "";
     setGraphsLoading(false);

--- a/src/web/js/views/heatmap.ts
+++ b/src/web/js/views/heatmap.ts
@@ -86,12 +86,12 @@ export function renderContributionHeatmap(target: HTMLElement, options: Contribu
   const MONTHS = t("graphs.monthLabels").split("|");
   const months = buildContributionMonthLabels(weeks, weeksToShow, MONTHS);
 
-  let html = '<div class="heatmap-wrap"><div class="heatmap-day-labels" style="width:10px;"></div><div class="heatmap-grid-area">';
+  let html = '<div class="heatmap-wrap"><div class="heatmap-day-labels w-10"></div><div class="heatmap-grid-area">';
   html += '<div class="heatmap-months">';
   for (const m of months) {
     html += `<span style="position:absolute;left:${m.week * 17}px;">${escapeHtml(m.label)}</span>`;
   }
-  html += '<span style="visibility:hidden;">' + escapeHtml(MONTHS[0]) + '</span></div>';
+  html += '<span class="visibility-hidden">' + escapeHtml(MONTHS[0]) + '</span></div>';
   html += '<div class="heatmap-grid">';
   for (let weekIndex = 0; weekIndex < weeks.length; weekIndex += 1) {
     const week = weeks[weekIndex];

--- a/src/web/js/views/library.ts
+++ b/src/web/js/views/library.ts
@@ -348,8 +348,8 @@ export function renderLibrary(): void {
           </div>
           ${blurbLine}
           ${statsBlock}
-          <div class="book-actions" style="display: flex; gap: 0.5rem; align-items: center; width: 100%; flex-wrap: wrap; margin-top: auto;">
-             <button class="primary-button" type="button" data-action="read-sample" data-id="${escapeHtml(book.id)}" style="flex: 1; justify-content: center; display: inline-flex; align-items: center; gap: 0.4rem;">
+          <div class="book-actions actions-row">
+             <button class="primary-button action-grow" type="button" data-action="read-sample" data-id="${escapeHtml(book.id)}">
               ${icon("play", 16)}
               ${escapeHtml(t("library.read"))}
             </button>

--- a/src/web/js/views/translator.ts
+++ b/src/web/js/views/translator.ts
@@ -298,7 +298,7 @@ async function translateNow(): Promise<void> {
   if (provider === "offline" && !hasModelForPair(pair.fromCode, pair.toCode) && pair.fromCode !== pair.toCode) {
     const sizeMb = getPackageSize(pair.fromCode, pair.toCode);
     if (els.translatorStatus) {
-      els.translatorStatus.innerHTML = `${t("translator.noModelFor", { from: languageName(pair.fromCode), to: languageName(pair.toCode) })} <button class="ghost-button" id="translator-download-prompt" style="font-size:0.8rem; padding:0.2rem 0.5rem;">${t("translator.downloadNow")} (${t("translator.sizeMb", { size: Math.round(sizeMb) })})</button>`;
+      els.translatorStatus.innerHTML = `${t("translator.noModelFor", { from: languageName(pair.fromCode), to: languageName(pair.toCode) })} <button class="ghost-button badge-sm" id="translator-download-prompt">${t("translator.downloadNow")} (${t("translator.sizeMb", { size: Math.round(sizeMb) })})</button>`;
       const downloadBtn = document.getElementById("translator-download-prompt");
       if (downloadBtn) {
         downloadBtn.addEventListener("click", () => openDownloadDialog(pair.fromCode, pair.toCode));

--- a/src/web/js/vocabulary/review-card.ts
+++ b/src/web/js/vocabulary/review-card.ts
@@ -186,16 +186,16 @@ export function renderReview(transition?: ReviewTransitionDirection): void {
   let frontHtml = "";
   if (!isReverse) {
     frontHtml = `
-      <strong style="font-size: 2rem; display: inline-flex; align-items: center; gap: 0.5rem; justify-content: center; width: 100%;">
+      <strong class="review-icon">
         ${escapeHtml(formatHeadword(card.word, card.article))}
-        <button class="secondary-button" type="button" data-tts-word="${escapeAttribute(formatHeadword(card.word, card.article))}" title="${escapeAttribute(t("reader.ttsWordTitle"))}" aria-label="${escapeAttribute(t("reader.ttsWordTitle"))}" style="padding: 0.2rem; min-height: auto; border-radius: 50%; width: 28px; height: 28px; display: inline-flex; align-items: center; justify-content: center; background: none; border: 1px solid var(--line); color: var(--muted); cursor: pointer;">
+        <button class="secondary-button round-icon-btn-28" type="button" data-tts-word="${escapeAttribute(formatHeadword(card.word, card.article))}" title="${escapeAttribute(t("reader.ttsWordTitle"))}" aria-label="${escapeAttribute(t("reader.ttsWordTitle"))}">
           ${icon("speaker", 14)}
         </button>
       </strong>
       ${context ? `
-        <p class="review-context" style="font-size: 0.9rem; color: var(--muted); margin-top: 0.75rem; font-style: italic; display: inline-flex; align-items: center; gap: 0.5rem; justify-content: center; width: 100%;">
+        <p class="review-context hint-italic-center">
           „${escapeHtml(displayContext)}”
-          <button class="secondary-button" type="button" data-tts-word="${escapeAttribute(context)}" title="${escapeAttribute(t("vocab.readSentence"))}" aria-label="${escapeAttribute(t("vocab.readSentence"))}" style="padding: 0.2rem; min-height: auto; border-radius: 50%; width: 24px; height: 24px; display: inline-flex; align-items: center; justify-content: center; background: none; border: 1px solid var(--line); color: var(--muted); cursor: pointer;">
+          <button class="secondary-button round-icon-btn-24" type="button" data-tts-word="${escapeAttribute(context)}" title="${escapeAttribute(t("vocab.readSentence"))}" aria-label="${escapeAttribute(t("vocab.readSentence"))}">
             ${icon("speaker", 12)}
           </button>
         </p>
@@ -204,12 +204,12 @@ export function renderReview(transition?: ReviewTransitionDirection): void {
   } else {
     frontHtml = `
       ${card.translation ? `
-        <p class="review-translation-front" style="font-size: 1.5rem; font-weight: 500; color: var(--ink); margin-top: 0.5rem; display: block; width: 100%; text-align: center;">
+        <p class="review-translation-front review-title">
           ${escapeHtml(card.translation)}
         </p>
       ` : renderReviewTranslationInput(card)}
       ${context ? `
-        <p class="review-context" style="font-size: 0.9rem; color: var(--muted); margin-top: 0.75rem; font-style: italic; display: inline-flex; align-items: center; gap: 0.5rem; justify-content: center; width: 100%;">
+        <p class="review-context hint-italic-center">
           „${escapeHtml(maskHeadwordInSentence(displayContext, card.word, card.article))}”
         </p>
       ` : ""}
@@ -219,20 +219,20 @@ export function renderReview(transition?: ReviewTransitionDirection): void {
   let imageHtml = "";
   if (card.imageUrl) {
     imageHtml = `
-      <div class="review-image" style="margin-top: 0.5rem; text-align: center; position: relative; display: inline-block;">
-        <img src="${escapeAttribute(card.imageUrl)}" alt="${escapeAttribute(formatHeadword(card.word, card.article))}" style="max-height: 120px; max-width: 100%; border-radius: 6px; border: 1px solid var(--line);" />
+      <div class="review-image upload-zone-sm">
+        <img src="${escapeAttribute(card.imageUrl)}" alt="${escapeAttribute(formatHeadword(card.word, card.article))}"  class="thumb-bordered" />
         <button class="word-image-remove review-image-remove" type="button" data-action="remove-image" data-word="${escapeAttribute(card.key)}" title="${escapeAttribute(t("reader.removeImage"))}" aria-label="${escapeAttribute(t("reader.removeImage"))}">×</button>
       </div>
     `;
   } else {
     imageHtml = `
-      <div class="review-image-search" style="margin-top: 0.5rem; text-align: center;">
+      <div class="review-image-search m-t-05-center">
         <button class="secondary-button button-xs image-action-button" type="button" data-review-action="search-image" data-word="${escapeAttribute(card.key)}" title="${escapeAttribute(t("vocab.addImage"))}">
           ${icon("image", 14)}
           ${escapeHtml(t("vocab.addImage"))}
           <span class="shortcut-badge">I</span>
         </button>
-        <div id="review-image-search-results-${escapeAttribute(card.key)}" style="margin-top: 0.25rem;"></div>
+        <div id="review-image-search-results-${escapeAttribute(card.key)}" class="m-t-025"></div>
       </div>
     `;
   }
@@ -242,27 +242,27 @@ export function renderReview(transition?: ReviewTransitionDirection): void {
     if (!isReverse) {
       backHtml = `
         ${card.translation ? `
-          <p class="review-translation" style="margin-top: 1rem; font-size: 1.2rem; font-weight: 500; color: var(--ink);">${escapeHtml(card.translation)}</p>
+          <p class="review-translation review-subtitle">${escapeHtml(card.translation)}</p>
         ` : renderReviewTranslationInput(card)}
-        ${card.note ? `<p class="review-note" style="margin-top: 0.5rem; color: var(--muted); font-size: 0.95rem;">${escapeHtml(card.note)}</p>` : ""}
+        ${card.note ? `<p class="review-note stat-note">${escapeHtml(card.note)}</p>` : ""}
       `;
     } else {
       backHtml = `
-        <strong style="font-size: 2rem; display: inline-flex; align-items: center; gap: 0.5rem; justify-content: center; width: 100%; margin-top: 1rem;">
+        <strong class="review-icon-m-t-1">
           ${escapeHtml(formatHeadword(card.word, card.article))}
-          <button class="secondary-button" type="button" data-tts-word="${escapeAttribute(formatHeadword(card.word, card.article))}" title="${escapeAttribute(t("reader.ttsWordTitle"))}" aria-label="${escapeAttribute(t("reader.ttsWordTitle"))}" style="padding: 0.2rem; min-height: auto; border-radius: 50%; width: 28px; height: 28px; display: inline-flex; align-items: center; justify-content: center; background: none; border: 1px solid var(--line); color: var(--muted); cursor: pointer;">
+          <button class="secondary-button round-icon-btn-28" type="button" data-tts-word="${escapeAttribute(formatHeadword(card.word, card.article))}" title="${escapeAttribute(t("reader.ttsWordTitle"))}" aria-label="${escapeAttribute(t("reader.ttsWordTitle"))}">
             ${icon("speaker", 14)}
           </button>
         </strong>
         ${context ? `
-          <p class="review-context-unmasked" style="font-size: 0.9rem; color: var(--muted); margin-top: 0.5rem; font-style: italic; display: inline-flex; align-items: center; gap: 0.5rem; justify-content: center; width: 100%;">
+          <p class="review-context-unmasked hint-italic-center-m-t-05">
             „${escapeHtml(displayContext)}”
-            <button class="secondary-button" type="button" data-tts-word="${escapeAttribute(context)}" title="${escapeAttribute(t("vocab.readSentence"))}" aria-label="${escapeAttribute(t("vocab.readSentence"))}" style="padding: 0.2rem; min-height: auto; border-radius: 50%; width: 24px; height: 24px; display: inline-flex; align-items: center; justify-content: center; background: none; border: 1px solid var(--line); color: var(--muted); cursor: pointer;">
+            <button class="secondary-button round-icon-btn-24" type="button" data-tts-word="${escapeAttribute(context)}" title="${escapeAttribute(t("vocab.readSentence"))}" aria-label="${escapeAttribute(t("vocab.readSentence"))}">
               ${icon("speaker", 12)}
             </button>
           </p>
         ` : ""}
-        ${card.note ? `<p class="review-note" style="margin-top: 0.5rem; color: var(--muted); font-size: 0.95rem;">${escapeHtml(card.note)}</p>` : ""}
+        ${card.note ? `<p class="review-note stat-note">${escapeHtml(card.note)}</p>` : ""}
       `;
     }
     backHtml = `<div id="review-card-answer" class="review-card-answer">${backHtml}</div>`;
@@ -284,7 +284,7 @@ export function renderReview(transition?: ReviewTransitionDirection): void {
         </div>
       </div>
     </div>
-    <div class="word-actions" style="flex-wrap: wrap;">
+    <div class="word-actions flex-wrap">
       <button class="secondary-button" type="button" data-dict-word="${escapeAttribute(card.word)}" title="${escapeAttribute(t("vocab.openDictionary"))}" aria-label="${escapeAttribute(t("vocab.openDictionary"))}">
         ${icon("book", 16)}
         <span class="shortcut-badge">M</span>
@@ -335,7 +335,7 @@ function renderSessionSummary(): void {
       <h3>${escapeHtml(t("review.sessionSummaryTitle"))}</h3>
       <p>${escapeHtml(t("review.sessionSummaryCount", { n: sessionStats.total }))}</p>
       <p>${escapeHtml(t("review.sessionSummaryAccuracy", { pct }))}</p>
-      <button type="button" class="primary-button" id="review-session-summary-done" style="margin-top: 1rem;">${escapeHtml(t("review.sessionSummaryDone"))}</button>
+      <button type="button" class="primary-button m-t-1" id="review-session-summary-done">${escapeHtml(t("review.sessionSummaryDone"))}</button>
     </div>
   `;
   document.getElementById("review-session-summary-done")?.addEventListener("click", () => {

--- a/src/web/js/vocabulary/review-chart.ts
+++ b/src/web/js/vocabulary/review-chart.ts
@@ -60,7 +60,7 @@ export function renderReviewChart(srsEntries: readonly ReviewEntry[], today: str
       tooltip: (isoDate, count) => `${isoDate} · ${t("vocab.cardCount", { count })}`
     });
   } else {
-    reviewEls.reviewChart.innerHTML = `<div class="review-chart-frame"><canvas id="review-chart-canvas" class="chart-reveal" style="width:100%;height:160px;display:block;"></canvas></div>`;
+    reviewEls.reviewChart.innerHTML = `<div class="review-chart-frame"><canvas id="review-chart-canvas" class="chart-reveal chart-placeholder"></canvas></div>`;
     requestAnimationFrame(() => {
       const c = document.getElementById("review-chart-canvas") as HTMLCanvasElement | null;
       if (!c) return;

--- a/src/web/js/vocabulary/vocab-list.ts
+++ b/src/web/js/vocabulary/vocab-list.ts
@@ -125,9 +125,9 @@ export function renderVocabulary(resetLimit = true): void {
           <button class="icon-button" type="button" data-edit-word="${escapeHtml(entry.key)}" title="${escapeAttribute(t("editBook.title"))}" aria-label="${escapeAttribute(t("editBook.title"))}">${icon("edit", 16)}</button>
           <button class="icon-button" type="button" data-tts-word="${escapeAttribute(formatHeadword(entry.word, entry.article))}" title="${escapeAttribute(t("reader.ttsWordTitle"))}" aria-label="${escapeAttribute(t("reader.ttsWordTitle"))}">${icon("speaker", 16)}</button>
           <button class="icon-button" type="button" data-youglish-word="${escapeHtml(entry.word)}" title="${escapeAttribute(t("reader.youglishWordTitle"))}" aria-label="${escapeAttribute(t("reader.youglishWordTitle"))}">${icon("video", 16)}</button>
-          <button class="icon-button" style="color: var(--blue); border-color: color-mix(in srgb, var(--blue) 42%, var(--line)); background: var(--blue-soft);" type="button" data-word="${escapeHtml(entry.key)}" data-set-status="learning" title="${escapeAttribute(t("vocab.btnLearning"))}" aria-label="${escapeAttribute(t("vocab.btnLearning"))}">${icon("pencil", 14)}</button>
-          <button class="icon-button" style="color: var(--green); border-color: color-mix(in srgb, var(--green) 42%, var(--line)); background: var(--green-soft);" type="button" data-word="${escapeHtml(entry.key)}" data-set-status="known" title="${escapeAttribute(t("vocab.btnKnown"))}" aria-label="${escapeAttribute(t("vocab.btnKnown"))}">${icon("check", 14)}</button>
-          <button class="icon-button" style="color: var(--muted); border-color: var(--line);" type="button" data-ignore-word="${escapeHtml(entry.key)}" title="${escapeAttribute(t("vocab.btnIgnore"))}" aria-label="${escapeAttribute(t("vocab.btnIgnore"))}">${icon("eyeOff", 14)}</button>
+          <button class="icon-button status-blue" type="button" data-word="${escapeHtml(entry.key)}" data-set-status="learning" title="${escapeAttribute(t("vocab.btnLearning"))}" aria-label="${escapeAttribute(t("vocab.btnLearning"))}">${icon("pencil", 14)}</button>
+          <button class="icon-button status-green" type="button" data-word="${escapeHtml(entry.key)}" data-set-status="known" title="${escapeAttribute(t("vocab.btnKnown"))}" aria-label="${escapeAttribute(t("vocab.btnKnown"))}">${icon("check", 14)}</button>
+          <button class="icon-button status-muted" type="button" data-ignore-word="${escapeHtml(entry.key)}" title="${escapeAttribute(t("vocab.btnIgnore"))}" aria-label="${escapeAttribute(t("vocab.btnIgnore"))}">${icon("eyeOff", 14)}</button>
           <button class="icon-button danger-button" type="button" data-delete-word="${escapeHtml(entry.key)}" title="${escapeAttribute(t("vocab.btnDelete"))}" aria-label="${escapeAttribute(t("vocab.btnDelete"))}">${icon("trash", 14)}</button>
         </div>
       </td>
@@ -136,7 +136,7 @@ export function renderVocabulary(resetLimit = true): void {
   }).join("");
 
   if (vocabRenderCount < filteredVocabEntries.length) {
-    els.vocabTableBody.innerHTML += `<tr><td colspan="5" style="text-align: center; padding: 1rem;"><button type="button" class="ghost-button" id="load-more-vocab">${escapeHtml(t("vocab.loadMore"))}</button></td></tr>`;
+    els.vocabTableBody.innerHTML += `<tr><td colspan="5" class="center-p-1"><button type="button" class="ghost-button" id="load-more-vocab">${escapeHtml(t("vocab.loadMore"))}</button></td></tr>`;
   }
 }
 

--- a/src/web/platforms/android-pocket.css
+++ b/src/web/platforms/android-pocket.css
@@ -18,6 +18,22 @@ html.pocket-mode {
     var(--pocket-word-sheet-expanded-top),
     calc(100dvh - 4.6rem - var(--pocket-navbar-safe-bottom) - var(--pocket-word-sheet-collapsed-size))
   );
+  /* Pocket z-index scale — pinned by frontend-tests/shared/css-verifiability.test.js. */
+  --z-pocket-statusbar: 90;
+  --z-pocket-scrim: 75;
+  --z-pocket-sidebar: 80;
+  --z-pocket-toggle: 66;
+  --z-pocket-toggle-open: 81;
+  --z-pocket-topbar: 25;
+  --z-pocket-import-toggle: 50;
+  --z-pocket-toolbar: 65;
+  --z-pocket-sheet: 60;
+  --z-pocket-word-panel: 2;
+  --z-pocket-sheet-handle: 3;
+  --z-pocket-ghost: 4;
+  --z-pocket-header: 1;
+  --z-pocket-flat: 0;
+  --z-auto: auto;
   zoom: 1 !important;
 }
 
@@ -34,7 +50,7 @@ html.pocket-mode {
 .pocket-mode body::before {
   content: "";
   position: fixed;
-  z-index: 90;
+  z-index: var(--z-pocket-statusbar);
   top: 0;
   right: 0;
   left: 0;
@@ -47,7 +63,7 @@ html.pocket-mode {
 .pocket-mode.pocket-navigation-open body::after {
   content: "";
   position: fixed;
-  z-index: 75;
+  z-index: var(--z-pocket-scrim);
   inset: 0;
   background: rgba(10, 18, 14, 0.28);
 }
@@ -142,7 +158,7 @@ html.pocket-mode {
 
 .pocket-mode .sidebar {
   position: fixed;
-  z-index: 80;
+  z-index: var(--z-pocket-sidebar);
   inset: var(--pocket-statusbar-safe-top) auto 0 0;
   width: min(84vw, 320px);
   height: auto;
@@ -222,7 +238,7 @@ html.pocket-mode {
 
 .pocket-mode .pocket-navigation-toggle {
   position: fixed;
-  z-index: 66;
+  z-index: var(--z-pocket-toggle);
   bottom: calc(0.35rem + var(--pocket-navbar-safe-bottom));
   left: max(0.45rem, env(safe-area-inset-left, 0px));
   display: inline-flex;
@@ -242,7 +258,7 @@ html.pocket-mode {
 }
 
 .pocket-mode.pocket-navigation-open .pocket-navigation-toggle {
-  z-index: 81;
+  z-index: var(--z-pocket-toggle-open);
   left: max(0.45rem, env(safe-area-inset-left, 0px));
   color: var(--sidebar-ink);
   background: var(--sidebar-nav-active);
@@ -266,7 +282,7 @@ html.pocket-mode {
 
 .pocket-mode .topbar {
   position: static;
-  z-index: 25;
+  z-index: var(--z-pocket-topbar);
   display: grid;
   grid-template-columns: minmax(0, 1fr);
   align-items: stretch;
@@ -357,7 +373,7 @@ html.pocket-mode {
 
 .pocket-mode .pocket-import-toggle {
   position: fixed;
-  z-index: 50;
+  z-index: var(--z-pocket-import-toggle);
   top: 50dvh;
   right: 0;
   display: none;
@@ -398,7 +414,7 @@ html.pocket-mode {
 
 .pocket-mode .import-panel {
   position: fixed;
-  z-index: 80;
+  z-index: var(--z-pocket-sidebar);
   top: var(--pocket-statusbar-safe-top);
   right: 0;
   bottom: calc(4.6rem + var(--pocket-navbar-safe-bottom));
@@ -422,7 +438,7 @@ html.pocket-mode {
 
 .pocket-mode .import-panel .panel-header {
   position: sticky;
-  z-index: 1;
+  z-index: var(--z-pocket-header);
   top: 0;
   padding-right: 3.5rem;
   background: var(--panel);
@@ -611,7 +627,7 @@ html.pocket-mode {
 .pocket-mode #reader-view .toolbar-buttons {
   display: grid;
   position: fixed;
-  z-index: 65;
+  z-index: var(--z-pocket-toolbar);
   right: 0;
   bottom: 0;
   left: 0;
@@ -818,7 +834,7 @@ html.pocket-mode {
 .pocket-mode .vocab-table td:last-child {
   position: static;
   right: auto;
-  z-index: auto;
+  z-index: var(--z-auto);
   box-shadow: none;
 }
 
@@ -962,7 +978,7 @@ html.pocket-mode {
 
 .pocket-mode #reader-view.active .pagination-controls {
   position: static;
-  z-index: auto;
+  z-index: var(--z-auto);
   margin: 2rem 0 0;
   padding: 0.45rem;
   flex-wrap: nowrap;
@@ -1000,7 +1016,7 @@ html.pocket-mode {
 
 .pocket-mode.has-selected-word.pocket-word-panel-open #reader-view.active .reader-sidebar-wrapper {
   position: fixed;
-  z-index: 60;
+  z-index: var(--z-pocket-sheet);
   --pocket-word-sheet-current-top: var(--pocket-word-sheet-expanded-top);
   top: var(--pocket-word-sheet-current-top);
   left: max(0.75rem, env(safe-area-inset-left, 0px));
@@ -1052,7 +1068,7 @@ html.pocket-mode {
 .pocket-mode.has-selected-word.pocket-word-panel-open #reader-view.active .reader-sidebar-wrapper::after {
   content: "";
   position: absolute;
-  z-index: 0;
+  z-index: var(--z-pocket-flat);
   top: 2.6rem;
   right: 0.45rem;
   bottom: 0.15rem;
@@ -1075,7 +1091,7 @@ html.pocket-mode {
 
 .pocket-mode .pocket-word-panel-sheet-handle {
   position: relative;
-  z-index: 3;
+  z-index: var(--z-pocket-sheet-handle);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1109,7 +1125,7 @@ html.pocket-mode {
 
 .pocket-mode .word-panel {
   position: relative;
-  z-index: 2;
+  z-index: var(--z-pocket-word-panel);
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
@@ -1135,7 +1151,7 @@ html.pocket-mode {
 
 .pocket-mode .word-panel.word-panel-card-ghost {
   position: absolute;
-  z-index: 4;
+  z-index: var(--z-pocket-ghost);
   top: 56px;
   right: 0;
   bottom: 0;
@@ -1156,7 +1172,7 @@ html.pocket-mode {
 
 .pocket-mode .word-panel-header {
   position: relative;
-  z-index: 1;
+  z-index: var(--z-pocket-header);
   flex: 0 0 auto;
   padding: 1.35rem 0 0.65rem;
   background: var(--word-panel-status-bg, var(--panel));

--- a/src/web/styles.css
+++ b/src/web/styles.css
@@ -3,6 +3,21 @@
   --reader-line-height: 1.82;
   --reader-font-size: 1.125rem;
   --ui-scale: 1;
+  /* Z-index scale — every z-index declaration must reference these variables
+     (pinned by frontend-tests/shared/css-verifiability.test.js). */
+  --z-base: 0;
+  --z-raised: 1;
+  --z-chrome: 2;
+  --z-floating: 3;
+  --z-panel: 4;
+  --z-tabs: 5;
+  --z-toolbar: 8;
+  --z-loading: 10;
+  --z-toast: 20;
+  --z-overlay: 220;
+  --z-boot: 999;
+  --z-boot-logo: 1000;
+  --z-tooltip: 9999;
 }
 
 [hidden] {
@@ -154,7 +169,7 @@ html.app-booting body::before {
   inset: 0;
   background: var(--boot-bg);
   pointer-events: none;
-  z-index: 999;
+  z-index: var(--z-boot);
 }
 
 html.app-booting body::after {
@@ -170,7 +185,7 @@ html.app-booting body::after {
   transform: scale(0.92);
   animation: boot-logo-pulse 1.15s ease-in-out infinite !important;
   pointer-events: none;
-  z-index: 1000;
+  z-index: var(--z-boot-logo);
 }
 
 @keyframes boot-logo-pulse {
@@ -662,7 +677,7 @@ kbd {
 .heatmap-grid { display: flex; gap: 3px; }
 .heatmap-week { display: flex; flex-direction: column; gap: 3px; }
 .heatmap-cell { width: 14px; height: 14px; border-radius: 4px; background: var(--panel-strong); cursor: default; transition: transform 0.16s cubic-bezier(0.16, 1, 0.3, 1), filter 0.16s ease; animation: heatmap-cell-enter 0.38s cubic-bezier(0.16, 1, 0.3, 1) both; animation-delay: var(--heatmap-delay, 0ms); }
-.heatmap-cell:hover { transform: translateY(-2px) scale(1.32); filter: saturate(1.15) brightness(1.06); outline: 2px solid color-mix(in srgb, var(--control-accent) 55%, transparent); z-index: 1; }
+.heatmap-cell:hover { transform: translateY(-2px) scale(1.32); filter: saturate(1.15) brightness(1.06); outline: 2px solid color-mix(in srgb, var(--control-accent) 55%, transparent); z-index: var(--z-raised); }
 .heatmap-legend { display: flex; align-items: center; gap: 4px; padding: 0.5rem 0 0; font-size: 0.625rem; color: var(--muted); }
 .heatmap-legend-cell { width: 14px; height: 14px; border-radius: 3px; }
 
@@ -687,7 +702,7 @@ kbd {
 .highlight-green .graph-stat-value { color: var(--green); }
 .highlight-blue .graph-stat-value { color: var(--blue); }
 
-.chart-tooltip { position: fixed; z-index: 9999; max-width: min(320px, calc(100vw - 24px)); background: color-mix(in srgb, var(--panel) 92%, transparent); color: var(--ink); border: 1px solid color-mix(in srgb, var(--control-accent) 28%, var(--line)); border-radius: 8px; padding: 7px 10px; box-shadow: 0 10px 28px color-mix(in srgb, var(--ink) 18%, transparent); backdrop-filter: blur(10px); font-size: 0.6875rem; line-height: 1.35; font-family: Inter, system-ui, sans-serif; pointer-events: none; display: none; }
+.chart-tooltip { position: fixed; z-index: var(--z-tooltip); max-width: min(320px, calc(100vw - 24px)); background: color-mix(in srgb, var(--panel) 92%, transparent); color: var(--ink); border: 1px solid color-mix(in srgb, var(--control-accent) 28%, var(--line)); border-radius: 8px; padding: 7px 10px; box-shadow: 0 10px 28px color-mix(in srgb, var(--ink) 18%, transparent); backdrop-filter: blur(10px); font-size: 0.6875rem; line-height: 1.35; font-family: Inter, system-ui, sans-serif; pointer-events: none; display: none; }
 
 @keyframes chart-canvas-reveal { from { opacity: 0; transform: translateY(10px) scaleY(0.96); } to { opacity: 1; transform: none; } }
 @keyframes graph-card-enter { from { opacity: 0; transform: translateY(14px); } to { opacity: 1; transform: none; } }
@@ -754,7 +769,7 @@ kbd {
 :root.reader-focus-mode:not(.pocket-mode)[data-view="reader"] .reader-toolbar {
   position: sticky;
   top: 0;
-  z-index: 3;
+  z-index: var(--z-floating);
   align-items: center;
   padding: 0.55rem 0.75rem;
   background: var(--panel);
@@ -794,7 +809,7 @@ kbd {
 
 .panel-sidebar-resizer {
   position: absolute;
-  z-index: 2;
+  z-index: var(--z-chrome);
   top: 0.5rem;
   bottom: 0.5rem;
   width: 8px;
@@ -1899,7 +1914,7 @@ button.icon-button {
 
 .reader-bookmark-tabs {
   position: absolute;
-  z-index: 5;
+  z-index: var(--z-tabs);
   top: 9.5rem;
   right: -16px;
   bottom: 1.25rem;
@@ -2084,7 +2099,7 @@ html[data-max-width="full"] .reader-text {
 .word-token.reader-inline-bookmark::before {
   content: "";
   position: absolute;
-  z-index: 3;
+  z-index: var(--z-floating);
   top: -0.72em;
   right: -0.16em;
   width: 0.48em;
@@ -2188,7 +2203,7 @@ html[data-max-width="full"] .reader-text {
 .pdf-ocr-toolbar {
   position: sticky;
   top: 0.5rem;
-  z-index: 8;
+  z-index: var(--z-toolbar);
   display: flex;
   justify-content: flex-end;
   align-items: center;
@@ -2399,7 +2414,7 @@ html[data-max-width="full"] .reader-text {
 
 .word-panel.word-panel-card-ghost {
   position: absolute;
-  z-index: 4;
+  z-index: var(--z-panel);
   inset: 0;
   margin: 0;
   overflow: hidden;
@@ -2732,7 +2747,7 @@ html[data-max-width="full"] .reader-text {
   text-align: center;
   background: color-mix(in srgb, var(--bg) 92%, transparent);
   backdrop-filter: blur(3px);
-  z-index: 10;
+  z-index: var(--z-loading);
   animation: view-enter 160ms ease-out both !important;
 }
 .section-loading .spinner {
@@ -2818,7 +2833,7 @@ html[data-max-width="full"] .reader-text {
 /* Full-screen backdrop for the package export progress bar. */
 .export-progress-overlay {
   position: fixed;
-  z-index: 220;
+  z-index: var(--z-overlay);
   inset: 0;
   display: flex;
   align-items: center;
@@ -2854,7 +2869,7 @@ html[data-max-width="full"] .reader-text {
 .ocr-progress-document > span:nth-child(4) { width: 58%; }
 .ocr-progress-scan-line {
   position: absolute;
-  z-index: 1;
+  z-index: var(--z-raised);
   top: 13px;
   left: 5px;
   right: 5px;
@@ -3183,7 +3198,7 @@ button.reader-bookmark-location {
   content: "";
   position: absolute;
   inset: 0.25rem 0.75rem 0.75rem 0;
-  z-index: 0;
+  z-index: var(--z-base);
   border: 1px solid var(--line);
   border-radius: calc(var(--radius) + 2px);
   background: var(--panel);
@@ -3302,7 +3317,7 @@ textarea.vocab-translation-input {
 .vocab-table td:last-child {
   position: sticky;
   right: 0;
-  z-index: 2;
+  z-index: var(--z-chrome);
   white-space: nowrap;
   width: 340px;
   overflow: hidden;
@@ -3332,7 +3347,7 @@ textarea.vocab-translation-input {
 .vocab-table th:last-child {
   position: sticky;
   right: 0;
-  z-index: 3;
+  z-index: var(--z-floating);
   text-align: center;
   box-shadow: -12px 0 18px -16px rgba(0, 0, 0, 0.45);
 }
@@ -3372,7 +3387,7 @@ textarea.vocab-translation-input {
 
 .review-word {
   position: relative;
-  z-index: 1;
+  z-index: var(--z-raised);
   display: grid;
   place-items: center;
   min-height: clamp(260px, 36vh, 420px);
@@ -3441,7 +3456,7 @@ textarea.vocab-translation-input {
   position: fixed;
   right: 1rem;
   bottom: 1rem;
-  z-index: 20;
+  z-index: var(--z-toast);
   max-width: min(420px, calc(100vw - 2rem));
   border: 1px solid var(--line);
   border-radius: var(--radius);
@@ -3509,7 +3524,8 @@ textarea.vocab-translation-input {
   .vocab-layout,
   .flashcards-layout,
   .reader-grid,
-  .settings-grid {
+  .settings-grid,
+  .discover-grid {
     grid-template-columns: 1fr;
   }
 
@@ -3990,7 +4006,6 @@ textarea.vocab-translation-input {
 
 /* === Discover view === */
 .discover-grid { display: grid; gap: 1rem; grid-template-columns: minmax(0, 1fr) minmax(280px, 360px); align-items: start; }
-@media (max-width: 1080px) { .discover-grid { grid-template-columns: 1fr; } }
 .discover-search { display: flex; gap: .6rem; padding: 1rem; align-items: flex-end; flex-wrap: wrap; }
 .discover-search .grow { flex: 1 1 240px; }
 .discover-toolbar { display: flex; justify-content: space-between; align-items: center; gap: .8rem; padding: .6rem 1rem; border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); background: var(--panel-strong); flex-wrap: wrap; }
@@ -4319,7 +4334,7 @@ dialog {
   .import-form > .primary-button[type="submit"] {
     position: sticky;
     bottom: 0;
-    z-index: 2;
+    z-index: var(--z-chrome);
     display: flex;
     width: calc(100% + 2rem);
     margin: 0.75rem -1rem -1rem;
@@ -4353,3 +4368,106 @@ dialog {
     min-height: 0;
   }
 }
+
+/* === Utilities (inline-style sweep, issue #129) === */
+.abs-fill { position: absolute; top: 0; left: 0; width: 100%; height: 100%; opacity: 0; cursor: pointer; }
+.action-grow { flex: 1; justify-content: center; display: inline-flex; align-items: center; gap: 0.4rem; }
+.actions-row { display: flex; gap: 0.5rem; align-items: center; width: 100%; flex-wrap: wrap; margin-top: auto; }
+.badge-remove { position: absolute; top: -10px; right: -10px; width: 24px; height: 24px; border-radius: 50%; display: flex; align-items: center; justify-content: center; padding: 0; border: none; background: var(--red); color: var(--red-ink); cursor: pointer; }
+.badge-sm { font-size:0.8rem; padding:0.2rem 0.5rem; }
+.badge-tiny { font-size: 0.65rem; padding: 0.1rem 0.3rem; }
+.caption-tiny { font-size: 0.6875rem; color: var(--muted); padding: 0.25rem; }
+.center-p-1 { text-align: center; padding: 1rem; }
+.chart-placeholder { width:100%;height:160px;display:block; }
+.chip { font-size: 0.85rem; padding: 0.4rem 0.6rem; display: flex; align-items: center; gap: 0.3rem; }
+.cover-thumb { width: 1.5rem; height: 1.5rem; border-radius: 3px; object-fit: cover; flex-shrink: 0; box-shadow: 0 1px 3px rgba(0,0,0,0.1); display: none; }
+.cover-thumb-block { width: 1.5rem; height: 1.5rem; border-radius: 4px; object-fit: cover; flex-shrink: 0; display: block; pointer-events: none; }
+.dialog-500 { width: 90vw; max-width: 500px; }
+.dialog-680 { width: 92vw; max-width: 680px; }
+.dialog-header { display: flex; justify-content: space-between; align-items: center; padding: 1rem; border-bottom: 1px solid var(--line); }
+.dialog-title { margin: 0; font-size: 1.25rem; }
+.dimmed { opacity: 0.5; pointer-events: none; transition: opacity 0.2s; }
+.display-none { display:none; }
+.dropzone { display: flex; flex-direction: column; align-items: center; justify-content: center; border: 2px dashed var(--line); border-radius: 8px; padding: 1.5rem; cursor: pointer; transition: background 0.2s, border-color 0.2s; }
+.empty-pad { padding: 2rem; text-align: center; }
+.error-text { color: var(--red); font-size: 0.85rem; margin-top: 1rem; }
+.flex-1 { flex: 1; }
+.flex-center-p-1 { padding: 1rem; display: flex; justify-content: center; }
+.flex-gap-05 { display: flex; gap: 0.5rem; }
+.flex-wrap { flex-wrap: wrap; }
+.fs-085-muted-center { font-size: 0.85rem; color: var(--muted); text-align: center; }
+.fs-09-muted { font-size: 0.9rem; color: var(--muted); }
+.gap-2 { gap: 2rem; }
+.hint-blue { font-size: 0.75rem; margin-top: 0.25rem; color: var(--blue); font-weight: 500; }
+.hint-italic-center { font-size: 0.9rem; color: var(--muted); margin-top: 0.75rem; font-style: italic; display: inline-flex; align-items: center; gap: 0.5rem; justify-content: center; width: 100%; }
+.hint-italic-center-m-t-05 { font-size: 0.9rem; color: var(--muted); margin-top: 0.5rem; font-style: italic; display: inline-flex; align-items: center; gap: 0.5rem; justify-content: center; width: 100%; }
+.icon-sidebar { width: 1rem; height: 1rem; color: var(--sidebar-muted); }
+.img-block-center { max-width: 100%; height: auto; display: block; margin: 1rem auto; border-radius: 6px; }
+.img-placeholder { width:100%;height:100%;background:var(--line);border-radius:4px; }
+.justify-center-wrap-m-t-05 { display: flex; gap: 0.5rem; justify-content: center; flex-wrap: wrap; margin-top: 0.5rem; }
+.justify-end-m-t-1 { display: flex; gap: 0.5rem; justify-content: flex-end; margin-top: 1rem; }
+.justify-end-wrap-m-t-1 { display: flex; flex-wrap: wrap; gap: 0.5rem; justify-content: flex-end; margin-top: 1rem; }
+.justify-start { justify-content: flex-start; gap: 0.5rem; }
+.lh-2 { line-height: 2; }
+.lh-2-m-b-1 { line-height: 2; margin-bottom: 1rem; }
+.m-0 { margin: 0; }
+.m-0-auto-1 { margin: 0 auto 1rem; }
+.m-0-fs-09-lh-15-muted { margin: 0; font-size: 0.9rem; line-height: 1.5; color: var(--muted); }
+.m-b-15-center { margin-bottom: 1.5rem; text-align: center; }
+.m-b-15-w-max { margin-bottom: 1.5rem; position: relative; width: max-content; }
+.m-t-0 { margin-top: 0; }
+.m-t-025 { margin-top: 0.25rem; }
+.m-t-05-center { margin-top: 0.5rem; text-align: center; }
+.m-t-1 { margin-top: 1rem; }
+.m-t-1-center { margin-top: 1rem; text-align: center; }
+.max-h-150 { max-height: 150px; border-radius: 6px; border: 1px solid var(--line); }
+.max-w-700 { max-width: 700px; padding: 0; }
+.muted-fw-400 { color: var(--muted); font-weight: 400; }
+.muted-lh-1-6-m-b-05 { color: var(--muted); line-height: 1.6; margin-bottom: 0.5rem; }
+.muted-lh-1-6-m-b-1 { color: var(--muted); line-height: 1.6; margin-bottom: 1rem; }
+.note-list { padding-left: 1.2rem; line-height: 1.8; margin: 0; color: var(--muted); display: flex; flex-direction: column; gap: 0.8rem; }
+.note-list-g-05 { padding-left: 1.2rem; line-height: 1.8; margin: 0; color: var(--muted); display: flex; flex-direction: column; gap: 0.5rem; }
+.note-list-g-1 { padding-left: 1.2rem; line-height: 1.8; margin: 0; color: var(--muted); display: flex; flex-direction: column; gap: 1rem; }
+.p-15-g-1 { padding: 1.5rem; gap: 1rem; }
+.p-3 { padding:3rem; }
+.page-badge { font-size:0.6rem; padding: 1px 3px; margin-left: 4px; }
+.page-badge-r { font-size:0.6rem; padding: 1px 3px; margin-right: 4px; }
+.popup-title { color: var(--popup-muted); font-size: 1.2rem; font-weight: 300; margin-top: 1.1rem; }
+.rel-row { position: relative; display: flex; align-items: center; }
+.review-icon { font-size: 2rem; display: inline-flex; align-items: center; gap: 0.5rem; justify-content: center; width: 100%; }
+.review-icon-m-t-1 { font-size: 2rem; display: inline-flex; align-items: center; gap: 0.5rem; justify-content: center; width: 100%; margin-top: 1rem; }
+.review-subtitle { margin-top: 1rem; font-size: 1.2rem; font-weight: 500; color: var(--ink); }
+.review-title { font-size: 1.5rem; font-weight: 500; color: var(--ink); margin-top: 0.5rem; display: block; width: 100%; text-align: center; }
+.round-icon-btn-24 { padding: 0.2rem; min-height: auto; border-radius: 50%; width: 24px; height: 24px; display: inline-flex; align-items: center; justify-content: center; background: none; border: 1px solid var(--line); color: var(--muted); cursor: pointer; }
+.round-icon-btn-28 { padding: 0.2rem; min-height: auto; border-radius: 50%; width: 28px; height: 28px; display: inline-flex; align-items: center; justify-content: center; background: none; border: 1px solid var(--line); color: var(--muted); cursor: pointer; }
+.row { display: flex; align-items: center; gap: 0.5rem; }
+.row-between { display: flex; justify-content: space-between; align-items: center; width: 100%; }
+.row-between-g-05 { flex-direction: row; justify-content: space-between; align-items: center; gap: 0.5rem; width: 100%; }
+.row-nogap { display: flex; align-items: center; }
+.row-start-m-t-05 { display: flex; align-items: center; gap: 0.5rem; margin-top: 0.5rem; justify-content: flex-start; }
+.row-stretch-flex-1 { display: flex; gap: 0.5rem; align-items: stretch; flex: 1; min-height: 0; }
+.row-tight { display: flex; align-items: center; gap: 0.35rem; }
+.self-end-noshrink { align-self: flex-end; flex-shrink: 0; }
+.size-14 { width: 14px; height: 14px; }
+.size-16 { width: 16px; height: 16px; }
+.size-18 { width: 18px; height: 18px; }
+.size-20-green { width: 20px; height: 20px; flex-shrink: 0; color: var(--green); }
+.size-28-muted-m-b-05 { width: 28px; height: 28px; color: var(--muted); margin-bottom: 0.5rem; }
+.size-32-muted { width: 32px; height: 32px; color: var(--muted); }
+.size-32-muted-m-b-05 { width: 32px; height: 32px; color: var(--muted); margin-bottom: 0.5rem; }
+.stack { flex-direction: column; align-items: stretch; gap: 0.25rem; }
+.stack-g-05 { display: flex; flex-direction: column; gap: 0.5rem; }
+.stat-note { margin-top: 0.5rem; color: var(--muted); font-size: 0.95rem; }
+.status-blue { color: var(--blue); border-color: color-mix(in srgb, var(--blue) 42%, var(--line)); background: var(--blue-soft); }
+.status-green { color: var(--green); border-color: color-mix(in srgb, var(--green) 42%, var(--line)); background: var(--green-soft); }
+.status-muted { color: var(--muted); border-color: var(--line); }
+.text-accent-ink { color: var(--accent-ink); }
+.thumb-120 { height: 120px; width: 100%; object-fit: cover; border-radius: 4px; }
+.thumb-bordered { max-height: 120px; max-width: 100%; border-radius: 6px; border: 1px solid var(--line); }
+.tile-add { cursor: pointer; text-align: center; border: 2px dashed var(--line); padding: 0.25rem; border-radius: 6px; display: flex; flex-direction: column; align-items: center; justify-content: center; width: 180px; }
+.tile-solid { cursor: pointer; text-align: center; border: 1px solid var(--line); padding: 0.25rem; border-radius: 6px; display: flex; flex-direction: column; align-items: center; justify-content: space-between; width: 180px; }
+.upload-zone { margin-top: 1rem; text-align: center; position: relative; display: inline-block; width: 100%; }
+.upload-zone-sm { margin-top: 0.5rem; text-align: center; position: relative; display: inline-block; }
+.visibility-hidden { visibility:hidden; }
+.w-10 { width:10px; }
+.w-100 { width: 100%; }

--- a/src/web/templates/translator-popup.html
+++ b/src/web/templates/translator-popup.html
@@ -100,15 +100,15 @@
     <div class="toolbar">
         <label class="lang-group">
             <span>{{title}}</span>
-            <div style="display: flex; align-items: center; gap: 0.5rem;">
+            <div class="row">
                 <img id="flag-from" class="flag-icon" src="{{base_url}}/flags/{{from_code}}.svg" alt="">
                 <select id="from-lang" title="{{from_label}}" aria-label="{{from_label}}">{{from_options}}</select>
             </div>
         </label>
-        <span style="color: var(--popup-muted); font-size: 1.2rem; font-weight: 300; margin-top: 1.1rem;">→</span>
+        <span class="popup-title">→</span>
         <label class="lang-group">
             <span>&nbsp;</span>
-            <div style="display: flex; align-items: center; gap: 0.5rem;">
+            <div class="row">
                 <img id="flag-to" class="flag-icon" src="{{base_url}}/flags/{{to_code}}.svg" alt="">
                 <select id="to-lang" title="{{to_label}}" aria-label="{{to_label}}">{{to_options}}</select>
             </div>


### PR DESCRIPTION
Part of #129 (P0 inline sweep, P1 z-index scale, P2 duplicate extraction; P3 color audit + size budget tracked in the issue)

**T1 — gate pins**: new css-verifiability.test.js pins `--max-warnings 0` in lint:css and lint:css inside check:frontend (a future commit can no longer silently weaken the gate).

**T2 — inline-style sweep**: 172 static `style=` attributes swept into 101 utility classes (index.html 109 + translator-popup.html 3 + TS 60). Only genuinely dynamic ${}-styles remain (11, whitelisted by pattern). Attribute order preserved (id before class); px font sizes in new utility classes converted to rem so the px→rem audit stays green. RED on base: html 112 → GREEN: 0.

**T3 — z-index scale**: 23 distinct literal values consolidated into `--z-*` (13 vars in :root) + `--z-pocket-*` (15 vars in html.pocket-mode); all 37 declarations now reference variables; the contract pins the whitelist (var refs or {0,1,2,3,4,5,10,50,100,1000}). RED on base: 23 violations → GREEN.

**T4 — duplication**: the duplicated `@media (max-width: 1080px)` (styles.css:3507/3993) merged; contract pins unique @media preludes + identical-declaration groups ≤ 47 (post-sweep baseline, regression guard). RED on base (duplicate @media + 45→47 groups after utilities).

pocket-layout.test.js updated to the var-based scale (z-index: var(--z-pocket-sidebar)/var(--z-pocket-scrim)).

Gates: frontend 542/542, check:frontend clean (stylelint --max-warnings 0: 0 warnings), Rust 282/282, fmt/clippy clean, diff clean.