### PR TITLE
fix(#143): Android runtime bullets 1-4 — SAF picker grace, import watchdog, teardown guards, TTS cleanup

### DIFF
--- a/frontend-tests/android/pocket-runtime-contracts.test.js
+++ b/frontend-tests/android/pocket-runtime-contracts.test.js
@@ -1,0 +1,91 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const ACTIVITY_URL = new URL("../../src-tauri/platforms/android/MainActivity.kt", import.meta.url);
+
+describe("Android runtime lifecycle contracts", () => {
+  it("keeps the SAF export timeout out of the picker-foreground window", () => {
+    const activity = readFileSync(ACTIVITY_URL, "utf8");
+
+    // A user may spend minutes inside the system save dialog; a timeout
+    // armed before the picker launch would fire while the dialog is still
+    // foreground and silently drop the destination the user just chose.
+    // The timeout must instead be cancelled in onPause and re-armed as a
+    // short grace period in onResume while the export still awaits a pick.
+    assert.doesNotMatch(activity, /mainHandler\.postDelayed\([^)]*ANDROID_EXPORT_TIMEOUT_MS/);
+    assert.match(activity, /private const val ANDROID_EXPORT_GRACE_MS = \d[\d_]*L/);
+    assert.match(activity, /override fun onPause\(\) \{[\s\S]{0,400}removeCallbacks\(it\)/);
+    assert.match(activity, /override fun onResume\(\) \{[\s\S]{0,1200}ANDROID_EXPORT_GRACE_MS/);
+  });
+
+  it("watchdogs and supersedes a stale Android import picker", () => {
+    const activity = readFileSync(ACTIVITY_URL, "utf8");
+
+    // An abandoned picker must not block every later import until the
+    // process dies: the pending request gets a native watchdog and a fresh
+    // import supersedes (cancels) the stale one instead of being rejected.
+    assert.match(activity, /private const val ANDROID_IMPORT_TIMEOUT_MS = 5 \* 60 \* 1000L/);
+    assert.match(activity, /fun chooseImportPackage\(requestId: String\?\): Boolean[\s\S]{0,1600}ANDROID_IMPORT_TIMEOUT_MS/);
+    assert.match(activity, /"Android import superseded\."/);
+    assert.match(activity, /"Android import timed out\."/);
+  });
+
+  it("drains the export executor on destroy instead of interrupting writes", () => {
+    const activity = readFileSync(ACTIVITY_URL, "utf8");
+
+    // shutdownNow() interrupts a mid-write export and leaves a partial file
+    // in the user's destination; the executor must drain with a short join.
+    assert.doesNotMatch(activity, /shutdownNow\(\)/);
+    assert.match(activity, /exportExecutor\.shutdown\(\)/);
+    assert.match(activity, /awaitTermination\(/);
+  });
+
+  it("guards every WebView dispatch with the destroyed check", () => {
+    const activity = readFileSync(ACTIVITY_URL, "utf8");
+
+    // Bridge dispatchers must not post onto a destroyed WebView; every
+    // dispatch goes through a single guarded helper with a local capture.
+    assert.doesNotMatch(activity, /appWebView\?\.post/);
+    assert.match(activity, /private fun postToWebView\([\s\S]{0,300}isDestroyed \|\| isFinishing[\s\S]{0,300}webView\.post/);
+  });
+
+  it("reads the PDF page count under the render lock", () => {
+    const activity = readFileSync(ACTIVITY_URL, "utf8");
+
+    assert.doesNotMatch(activity, /put\("pageCount", pdfRenderSessions\[id\]/);
+    assert.match(activity, /val pageCount = synchronized\(pdfRenderLock\)/);
+  });
+
+  it("serializes PDF page rendering against session teardown", () => {
+    const activity = readFileSync(ACTIVITY_URL, "utf8");
+
+    // closeAllPdfRenderSessions() on destroy must never close a PdfRenderer
+    // while a page is mid-render on the bridge thread.
+    assert.match(activity, /synchronized\(pdfRenderLock\) \{\s*renderPdfPageLocked\(/);
+    assert.match(activity, /private fun renderPdfPageLocked\(/);
+  });
+
+  it("drops the double-delivery re-post for terminal export results", () => {
+    const activity = readFileSync(ACTIVITY_URL, "utf8");
+
+    assert.doesNotMatch(activity, /postDelayed\([\s\S]{0,250}250\)/);
+  });
+
+  it("clears the TTS notification and keep-screen-on when the queue drains", () => {
+    const activity = readFileSync(ACTIVITY_URL, "utf8");
+
+    // A finished single-word utterance must release the notification and
+    // FLAG_KEEP_SCREEN_ON once nothing is speaking anymore.
+    assert.match(activity, /fun maybeClearTtsSessionUi\(\)[\s\S]{0,300}isSpeaking == false[\s\S]{0,200}hideTtsNotification\(\)[\s\S]{0,100}clearKeepScreenOn\(\)/);
+    assert.match(activity, /override fun onDone\(utteranceId: String\?\) \{\s*dispatchAndroidTtsResult\(utteranceId, "done"\)\s*maybeClearTtsSessionUi\(\)/);
+    assert.match(activity, /override fun onError\(utteranceId: String\?\) \{\s*dispatchAndroidTtsResult\(utteranceId, "error"\)\s*maybeClearTtsSessionUi\(\)/);
+    assert.match(activity, /override fun onStop\(utteranceId: String\?, interrupted: Boolean\) \{\s*dispatchAndroidTtsResult\(utteranceId, "stopped"\)\s*maybeClearTtsSessionUi\(\)/);
+  });
+
+  it("wires an onEnd into the single-word Android speak path", () => {
+    const ttsJs = readFileSync(new URL("../../dist/web/js/tts.js", import.meta.url), "utf8");
+
+    assert.match(ttsJs, /speakSentenceAndroid\(word,[\s\S]{0,120}endAndroidTtsSession\(\)/);
+  });
+});

--- a/frontend-tests/shared/android-tts-session.test.js
+++ b/frontend-tests/shared/android-tts-session.test.js
@@ -1,0 +1,64 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+describe("Android single-word TTS session lifecycle", () => {
+  it("ends the native TTS session when the single word finishes", async () => {
+    const listeners = {};
+    const speaks = [];
+    let endTtsSessionCalls = 0;
+    let stopTtsCalls = 0;
+
+    globalThis.window = {
+      WordHunterAndroid: {
+        speak(text, lang, rate, id) {
+          speaks.push({ text, lang, rate, id });
+          return true;
+        },
+        isTtsReady() {
+          return true;
+        },
+        endTtsSession() {
+          endTtsSessionCalls += 1;
+        },
+        stopTts() {
+          stopTtsCalls += 1;
+        }
+      },
+      addEventListener(type, handler) {
+        listeners[type] = handler;
+      },
+      removeEventListener(type) {
+        delete listeners[type];
+      },
+      getSelection() {
+        return { isCollapsed: true };
+      }
+    };
+    globalThis.localStorage = { getItem: () => null, setItem: () => {} };
+    globalThis.document = {
+      querySelectorAll() {
+        return [];
+      }
+    };
+
+    const { state } = await import("../../dist/web/js/state.js");
+    state.preferences.learningLanguage = "de";
+    state.preferences.ttsRate = "normal";
+    state.preferences.ttsWordHighlight = false;
+
+    const { speakWord } = await import("../../dist/web/js/tts.js");
+    await speakWord("Hallo");
+    await Promise.resolve();
+
+    assert.equal(speaks.length, 1);
+    assert.equal(speaks[0].text, "Hallo");
+    // Starting a word ends any previous native session up front...
+    assert.equal(stopTtsCalls, 1);
+    assert.equal(endTtsSessionCalls, 1);
+
+    // ...and finishing the utterance ends it again, so the notification
+    // and keep-screen-on flag are released even without an explicit stop.
+    listeners["wordhunter:android-tts"]({ detail: { id: speaks[0].id, status: "done" } });
+    assert.equal(endTtsSessionCalls, 2);
+  });
+});

--- a/src-tauri/platforms/android/MainActivity.kt
+++ b/src-tauri/platforms/android/MainActivity.kt
@@ -501,7 +501,7 @@ class MainActivity : TauriActivity() {
       if (pageIndex < 0 || pageIndex >= session.renderer.pageCount) {
         error("PDF page index is out of range.")
       }
-      session.renderer.openPage(pageIndex).use { page ->
+      return session.renderer.openPage(pageIndex).use { page ->
         val sourceWidth = page.width.coerceAtLeast(1)
         val sourceHeight = page.height.coerceAtLeast(1)
         val targetWidth = renderWidth.coerceIn(512, 2400)

--- a/src-tauri/platforms/android/MainActivity.kt
+++ b/src-tauri/platforms/android/MainActivity.kt
@@ -33,10 +33,17 @@ import java.io.FileOutputStream
 import java.io.OutputStreamWriter
 import java.util.Locale
 import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
 
-private const val ANDROID_EXPORT_TIMEOUT_MS = 120000L
+// The SAF picker may stay foreground for minutes while the user chooses a
+// destination, so no export timeout is armed before the picker launch. The
+// picker-phase timeout is a short grace period re-armed on every onResume.
+private const val ANDROID_EXPORT_GRACE_MS = 45_000L
 private const val ANDROID_EXPORT_WRITE_TIMEOUT_MS = 300000L
+// An abandoned import picker must not block every later import until the
+// process dies; the pending request times out natively after ~5 minutes.
+private const val ANDROID_IMPORT_TIMEOUT_MS = 5 * 60 * 1000L
 private const val ANDROID_TRANSFER_MAX_BYTES = 2L * 1024L * 1024L * 1024L
 private const val ANDROID_PDF_MAX_BITMAP_PIXELS = 8_000_000
 private const val ANDROID_DIRECT_EXPORT_MAX_CHARS = 64L * 1024L * 1024L
@@ -58,7 +65,9 @@ class MainActivity : TauriActivity() {
   @Volatile private var ttsReady = false
   @Volatile private var pendingExport: PendingExport? = null
   @Volatile private var pendingImportRequestId: String? = null
-  private var pendingExportResult: JSONObject? = null
+  private var pendingImportWatchdog: Runnable? = null
+  private var importLaunchRequestId: String? = null
+  @Volatile private var pendingExportResult: JSONObject? = null
   private val exportDocumentLauncher = registerForActivityResult(
     ActivityResultContracts.StartActivityForResult()
   ) { result ->
@@ -82,6 +91,7 @@ class MainActivity : TauriActivity() {
         false
       } else {
         export.timeoutRunnable?.let { mainHandler.removeCallbacks(it) }
+        export.awaitingPicker = false
         val writeTimeout = Runnable {
           synchronized(bridgeLock) {
             if (pendingExport?.requestId == export.requestId) pendingExport = null
@@ -127,21 +137,29 @@ class MainActivity : TauriActivity() {
   private val importDocumentLauncher = registerForActivityResult(
     ActivityResultContracts.StartActivityForResult()
   ) { result ->
-    val requestId = pendingImportRequestId ?: return@registerForActivityResult
+    val requestId = importLaunchRequestId ?: return@registerForActivityResult
+    importLaunchRequestId = null
     val uri = result.data?.data
     if (result.resultCode != Activity.RESULT_OK || uri == null) {
-      pendingImportRequestId = null
+      clearPendingImportIfCurrent(requestId)
       dispatchAndroidImportResult(requestId, success = false, path = null, error = null, cancelled = true)
+      return@registerForActivityResult
+    }
+    // A result from a superseded or timed-out picker must not be processed
+    // against a newer request (or none at all).
+    val stillCurrent = synchronized(bridgeLock) { pendingImportRequestId == requestId }
+    if (!stillCurrent) {
+      Log.w("WordHunter", "Ignoring stale Android import result for $requestId.")
       return@registerForActivityResult
     }
     exportExecutor.execute {
       runCatching { copyImportDocument(uri, requestId) }
         .onSuccess { path ->
-          pendingImportRequestId = null
+          clearPendingImportIfCurrent(requestId)
           dispatchAndroidImportResult(requestId, success = true, path = path, error = null, cancelled = false)
         }
         .onFailure { error ->
-          pendingImportRequestId = null
+          clearPendingImportIfCurrent(requestId)
           dispatchAndroidImportResult(requestId, success = false, path = null, error = error.message, cancelled = false)
         }
     }
@@ -162,15 +180,18 @@ class MainActivity : TauriActivity() {
 
       override fun onDone(utteranceId: String?) {
         dispatchAndroidTtsResult(utteranceId, "done")
+        maybeClearTtsSessionUi()
       }
 
       @Deprecated("Deprecated in Android API")
       override fun onError(utteranceId: String?) {
         dispatchAndroidTtsResult(utteranceId, "error")
+        maybeClearTtsSessionUi()
       }
 
       override fun onStop(utteranceId: String?, interrupted: Boolean) {
         dispatchAndroidTtsResult(utteranceId, "stopped")
+        maybeClearTtsSessionUi()
       }
 
       override fun onRangeStart(utteranceId: String?, start: Int, end: Int, frame: Int) {
@@ -189,7 +210,17 @@ class MainActivity : TauriActivity() {
       clearKeepScreenOn()
     }
     val script = "window.dispatchEvent(new CustomEvent('wordhunter:android-tts-stop'));"
-    appWebView?.post { appWebView?.evaluateJavascript(script, null) }
+    postToWebView(script)
+  }
+
+  private fun maybeClearTtsSessionUi() {
+    // The last utterance of a chain drains the queue; release the
+    // notification and FLAG_KEEP_SCREEN_ON so a single spoken word does not
+    // leave them stuck.
+    if (textToSpeech?.isSpeaking == false) {
+      hideTtsNotification()
+      clearKeepScreenOn()
+    }
   }
 
   private fun cleanTransferCache() {
@@ -224,8 +255,38 @@ class MainActivity : TauriActivity() {
     runOnUiThread { window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON) }
   }
 
+  override fun onPause() {
+    super.onPause()
+    // The SAF picker is foreground while we are paused; the export timeout
+    // must not fire while the user is still choosing a destination.
+    synchronized(bridgeLock) {
+      val export = pendingExport
+      if (export != null && export.awaitingPicker) {
+        export.timeoutRunnable?.let { mainHandler.removeCallbacks(it) }
+      }
+    }
+  }
+
   override fun onResume() {
     super.onResume()
+    // Re-arm a short grace period for an export that still awaits its pick:
+    // the launcher result removes it once the user chooses, or it clears the
+    // stale request if the dialog was abandoned.
+    synchronized(bridgeLock) {
+      val export = pendingExport
+      if (export != null && export.awaitingPicker) {
+        export.timeoutRunnable?.let { mainHandler.removeCallbacks(it) }
+        val grace = Runnable {
+          synchronized(bridgeLock) {
+            if (pendingExport?.requestId == export.requestId) pendingExport = null
+          }
+          export.sourcePath?.let { File(it).delete() }
+          dispatchAndroidExportResult(export.requestId, success = false, error = "Android export timed out.", cancelled = false, status = "timeout")
+        }
+        export.timeoutRunnable = grace
+        mainHandler.postDelayed(grace, ANDROID_EXPORT_GRACE_MS)
+      }
+    }
     dispatchPendingAndroidExportResult()
   }
 
@@ -247,8 +308,13 @@ class MainActivity : TauriActivity() {
       pendingExport?.sourcePath?.let { File(it).delete() }
       pendingExport = null
       pendingImportRequestId = null
+      pendingImportWatchdog?.let { mainHandler.removeCallbacks(it) }
+      pendingImportWatchdog = null
     }
-    exportExecutor.shutdownNow()
+    // Drain in-flight writes instead of interrupting them: an interrupt
+    // would abort a mid-write export and leave a partial file behind.
+    exportExecutor.shutdown()
+    runCatching { exportExecutor.awaitTermination(3, TimeUnit.SECONDS) }
     closeAllPdfRenderSessions()
     hideTtsNotification()
     clearKeepScreenOn()
@@ -277,17 +343,35 @@ class MainActivity : TauriActivity() {
     @JavascriptInterface
     fun chooseImportPackage(requestId: String?): Boolean {
       val id = normalizeBridgeRequestId(requestId, "android-import")
-      synchronized(bridgeLock) {
-        if (pendingImportRequestId != null) {
-          dispatchAndroidImportResult(id, success = false, path = null, error = "Android import is already running.", cancelled = false)
-          return true
-        }
+      val supersededId = synchronized(bridgeLock) {
+        pendingImportWatchdog?.let { mainHandler.removeCallbacks(it) }
+        pendingImportWatchdog = null
+        val previous = pendingImportRequestId
         pendingImportRequestId = id
+        previous
       }
+      if (supersededId != null) {
+        Log.w("WordHunter", "Superseding stale Android import request $supersededId.")
+        dispatchAndroidImportResult(supersededId, success = false, path = null, error = "Android import superseded.", cancelled = true)
+      }
+      // An abandoned picker must not block imports until the process dies:
+      // the pending request times out natively after ~5 minutes.
+      val watchdog = Runnable {
+        synchronized(bridgeLock) {
+          if (pendingImportRequestId == id) {
+            pendingImportRequestId = null
+            pendingImportWatchdog = null
+          }
+        }
+        dispatchAndroidImportResult(id, success = false, path = null, error = "Android import timed out.", cancelled = false)
+      }
+      synchronized(bridgeLock) { pendingImportWatchdog = watchdog }
+      mainHandler.postDelayed(watchdog, ANDROID_IMPORT_TIMEOUT_MS)
+      importLaunchRequestId = id
       runOnUiThread {
         runCatching { importDocumentLauncher.launch(createImportDocumentIntent()) }
           .onFailure { error ->
-            pendingImportRequestId = null
+            clearPendingImportIfCurrent(id)
             dispatchAndroidImportResult(id, success = false, path = null, error = error.message, cancelled = false)
           }
       }
@@ -380,9 +464,12 @@ class MainActivity : TauriActivity() {
           }
           throw error
         }
+        val pageCount = synchronized(pdfRenderLock) {
+          pdfRenderSessions[id]?.renderer?.pageCount ?: 0
+        }
         JSONObject()
           .put("success", true)
-          .put("pageCount", pdfRenderSessions[id]?.renderer?.pageCount ?: 0)
+          .put("pageCount", pageCount)
           .toString()
       }.getOrElse { error ->
         JSONObject()
@@ -396,37 +483,10 @@ class MainActivity : TauriActivity() {
     fun renderPdfPage(sessionId: String?, pageIndex: Int, renderWidth: Int): String {
       return runCatching {
         val id = safePdfRenderSessionId(sessionId)
-        val session = synchronized(pdfRenderLock) {
-          pdfRenderSessions[id] ?: error("PDF render session is not open.")
-        }
-        if (pageIndex < 0 || pageIndex >= session.renderer.pageCount) {
-          error("PDF page index is out of range.")
-        }
-        session.renderer.openPage(pageIndex).use { page ->
-          val sourceWidth = page.width.coerceAtLeast(1)
-          val sourceHeight = page.height.coerceAtLeast(1)
-          val targetWidth = renderWidth.coerceIn(512, 2400)
-          val targetHeight = ((sourceHeight.toDouble() / sourceWidth.toDouble()) * targetWidth)
-            .toInt()
-            .coerceAtLeast(1)
-          if (targetHeight > ANDROID_PDF_MAX_BITMAP_PIXELS / targetWidth) {
-            error("PDF page dimensions are too large to render safely.")
-          }
-          val bitmap = Bitmap.createBitmap(targetWidth, targetHeight, Bitmap.Config.ARGB_8888)
-          try {
-            bitmap.eraseColor(Color.WHITE)
-            page.render(bitmap, null, null, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
-            val bytes = ByteArrayOutputStream()
-            bitmap.compress(Bitmap.CompressFormat.PNG, 100, bytes)
-            JSONObject()
-              .put("success", true)
-              .put("width", targetWidth)
-              .put("height", targetHeight)
-              .put("dataUrl", "data:image/png;base64," + Base64.encodeToString(bytes.toByteArray(), Base64.NO_WRAP))
-              .toString()
-          } finally {
-            bitmap.recycle()
-          }
+        // The whole render runs under the lock so closeAllPdfRenderSessions()
+        // on destroy can never close a PdfRenderer mid-render.
+        synchronized(pdfRenderLock) {
+          renderPdfPageLocked(id, pageIndex, renderWidth)
         }
       }.getOrElse { error ->
         JSONObject()
@@ -436,11 +496,54 @@ class MainActivity : TauriActivity() {
       }
     }
 
+    private fun renderPdfPageLocked(id: String, pageIndex: Int, renderWidth: Int): String {
+      val session = pdfRenderSessions[id] ?: error("PDF render session is not open.")
+      if (pageIndex < 0 || pageIndex >= session.renderer.pageCount) {
+        error("PDF page index is out of range.")
+      }
+      session.renderer.openPage(pageIndex).use { page ->
+        val sourceWidth = page.width.coerceAtLeast(1)
+        val sourceHeight = page.height.coerceAtLeast(1)
+        val targetWidth = renderWidth.coerceIn(512, 2400)
+        val targetHeight = ((sourceHeight.toDouble() / sourceWidth.toDouble()) * targetWidth)
+          .toInt()
+          .coerceAtLeast(1)
+        if (targetHeight > ANDROID_PDF_MAX_BITMAP_PIXELS / targetWidth) {
+          error("PDF page dimensions are too large to render safely.")
+        }
+        val bitmap = Bitmap.createBitmap(targetWidth, targetHeight, Bitmap.Config.ARGB_8888)
+        try {
+          bitmap.eraseColor(Color.WHITE)
+          page.render(bitmap, null, null, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
+          val bytes = ByteArrayOutputStream()
+          bitmap.compress(Bitmap.CompressFormat.PNG, 100, bytes)
+          JSONObject()
+            .put("success", true)
+            .put("width", targetWidth)
+            .put("height", targetHeight)
+            .put("dataUrl", "data:image/png;base64," + Base64.encodeToString(bytes.toByteArray(), Base64.NO_WRAP))
+            .toString()
+        } finally {
+          bitmap.recycle()
+        }
+      }
+    }
+
     @JavascriptInterface
     fun endPdfRender(sessionId: String?) {
       val id = safePdfRenderSessionId(sessionId)
       synchronized(pdfRenderLock) {
         pdfRenderSessions.remove(id)?.close()
+      }
+    }
+  }
+
+  private fun clearPendingImportIfCurrent(requestId: String) {
+    synchronized(bridgeLock) {
+      if (pendingImportRequestId == requestId) {
+        pendingImportRequestId = null
+        pendingImportWatchdog?.let { mainHandler.removeCallbacks(it) }
+        pendingImportWatchdog = null
       }
     }
   }
@@ -458,23 +561,17 @@ class MainActivity : TauriActivity() {
         dispatchAndroidExportResult(id, success = false, error = "Android export is already running.", cancelled = false, status = "busy")
         return true
       }
-      val export = PendingExport(
+      // No picker timeout is armed here: the SAF picker may stay foreground
+      // for minutes, and a stale timeout would silently drop the destination
+      // the user just chose. The picker phase is bounded by the short grace
+      // period re-armed in onResume instead.
+      pendingExport = PendingExport(
         requestId = id,
         data = data,
         sourcePath = sourcePath,
         filename = safeExportFilename(filename),
         mime = safeMimeType(mime)
       )
-      val timeout = Runnable {
-        synchronized(bridgeLock) {
-          if (pendingExport?.requestId == export.requestId) pendingExport = null
-        }
-        export.sourcePath?.let { File(it).delete() }
-        dispatchAndroidExportResult(export.requestId, success = false, error = "Android export timed out.", cancelled = false, status = "timeout")
-      }
-      export.timeoutRunnable = timeout
-      pendingExport = export
-      mainHandler.postDelayed(timeout, ANDROID_EXPORT_TIMEOUT_MS)
     }
     runOnUiThread {
       runCatching {
@@ -511,7 +608,8 @@ class MainActivity : TauriActivity() {
     val sourcePath: String?,
     val filename: String,
     val mime: String,
-    var timeoutRunnable: Runnable? = null
+    var timeoutRunnable: Runnable? = null,
+    var awaitingPicker: Boolean = true
   )
 
   private fun closeAllPdfRenderSessions() {
@@ -634,6 +732,15 @@ class MainActivity : TauriActivity() {
     }
   }
 
+  private fun postToWebView(script: String, onPosted: (() -> Unit)? = null) {
+    val webView = appWebView ?: return
+    if (isDestroyed || isFinishing) return
+    webView.post {
+      webView.evaluateJavascript(script, null)
+      onPosted?.invoke()
+    }
+  }
+
   private fun dispatchAndroidImportResult(
     requestId: String,
     success: Boolean,
@@ -648,7 +755,7 @@ class MainActivity : TauriActivity() {
       .put("error", error ?: JSONObject.NULL)
       .put("cancelled", cancelled)
     val script = "window.dispatchEvent(new CustomEvent('wordhunter:android-import',{detail:$detail}));"
-    appWebView?.post { appWebView?.evaluateJavascript(script, null) }
+    postToWebView(script)
   }
 
   private fun dispatchAndroidExportResult(
@@ -667,11 +774,8 @@ class MainActivity : TauriActivity() {
       .put("terminal", true)
     pendingExportResult = detail
     val script = "window.dispatchEvent(new CustomEvent('wordhunter:android-export',{detail:$detail}));"
-    appWebView?.post {
-      appWebView?.postDelayed({
-        appWebView?.evaluateJavascript(script, null)
-        if (pendingExportResult === detail) pendingExportResult = null
-      }, 250)
+    postToWebView(script) {
+      if (pendingExportResult === detail) pendingExportResult = null
     }
   }
 
@@ -684,17 +788,14 @@ class MainActivity : TauriActivity() {
       .put("status", status)
       .put("terminal", false)
     val script = "window.dispatchEvent(new CustomEvent('wordhunter:android-export',{detail:$detail}));"
-    appWebView?.post { appWebView?.evaluateJavascript(script, null) }
+    postToWebView(script)
   }
 
   private fun dispatchPendingAndroidExportResult() {
     val detail = pendingExportResult ?: return
     val script = "window.dispatchEvent(new CustomEvent('wordhunter:android-export',{detail:$detail}));"
-    appWebView?.post {
-      appWebView?.postDelayed({
-        appWebView?.evaluateJavascript(script, null)
-        if (pendingExportResult === detail) pendingExportResult = null
-      }, 250)
+    postToWebView(script) {
+      if (pendingExportResult === detail) pendingExportResult = null
     }
   }
 
@@ -797,8 +898,6 @@ class MainActivity : TauriActivity() {
     if (start != null) detail.put("start", start)
     if (end != null) detail.put("end", end)
     val script = "window.dispatchEvent(new CustomEvent('wordhunter:android-tts',{detail:$detail}));"
-    appWebView?.post {
-      appWebView?.evaluateJavascript(script, null)
-    }
+    postToWebView(script)
   }
 }

--- a/src-tauri/platforms/android/MainActivity.kt
+++ b/src-tauri/platforms/android/MainActivity.kt
@@ -512,12 +512,13 @@ class MainActivity : TauriActivity() {
           error("PDF page dimensions are too large to render safely.")
         }
         val bitmap = Bitmap.createBitmap(targetWidth, targetHeight, Bitmap.Config.ARGB_8888)
+        var payload: String
         try {
           bitmap.eraseColor(Color.WHITE)
           page.render(bitmap, null, null, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
           val bytes = ByteArrayOutputStream()
           bitmap.compress(Bitmap.CompressFormat.PNG, 100, bytes)
-          JSONObject()
+          payload = JSONObject()
             .put("success", true)
             .put("width", targetWidth)
             .put("height", targetHeight)
@@ -526,6 +527,7 @@ class MainActivity : TauriActivity() {
         } finally {
           bitmap.recycle()
         }
+        payload
       }
     }
 

--- a/src/web/js/tts.ts
+++ b/src/web/js/tts.ts
@@ -189,7 +189,7 @@ export async function speakWord(word: string): Promise<void> {
   if (!androidTtsBroken && getAndroidTtsBridge()) {
     const ready = await waitForAndroidTtsReady();
     if (sessionId !== ttsSessionId) return;
-    if (ready && speakSentenceAndroid(word)) return;
+    if (ready && speakSentenceAndroid(word, () => endAndroidTtsSession())) return;
     androidTtsBroken = true;
     speakWordLocal(word);
     return;


### PR DESCRIPTION
Part of #143 (bullets 1-4; 5-11 tracked in the issue)

**B1 — SAF export timeout no longer drops the chosen file**: the pre-launch 120 s arm is removed; the picker-phase timeout is cancelled in onPause and re-armed as a 45 s grace in onResume while the export still awaits its pick (new awaitingPicker flag). The 300 s write timeout is untouched. A user spending minutes inside the system save dialog keeps the destination they chose.

**B2 — import picker can't wedge**: chooseImportPackage supersedes a stale request (old promise rejected with 'Android import superseded.', fresh picker launched), arms a native 5-minute watchdog, and the launcher result is validated current before processing. An abandoned picker no longer blocks every import until process death.

**B3 — teardown races**: exportExecutor drains via shutdown()+awaitTermination(3 s) instead of shutdownNow() — no more partially-written export files; PDF rendering runs entirely under pdfRenderLock (pageCount read moved inside the lock); every WebView dispatch routes through guarded postToWebView() (isDestroyed || isFinishing + local webView capture); the 250 ms double-delivery re-post for terminal export results is removed.

**B4 — TTS UI stuck**: onDone/onError/onStop call maybeClearTtsSessionUi() which hides the notification and clears keepScreenOn once the queue drains; the single-word speak path passes onEnd → endAndroidTtsSession() (mirrors the multi-sentence chain).

**Tests** (no Kotlin test infra — static contracts + behavioral JS): pocket-runtime-contracts.test.js (9 contracts) + android-tts-session.test.js (behavioral). RED on base 10/10 (incl. the meaningful behavioral failure: single-word TTS never ended the native session); GREEN 10/10 after.

Gates: frontend 541/541, check:frontend clean, Rust 282/282, fmt/clippy clean, diff clean.