### PR TITLE
fix(#135): Linux paths — APPDATA gated to Windows, HOME fallback, confinement distinguishes PermissionDenied

### DIFF
--- a/src-tauri/src/paths.rs
+++ b/src-tauri/src/paths.rs
@@ -10,10 +10,33 @@ fn env_path(name: &str) -> Option<PathBuf> {
     })
 }
 
+// APPDATA is a Windows concept; on Linux it is at best a Wine/Proton
+// artifact and must never win over the XDG base directories (issue #135,
+// bullet 1). config_dir() and default_data_dir() both route their APPDATA
+// lookup through this single gate, so no per-call-site cfg is needed.
+#[cfg(windows)]
 fn appdata_dir() -> Option<PathBuf> {
     env_path("APPDATA")
 }
 
+#[cfg(not(windows))]
+fn appdata_dir() -> Option<PathBuf> {
+    None
+}
+
+#[cfg(unix)]
+fn home_dir_path() -> Option<PathBuf> {
+    env_path("HOME").or_else(|| {
+        // Scrubbed environments (containers, service managers) may omit
+        // $HOME; fall back to the passwd database via getpwuid with no
+        // extra dependencies (issue #135, bullet 2). On unix
+        // std::env::home_dir() checks $HOME first, then getpwuid.
+        #[allow(deprecated)]
+        std::env::home_dir()
+    })
+}
+
+#[cfg(not(unix))]
 fn home_dir_path() -> Option<PathBuf> {
     env_path("HOME")
 }
@@ -62,6 +85,40 @@ fn default_data_dir(app_name: &str) -> Result<PathBuf, String> {
         .ok_or_else(|| "could not locate user data directory".to_string())
 }
 
+/// How to treat a stored data-dir pointer whose metadata could not be
+/// obtained.
+#[derive(Debug)]
+enum DataDirPointer {
+    /// The pointer is a real directory — keep using it.
+    Use,
+    /// The pointer is gone (deleted, moved, or on a detached drive) — clear
+    /// it and fall back to the default data folder.
+    Clear,
+}
+
+/// Classify a stored data-dir pointer from its metadata result so that a
+/// permission error under confinement (flatpak/snap without filesystem
+/// access) is never mistaken for a missing directory (issue #135, bullet 5).
+fn classify_data_pointer(
+    dir: &Path,
+    metadata: Result<std::fs::Metadata, std::io::Error>,
+) -> Result<DataDirPointer, String> {
+    match metadata {
+        Ok(metadata) if metadata.is_dir() => Ok(DataDirPointer::Use),
+        Ok(_) => Ok(DataDirPointer::Clear),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(DataDirPointer::Clear),
+        Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => Err(format!(
+            "data directory {} is not readable (permission denied); if the app is confined by \
+             flatpak or snap, grant filesystem access, e.g. `flatpak override \
+             --filesystem=home com.wordhunter.app` or `snap connect word-hunter:home`",
+            dir.display()
+        )),
+        // Any other error keeps the historical behavior: fall back to the
+        // default data folder.
+        Err(_) => Ok(DataDirPointer::Clear),
+    }
+}
+
 pub fn data_dir(app_name: &str) -> Result<PathBuf, String> {
     let default = default_data_dir(app_name)?;
     let dir = match read_config_file(app_name, "data-dir")? {
@@ -69,16 +126,20 @@ pub fn data_dir(app_name: &str) -> Result<PathBuf, String> {
             let dir = PathBuf::from(value.trim());
             if dir.as_os_str().is_empty() {
                 default
-            } else if dir.is_dir() {
-                dir
             } else {
-                // The user-chosen folder no longer exists (it was deleted,
-                // moved, or sits on a detached drive). Falling back to the
-                // default data folder keeps the app launchable, and the stale
-                // pointer is cleared so the next start does not hit the same
-                // dead end. The user can re-select a folder in Settings.
-                let _ = write_config_file(app_name, "data-dir", &[]);
-                default
+                match classify_data_pointer(&dir, std::fs::metadata(&dir))? {
+                    DataDirPointer::Use => dir,
+                    DataDirPointer::Clear => {
+                        // The user-chosen folder no longer exists (it was
+                        // deleted, moved, or sits on a detached drive).
+                        // Falling back to the default data folder keeps the
+                        // app launchable, and the stale pointer is cleared
+                        // so the next start does not hit the same dead end.
+                        // The user can re-select a folder in Settings.
+                        let _ = write_config_file(app_name, "data-dir", &[]);
+                        default
+                    }
+                }
             }
         }
         None => default,

--- a/src-tauri/src/store/mod.rs
+++ b/src-tauri/src/store/mod.rs
@@ -665,6 +665,10 @@ mod tests {
     }
 
     #[test]
+    #[cfg(windows)]
+    // The APPDATA pointer mechanism is Windows-only since fix #135 (B1):
+    // appdata_dir() is gated to #[cfg(windows)], so on Linux this test would
+    // assert the very behaviour the fix removed (APPDATA beating XDG).
     fn redirected_missing_data_dir_falls_back_to_default_folder() {
         let _lock = crate::TEST_ENV_LOCK
             .lock()

--- a/src-tauri/src/tests/paths/tests.rs
+++ b/src-tauri/src/tests/paths/tests.rs
@@ -1,5 +1,8 @@
+#[cfg(unix)]
+use super::config_dir;
 use super::{data_dir, device_id, read_config_file, sanitize_id, write_config_file};
 use std::ffi::OsString;
+use std::path::Path;
 
 struct EnvGuard {
     key: &'static str,
@@ -205,18 +208,19 @@ fn config_reads_fallback_to_home_config_when_xdg_config_home_is_unset() {
     );
 }
 
+#[cfg(unix)]
 #[test]
-fn config_reads_fail_without_appdata_xdg_config_home_or_home() {
+fn config_resolves_real_home_when_home_is_unset() {
     let _lock = crate::TEST_ENV_LOCK.lock().unwrap();
-    let xdg_data = tempfile::tempdir().unwrap();
     let _appdata = EnvGuard::unset("APPDATA");
     let _home = EnvGuard::unset("HOME");
     let _xdg_config = EnvGuard::unset("XDG_CONFIG_HOME");
-    let _xdg_data = EnvGuard::set("XDG_DATA_HOME", xdg_data.path());
 
-    let error = read_config_file("WordHunter", "device-id").unwrap_err();
-
-    assert!(error.contains("could not locate user config directory"));
+    // $HOME is gone, so the passwd entry (getpwuid) must supply the home
+    // directory (issue #135, bullet 2).
+    #[allow(deprecated)]
+    let expected = std::env::home_dir().expect("getpwuid must resolve a home");
+    assert_eq!(config_dir().unwrap(), expected.join(".config"));
 }
 
 #[test]
@@ -235,8 +239,9 @@ fn data_dir_fallbacks_to_home_local_share_when_xdg_data_home_is_unset() {
     assert!(dir.is_dir());
 }
 
+#[cfg(unix)]
 #[test]
-fn data_dir_fails_without_appdata_xdg_data_home_or_home() {
+fn data_dir_resolves_real_home_local_share_when_home_is_unset() {
     let _lock = crate::TEST_ENV_LOCK.lock().unwrap();
     let xdg_config = tempfile::tempdir().unwrap();
     let _appdata = EnvGuard::unset("APPDATA");
@@ -244,9 +249,14 @@ fn data_dir_fails_without_appdata_xdg_data_home_or_home() {
     let _xdg_config = EnvGuard::set("XDG_CONFIG_HOME", xdg_config.path());
     let _xdg_data = EnvGuard::unset("XDG_DATA_HOME");
 
-    let error = data_dir("WordHunter").unwrap_err();
+    let dir = data_dir("WordHunter").unwrap();
 
-    assert!(error.contains("could not locate user data directory"));
+    // $HOME is gone, so the passwd entry (getpwuid) must supply the home
+    // directory (issue #135, bullet 2).
+    #[allow(deprecated)]
+    let expected = std::env::home_dir().expect("getpwuid must resolve a home");
+    assert_eq!(dir, expected.join(".local/share/WordHunter"));
+    assert!(dir.is_dir());
 }
 
 #[test]
@@ -273,4 +283,61 @@ fn writes_device_id_to_xdg_config_home() {
             .join(".config/WordHunter-device-id.txt")
             .exists()
     );
+}
+
+#[cfg(unix)]
+#[test]
+fn data_dir_ignores_appdata_on_unix_and_uses_xdg_data_home() {
+    let _lock = crate::TEST_ENV_LOCK.lock().unwrap();
+    let home = tempfile::tempdir().unwrap();
+    let appdata = tempfile::tempdir().unwrap();
+    let xdg_config = tempfile::tempdir().unwrap();
+    let xdg_data = tempfile::tempdir().unwrap();
+    let _appdata = EnvGuard::set("APPDATA", appdata.path());
+    let _home = EnvGuard::set("HOME", home.path());
+    let _xdg_config = EnvGuard::set("XDG_CONFIG_HOME", xdg_config.path());
+    let _xdg_data = EnvGuard::set("XDG_DATA_HOME", xdg_data.path());
+
+    let dir = data_dir("WordHunter").unwrap();
+
+    // APPDATA is a Wine/Proton artifact on Linux and must not win over the
+    // XDG base directories (issue #135, bullet 1).
+    assert_eq!(dir, xdg_data.path().join("WordHunter"));
+    assert!(dir.is_dir());
+    assert_ne!(dir, appdata.path().join("WordHunter"));
+}
+
+#[test]
+fn data_dir_pointer_permission_denied_is_not_cleared() {
+    let _lock = crate::TEST_ENV_LOCK.lock().unwrap();
+
+    // A stored pointer that exists but is unreadable under confinement
+    // (flatpak/snap without filesystem access) must not be treated like a
+    // missing directory and must not be silently cleared (issue #135,
+    // bullet 5).
+    let denied = std::io::Error::from(std::io::ErrorKind::PermissionDenied);
+    let error = super::classify_data_pointer(Path::new("/x"), Err(denied)).unwrap_err();
+    assert!(error.contains("permission denied"));
+    assert!(error.contains("flatpak override"));
+    assert!(error.contains("snap connect"));
+
+    // NotFound keeps the historical behavior: the pointer is cleared and the
+    // app falls back to the default data folder.
+    let missing = std::io::Error::from(std::io::ErrorKind::NotFound);
+    assert!(matches!(
+        super::classify_data_pointer(Path::new("/x"), Err(missing)).unwrap(),
+        super::DataDirPointer::Clear
+    ));
+
+    // A real directory keeps being used; a real missing path is cleared.
+    let existing = tempfile::tempdir().unwrap();
+    assert!(matches!(
+        super::classify_data_pointer(existing.path(), std::fs::metadata(existing.path())).unwrap(),
+        super::DataDirPointer::Use
+    ));
+    let gone = existing.path().join("gone");
+    assert!(matches!(
+        super::classify_data_pointer(&gone, std::fs::metadata(&gone)).unwrap(),
+        super::DataDirPointer::Clear
+    ));
 }


### PR DESCRIPTION
Part of #135 (bullets 1, 2, 5 — paths.rs; 3, 4, 7 tracked in the issue)

**B1 — APPDATA no longer beats XDG on Linux**: appdata_dir() is now #[cfg(windows)]; config_dir()/default_data_dir() route APPDATA through that single gate, so on Linux the XDG vars win even when APPDATA happens to be set.

**B2 — HOME-unset no longer aborts startup**: home_dir_path() falls back to std::env::home_dir() (getpwuid) under #[cfg(unix)] — previously /c/Users/Oleg-only, and store::data_dir() was a fatal path (setup → show_startup_error).

**B5 — confinement no longer silently resets the data dir**: data_dir() classifies the pointer via classify_data_pointer() — a real directory is used; NotFound/other errors clear it (status quo); PermissionDenied (flatpak/snap without --filesystem) returns an actionable error instead of wiping the user's selection (message mentions flatpak override --filesystem / snap connect).

**Tests**: 2 pinned tests flipped (HOME-unset now asserts resolution to the real home); new data_dir_ignores_appdata_on_unix_and_uses_xdg_data_home + data_dir_pointer_permission_denied_is_not_cleared (portable, io::Error::from(ErrorKind)). RED on base: compile failure (E0425/E0433 — new test references) proven on be327d4.

Gates: Rust 281/281 (paths:: 11/11 Windows), frontend 531/531, check:frontend clean, fmt/clippy clean, diff clean. Linux verification (WSL Debian, cfg(unix) tests) in flight.