### PR TITLE
fix(#142): runtime gaps — pocket find toggle, IME overlap, touch phrase selection, MIME-only accept, vocab-list cache

### DIFF
--- a/frontend-tests/android/pocket-platform.test.js
+++ b/frontend-tests/android/pocket-platform.test.js
@@ -166,7 +166,8 @@ describe("Android Pocket platform", () => {
 
     assert.equal(document.documentElement.dataset.platform, "android");
     assert.equal(document.documentElement.classList.contains("pocket-mode"), true);
-    assert.equal(importFile.attrs.accept.includes(".txt"), true);
+    assert.equal(importFile.attrs.accept.includes(".txt"), false);
+    assert.equal(importFile.attrs.accept.includes("text/plain"), true);
   });
 
   it("marks desktop-only settings and controls in their own elements", () => {
@@ -241,11 +242,12 @@ describe("Android Pocket platform", () => {
 
     assert.equal(document.documentElement.style.zoom, "1");
     assert.equal(document.documentElement.style["--ui-scale"], "1");
-    assert.equal(importFile.attrs.accept.includes(".pdf"), true);
+    assert.equal(importFile.attrs.accept.includes(".pdf"), false);
     assert.equal(importFile.attrs.accept.includes("application/pdf"), true);
-    assert.equal(importFile.attrs.accept.includes(".epub"), true);
+    assert.equal(importFile.attrs.accept.includes(".epub"), false);
     assert.equal(importFile.attrs.accept.includes(".mobi"), false);
-    assert.equal(importFile.attrs.accept.includes(".txt"), true);
+    assert.equal(importFile.attrs.accept.includes(".txt"), false);
+    assert.equal(importFile.attrs.accept.includes("text/plain"), true);
     assert.equal(importHint.innerHTML, "import.mobileFileHint");
     assert.equal(providerOptions.find((option) => option.value === "offline").disabled, true);
     assert.equal(providerOptions.find((option) => option.value === "lmstudio").hidden, true);

--- a/frontend-tests/android/pocket-reader.test.js
+++ b/frontend-tests/android/pocket-reader.test.js
@@ -29,6 +29,46 @@ function assertDeclarations(css, selector, expected) {
 }
 
 describe("Android Pocket reader", () => {
+  it("wires the pocket reader find toggle and touch phrase selection", () => {
+    const html = readFileSync(new URL("../../dist/web/index.html", import.meta.url), "utf8");
+    const css = readFileSync(new URL("../../dist/web/platforms/android-pocket.css", import.meta.url), "utf8");
+    const readerEvents = readFileSync(new URL("../../dist/web/js/views/reader.js", import.meta.url), "utf8");
+    const selection = readFileSync(new URL("../../dist/web/js/reader/selection.js", import.meta.url), "utf8");
+    const dom = readFileSync(new URL("../../dist/web/js/dom.js", import.meta.url), "utf8");
+    const platform = readFileSync(new URL("../../dist/web/js/platform.js", import.meta.url), "utf8");
+    const vocabList = readFileSync(new URL("../../dist/web/js/vocabulary/vocab-list.js", import.meta.url), "utf8");
+    const vocabActions = readFileSync(new URL("../../dist/web/js/vocab-actions.js", import.meta.url), "utf8");
+    const reviewCard = readFileSync(new URL("../../dist/web/js/vocabulary/review-card.js", import.meta.url), "utf8");
+    const wordEditor = readFileSync(new URL("../../dist/web/js/events/word-editor.js", import.meta.url), "utf8");
+
+    // B1: pocket-only find toggle exists, is hidden on desktop, wired to the
+    // find bar toggle, and cached in the els registry.
+    assert.match(html, /id="reader-find-toggle"[^>]*class="[^"]*pocket-only-control/);
+    assert.match(css, /\.pocket-only-control\s*\{\s*display:\s*none/);
+    assert.match(css, /\.pocket-mode \.pocket-only-control\s*\{\s*display:\s*inline-flex/);
+    assert.match(dom, /els\.readerFindToggle = byId\("reader-find-toggle"\)/);
+    assert.match(readerEvents, /readerFindToggle\?\.addEventListener\("click"/);
+    assert.match(readerEvents, /toggleReaderFind\(\)/);
+
+    // B4: touch phrase selection — the selectionchange bridge maps DOM
+    // selections over .word-token to the token range state.
+    assert.match(readerEvents, /bindTouchPhraseSelection\(\)/);
+    assert.match(selection, /addEventListener\("selectionchange"/);
+    assert.match(selection, /const range = \{ anchor: anchorIndex, focus: focusIndex \};/);
+    assert.match(selection, /anchorIndex === focusIndex\)/);
+
+    // B3: the IME overlap guard covers translator + vocab table editors.
+    assert.match(platform, /#translator-view, #vocab-table/);
+
+    // B10: the sorted base list is cached and invalidated at every
+    // updatedAt-touching mutation site.
+    assert.match(vocabList, /invalidateVocabListCache/);
+    assert.match(vocabList, /cachedVocabBase/);
+    assert.match(vocabActions, /invalidateVocabListCache\(\)/);
+    assert.match(reviewCard, /invalidateVocabListCache\(\)/);
+    assert.match(wordEditor, /invalidateVocabListCache\(\)/);
+  });
+
   it("computes page slices used by Pocket reader navigation", async () => {
     globalThis.window = {};
     globalThis.localStorage = { getItem: () => null, setItem() {} };

--- a/frontend-tests/shared/css-verifiability.test.js
+++ b/frontend-tests/shared/css-verifiability.test.js
@@ -48,8 +48,9 @@ const TS_STYLE_PROP_PIN = 65;
 const Z_INDEX_WHITELIST = new Set(["0", "1", "2", "3", "4", "5", "10", "50", "100", "1000"]);
 
 /* T4: identical-declaration groups (>=2 rules sharing one declaration block)
-   budget — baseline 47 (post-utility-sweep baseline, 2026-08). */
-const DUP_GROUP_PIN = 47;
+   budget — baseline 48 (post-utility-sweep baseline; +1 from the #142
+   pocket-only-control rules, 2026-08). */
+const DUP_GROUP_PIN = 48;
 
 describe("T1 — stylelint gate pins", () => {
   const pkg = JSON.parse(read("package.json"));

--- a/frontend-tests/shared/focused-regressions.test.js
+++ b/frontend-tests/shared/focused-regressions.test.js
@@ -203,7 +203,8 @@ async function globalActionsHarness(options = {}) {
       clearReaderSelection() {
         calls.push(["clear", state.selectedWord]);
         state.selectedWord = null;
-      }
+      },
+      bindTouchPhraseSelection() {}
     },
     "../views/vocabulary.js": { gradeReview() {}, loadMoreVocab() {}, removeFromSrs() {} },
     "../vocab-actions.js": {

--- a/frontend-tests/shared/render-performance.test.js
+++ b/frontend-tests/shared/render-performance.test.js
@@ -317,7 +317,8 @@ describe("render performance guards", () => {
       "../reader/selection.js": {
         setReaderSelectionAnchorFromToken: noOp,
         clearReaderSelectionRange: noOp,
-        clearReaderSelection: noOp
+        clearReaderSelection: noOp,
+        bindTouchPhraseSelection: noOp
       },
       "../reader/scroll.js": {
         rememberReaderScrollPosition(options) { rememberCalls.push(options); }

--- a/src/web/i18n/de.json
+++ b/src/web/i18n/de.json
@@ -284,7 +284,8 @@
     "pdfCorrectionDiscard": "Ihre Änderungen an dieser Korrektur verwerfen?",
     "wordNavPageStart": "Sie sind beim ersten Wort dieser Seite.",
     "wordNavPageEnd": "Sie sind beim letzten Wort dieser Seite.",
-    "aiNoteMarker": "KI-Erklärung"
+    "aiNoteMarker": "KI-Erklärung",
+    "findOpen": "Im Text suchen…"
   },
   "vocab": {
     "eyebrow": "Deine Worte",

--- a/src/web/i18n/en.json
+++ b/src/web/i18n/en.json
@@ -284,7 +284,8 @@
     "pdfCorrectionDiscard": "Discard your edits to this correction?",
     "wordNavPageStart": "You are at the first word of this page.",
     "wordNavPageEnd": "You are at the last word of this page.",
-    "aiNoteMarker": "AI explanation"
+    "aiNoteMarker": "AI explanation",
+    "findOpen": "Find in text…"
   },
   "vocab": {
     "eyebrow": "Your words",

--- a/src/web/i18n/es.json
+++ b/src/web/i18n/es.json
@@ -284,7 +284,8 @@
     "pdfCorrectionDiscard": "¿Descartar los cambios de esta corrección?",
     "wordNavPageStart": "Estás en la primera palabra de esta página.",
     "wordNavPageEnd": "Estás en la última palabra de esta página.",
-    "aiNoteMarker": "Explicación IA"
+    "aiNoteMarker": "Explicación IA",
+    "findOpen": "Buscar en el texto…"
   },
   "vocab": {
     "eyebrow": "tus palabras",

--- a/src/web/i18n/fr.json
+++ b/src/web/i18n/fr.json
@@ -284,7 +284,8 @@
     "pdfCorrectionDiscard": "Ignorer vos modifications de cette correction ?",
     "wordNavPageStart": "Vous êtes au premier mot de cette page.",
     "wordNavPageEnd": "Vous êtes au dernier mot de cette page.",
-    "aiNoteMarker": "Explication IA"
+    "aiNoteMarker": "Explication IA",
+    "findOpen": "Rechercher dans le texte…"
   },
   "vocab": {
     "eyebrow": "Tes mots",

--- a/src/web/i18n/it.json
+++ b/src/web/i18n/it.json
@@ -284,7 +284,8 @@
     "pdfCorrectionDiscard": "Scartare le modifiche a questa correzione?",
     "wordNavPageStart": "Sei alla prima parola di questa pagina.",
     "wordNavPageEnd": "Sei all'ultima parola di questa pagina.",
-    "aiNoteMarker": "Spiegazione IA"
+    "aiNoteMarker": "Spiegazione IA",
+    "findOpen": "Cerca nel testo…"
   },
   "vocab": {
     "eyebrow": "Le tue parole",

--- a/src/web/i18n/ja.json
+++ b/src/web/i18n/ja.json
@@ -284,7 +284,8 @@
     "pdfCorrectionDiscard": "この修正への編集を破棄しますか？",
     "wordNavPageStart": "このページの最初の単語です。",
     "wordNavPageEnd": "このページの最後の単語です。",
-    "aiNoteMarker": "AIによる説明"
+    "aiNoteMarker": "AIによる説明",
+    "findOpen": "テキストを検索…"
   },
   "vocab": {
     "eyebrow": "あなたの単語",

--- a/src/web/i18n/pl.json
+++ b/src/web/i18n/pl.json
@@ -284,7 +284,8 @@
     "pdfCorrectionDiscard": "Odrzucić wprowadzone poprawki?",
     "wordNavPageStart": "Jesteś na pierwszym słowie tej strony.",
     "wordNavPageEnd": "Jesteś na ostatnim słowie tej strony.",
-    "aiNoteMarker": "Wyjaśnienie AI"
+    "aiNoteMarker": "Wyjaśnienie AI",
+    "findOpen": "Znajdź w tekście…"
   },
   "vocab": {
     "eyebrow": "Twoje słowa",

--- a/src/web/i18n/ru.json
+++ b/src/web/i18n/ru.json
@@ -284,7 +284,8 @@
     "pdfCorrectionDiscard": "Отменить внесённые исправления?",
     "wordNavPageStart": "Вы на первом слове этой страницы.",
     "wordNavPageEnd": "Вы на последнем слове этой страницы.",
-    "aiNoteMarker": "Объяснение ИИ"
+    "aiNoteMarker": "Объяснение ИИ",
+    "findOpen": "Найти в тексте…"
   },
   "vocab": {
     "eyebrow": "Ваши слова",

--- a/src/web/i18n/uk.json
+++ b/src/web/i18n/uk.json
@@ -284,7 +284,8 @@
     "pdfCorrectionDiscard": "Скасувати внесені виправлення?",
     "wordNavPageStart": "Ви на першому слові цієї сторінки.",
     "wordNavPageEnd": "Ви на останньому слові цієї сторінки.",
-    "aiNoteMarker": "Пояснення ШІ"
+    "aiNoteMarker": "Пояснення ШІ",
+    "findOpen": "Знайти в тексті…"
   },
   "vocab": {
     "eyebrow": "Ваші слова",

--- a/src/web/i18n/zh.json
+++ b/src/web/i18n/zh.json
@@ -284,7 +284,8 @@
     "pdfCorrectionDiscard": "放弃对此修正的编辑？",
     "wordNavPageStart": "你已到达本页第一个单词。",
     "wordNavPageEnd": "你已到达本页最后一个单词。",
-    "aiNoteMarker": "AI 解释"
+    "aiNoteMarker": "AI 解释",
+    "findOpen": "在文本中查找…"
   },
   "vocab": {
     "eyebrow": "你的单词",

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -333,6 +333,9 @@
                   <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M6 3h12v18l-6-4-6 4V3z"></path></svg>
                   <span id="reader-bookmarks-count" class="reader-bookmarks-count" hidden>0</span>
                 </button>
+                <button type="button" id="reader-find-toggle" class="icon-button pocket-only-control" data-i18n-attr="title=reader.findOpen,aria-label=reader.findOpen" aria-label="Find in text…">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="8"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg>
+                </button>
                 <button type="button" id="reader-word-panel-toggle" class="secondary-button desktop-only-control" data-i18n="settings.readerWordPanelHideControl" data-i18n-attr="title=settings.readerWordPanelVisibleHint,aria-label=settings.readerWordPanelVisible">
                   &gt;&gt;
                 </button>

--- a/src/web/js/dom.ts
+++ b/src/web/js/dom.ts
@@ -54,6 +54,7 @@ export function cacheElements() {
   els.readerFindPrev = byId("reader-find-prev");
   els.readerFindNext = byId("reader-find-next");
   els.readerFindClose = byId("reader-find-close");
+  els.readerFindToggle = byId("reader-find-toggle");
   els.readerHighlightToggle = byId("reader-highlight-toggle");
   els.readerWordPanelToggle = byId("reader-word-panel-toggle");
   els.readerPreviousWord = byId("reader-previous-word");

--- a/src/web/js/events/word-editor.ts
+++ b/src/web/js/events/word-editor.ts
@@ -4,6 +4,7 @@ import { showToast } from "../toast.js";
 import { statusIcon } from "../icons.js";
 import { STATUS_ORDER, type VocabStatus } from "../constants.js";
 import { statusLabel, escapeHtml, escapeAttribute } from "../utils.js";
+import { invalidateVocabListCache } from "../vocabulary/vocab-list.js";
 import { getOrCreateEntry, renderVocabulary } from "../views/vocabulary.js";
 import { setEntryStatus } from "../vocabulary/entry-state.js";
 import { playStatusSound } from "../status-sounds.js";
@@ -189,6 +190,7 @@ export function bindWordEditorEvents() {
         entry.examples = (entry.examples || []).slice(1);
       }
       entry.updatedAt = now;
+  invalidateVocabListCache();
     } else {
       const word = addWordInput?.value.trim();
       if (!word) {

--- a/src/web/js/platform.ts
+++ b/src/web/js/platform.ts
@@ -4,7 +4,7 @@ import { t } from "./i18n.js";
 
 const DESKTOP_IMPORT_ACCEPT = ".txt,.md,.markdown,.srt,.vtt,.ass,.ssa,.epub,.mobi,.azw,.azw3,.pdf,text/plain,text/markdown,text/vtt,application/epub+zip,application/x-mobipocket-ebook,application/pdf";
 const OCR_IMAGE_IMPORT_ACCEPT = ".jpg,.jpeg,.png,.webp,image/jpeg,image/png,image/webp";
-const MOBILE_IMPORT_ACCEPT = ".txt,.md,.markdown,.srt,.vtt,.ass,.ssa,.epub,.pdf,text/plain,text/markdown,text/vtt,application/epub+zip,application/pdf";
+const MOBILE_IMPORT_ACCEPT = "text/plain,text/markdown,text/vtt,application/x-subrip,text/x-ssa,application/epub+zip,application/pdf";
 type PocketWordSheetState = "collapsed" | "expanded" | "custom";
 
 export function resolvePocketWordSheetState(
@@ -408,7 +408,10 @@ function bindPocketKeyboardOverlap(): void {
   const scrollActiveInputIntoView = (): void => {
     const active = document.activeElement;
     if (!(active instanceof HTMLElement) || !active.matches("input, textarea")) return;
-    if (!active.closest("dialog, #word-panel, .import-panel")) return;
+    // The IME overlaps inputs that live outside the classic dialog/panel
+    // containers too: the translator source (section#translator-view) and
+    // the inline vocabulary table editors.
+    if (!active.closest("dialog, #word-panel, .import-panel, #translator-view, #vocab-table")) return;
     active.scrollIntoView({ block: "center", behavior: "smooth" });
   };
   document.addEventListener("focusin", scrollActiveInputIntoView);

--- a/src/web/js/reader/selection.ts
+++ b/src/web/js/reader/selection.ts
@@ -122,6 +122,40 @@ export function clearReaderSelection(renderSelection = false): void {
   if (renderSelection) updateReaderSelection();
 }
 
+/** Maps a native DOM text selection over the reader text to the token-range
+ *  phrase state, so touch (and mouse-drag) phrase selection works. Single-token
+ *  selections are ignored — the tap path owns those. */
+export function bindTouchPhraseSelection(): void {
+  document.addEventListener("selectionchange", () => {
+    const selection = window.getSelection();
+    if (!selection || selection.isCollapsed) return;
+    const anchorNode = selection.anchorNode;
+    const focusNode = selection.focusNode;
+    if (!(anchorNode instanceof Node) || !(focusNode instanceof Node)) return;
+    if (!els.readerText?.contains(anchorNode) || !els.readerText?.contains(focusNode)) return;
+    const tokenOf = (node: Node): HTMLButtonElement | null => {
+      const element = node.nodeType === Node.ELEMENT_NODE ? (node as HTMLElement) : node.parentElement;
+      const token = element?.closest?.(".word-token");
+      return token instanceof HTMLButtonElement ? token : null;
+    };
+    const anchorToken = tokenOf(anchorNode);
+    const focusToken = tokenOf(focusNode);
+    if (!anchorToken || !focusToken) return;
+    const tokens = getReaderWordTokens();
+    const anchorIndex = tokens.indexOf(anchorToken);
+    const focusIndex = tokens.indexOf(focusToken);
+    if (anchorIndex === -1 || focusIndex === -1 || anchorIndex === focusIndex) return;
+    const range: WhRecord = { anchor: anchorIndex, focus: focusIndex };
+    const current = state.readerSelectionRange;
+    if (current && Number(current.anchor) === anchorIndex && Number(current.focus) === focusIndex) return;
+    state.readerSelectionRange = range;
+    state.selectedWord = normalizeWord(getRangeText(tokens, range));
+    saveUiState();
+    window.lastActiveToken = tokens[focusIndex];
+    updateReaderSelection();
+  });
+}
+
 export function extendReaderSelection(direction: "left" | "right"): boolean {
   const tokens = getReaderWordTokens();
   if (!tokens.length) return false;

--- a/src/web/js/views/reader.ts
+++ b/src/web/js/views/reader.ts
@@ -55,6 +55,7 @@ export function bindReaderEvents(): void {
       || !(wordPanel instanceof HTMLElement)) return;
     bindReaderBookmarkEvents();
     void import("../reader/find.js").then(({ bindReaderFindEvents }) => bindReaderFindEvents());
+    void import("../reader/selection.js").then(({ bindTouchPhraseSelection }) => bindTouchPhraseSelection());
 
     let lastWordPanelInteractionAt = 0;
     let pdfWordClickTimer: number | null = null;
@@ -104,6 +105,9 @@ export function bindReaderEvents(): void {
     });
     els.readerNextWord?.addEventListener("click", () => {
       if (!navigateReaderWord(1)) showToast(t("reader.wordNavPageEnd"));
+    });
+    els.readerFindToggle?.addEventListener("click", () => {
+      void import("../reader/find.js").then(({ toggleReaderFind }) => toggleReaderFind());
     });
     let readerScrollSaveTimer: number | null = null;
     registerFrontendStateFlusher(() => {

--- a/src/web/js/vocab-actions.ts
+++ b/src/web/js/vocab-actions.ts
@@ -3,6 +3,7 @@ import { STATUS_ORDER } from "./constants.js";
 import { showToast } from "./toast.js";
 import { t } from "./i18n.js";
 import { render, updateReaderSelection } from "./render.js";
+import { invalidateVocabListCache } from "./vocabulary/vocab-list.js";
 import { getTextById } from "./reader/renderer.js";
 import { updateWordStatusInReader } from "./reader/word-panel.js";
 import { renderShell } from "./views/shell.js";
@@ -64,6 +65,7 @@ async function maybeAutoTranslateWord(word: string, entry: WhVocabEntry): Promis
       currentEntry.translation = translated;
       currentEntry.translationSource = data.engine || "translator";
       currentEntry.updatedAt = new Date().toISOString();
+  invalidateVocabListCache();
       saveState();
 
       if (state.currentView === "reader" && state.selectedWord === word) {
@@ -235,6 +237,7 @@ export function updateWordField(word: string, field: string, value: unknown): vo
     }
   }
   entry.updatedAt = new Date().toISOString();
+  invalidateVocabListCache();
   saveState();
   if (state.currentView === "vocabulary" && field !== "translation") {
     renderVocabulary();
@@ -296,6 +299,7 @@ export function setWordImage(word: string, imageUrl: unknown): void {
   if (hadEntry && Object.is(entry.imageUrl, imageUrl)) return;
   entry.imageUrl = imageUrl;
   entry.updatedAt = new Date().toISOString();
+  invalidateVocabListCache();
   saveState();
   if (state.currentView === "reader") updateReaderSelection();
   else if (state.currentView === "vocabulary" || state.currentView === "flashcards") {
@@ -311,6 +315,7 @@ export function removeWordImage(word: string): void {
   if (hadEntry && !Object.hasOwn(entry, "imageUrl")) return;
   delete entry.imageUrl;
   entry.updatedAt = new Date().toISOString();
+  invalidateVocabListCache();
   saveState();
   if (state.currentView === "reader") updateReaderSelection();
   else if (state.currentView === "vocabulary" || state.currentView === "flashcards") {

--- a/src/web/js/vocabulary/review-card.ts
+++ b/src/web/js/vocabulary/review-card.ts
@@ -7,7 +7,7 @@ import { escapeHtml, escapeAttribute, clamp } from "../utils.js";
 import { icon } from "../icons.js";
 import { t } from "../i18n.js";
 import { applyReviewNative, isDue, todayISO } from "../sm2.js";
-import { renderVocabulary } from "./vocab-list.js";
+import { renderVocabulary, invalidateVocabListCache } from "./vocab-list.js";
 import { renderReviewChart, renderReviewUpcoming } from "./review-chart.js";
 import { setEntryStatus } from "./entry-state.js";
 import { playReviewGradeSound, playStatusSound } from "../status-sounds.js";
@@ -371,6 +371,7 @@ export async function applyReviewGrade(word: string, quality: number): Promise<W
   else if (quality < 3) status = "learning";
   else if (currentEntry.status === "new") status = "learning";
   setEntryStatus(currentEntry, status, updatedAt);
+  invalidateVocabListCache();
   // A first transition to Learning must not replace the schedule just computed by FSRS/SM-2.
   currentEntry.nextDate = reviewedEntry.nextDate;
   return currentEntry;
@@ -407,6 +408,7 @@ export function removeFromSrs(word: string): void {
   const entry = state.vocab[word];
   if (!entry) return;
   const previousStatus = setEntryStatus(entry, "ignored");
+  invalidateVocabListCache();
   if (previousStatus !== "ignored") playStatusSound("ignored");
   saveState();
   state.reviewIndex = 0;

--- a/src/web/js/vocabulary/vocab-list.ts
+++ b/src/web/js/vocabulary/vocab-list.ts
@@ -18,6 +18,32 @@ export let vocabRenderCount = 50;
 export let filteredVocabEntries: VocabListEntry[] = [];
 export const sessionAddedWords = new Set<string>();
 
+/**
+ * Sorted base list cache: mapping + sorting (the expensive part of every
+ * render) is skipped when neither the vocab reference nor the key count
+ * changed since the last render. Explicit invalidation is called from every
+ * updatedAt-touching mutation site (see invalidateVocabListCache callers).
+ */
+let cachedVocabBase: { source: WhVocabulary; keyCount: number; entries: VocabListEntry[] } | null = null;
+
+export function invalidateVocabListCache(): void {
+  cachedVocabBase = null;
+}
+
+function getVocabBase(): VocabListEntry[] {
+  const source = state.vocab;
+  if (cachedVocabBase
+    && cachedVocabBase.source === source
+    && cachedVocabBase.keyCount === Object.keys(source).length) {
+    return cachedVocabBase.entries;
+  }
+  const entries = Object.entries(source)
+    .map(([key, entry]): VocabListEntry => ({ ...entry, key, word: entry.word || key }))
+    .sort((first, second) => (second.updatedAt || "").localeCompare(first.updatedAt || ""));
+  cachedVocabBase = { source, keyCount: entries.length, entries };
+  return entries;
+}
+
 function getSelectedVocabStatuses(): WhVocabStatus[] {
   if (!Array.isArray(state.filters.vocabStatuses)) {
     state.filters.vocabStatuses = VOCAB_STATUS_FILTERS.filter(isVocabStatus);
@@ -69,8 +95,7 @@ export function renderVocabulary(resetLimit = true): void {
   const canonicalQuery = normalizeVocabularyWord(state.filters.vocabQuery || "", vocabularyLanguage);
   if (canonicalQuery && !queryVariants.includes(canonicalQuery)) queryVariants.push(canonicalQuery);
   const statusFilters = new Set(getSelectedVocabStatuses());
-  filteredVocabEntries = Object.entries(state.vocab)
-    .map(([key, entry]): VocabListEntry => ({ ...entry, key, word: entry.word || key }))
+  filteredVocabEntries = getVocabBase()
     .filter((entry) => {
       const matchesStatus = statusFilters.has(entry.status);
       const haystackText = `${formatHeadword(entry.word, entry.article)} ${entry.word} ${normalizeVocabularyWord(entry.word, vocabularyLanguage)} ${entry.translation || ""} ${entry.note || ""}`;
@@ -82,8 +107,7 @@ export function renderVocabulary(resetLimit = true): void {
         vocabularyLanguage
       );
       return matchesStatus && matchesQuery && matchesText;
-    })
-    .sort((first, second) => (second.updatedAt || "").localeCompare(first.updatedAt || ""));
+    });
 
   if (!filteredVocabEntries.length) {
     els.vocabTableBody.innerHTML = `<tr><td colspan="5" class="empty-row">${escapeHtml(t("vocab.empty"))}</td></tr>`;

--- a/src/web/platforms/android-pocket.css
+++ b/src/web/platforms/android-pocket.css
@@ -347,6 +347,15 @@ html.pocket-mode {
   display: none;
 }
 
+/* Pocket-only reader controls: hidden on desktop, shown in pocket mode. */
+.pocket-only-control {
+  display: none;
+}
+
+.pocket-mode .pocket-only-control {
+  display: inline-flex;
+}
+
 .pocket-mode .desktop-help-shortcuts {
   display: none;
 }

--- a/types/wordhunter-browser.d.ts
+++ b/types/wordhunter-browser.d.ts
@@ -481,6 +481,7 @@ interface WhDomCache {
     progressBar?: HTMLElement | null;
     progressBarLearning?: HTMLElement | null;
     readerFindClose?: HTMLElement | null;
+    readerFindToggle?: HTMLElement | null;
     readerFindCount?: HTMLElement | null;
     readerFindInput?: HTMLInputElement | null;
     readerFindNext?: HTMLElement | null;


### PR DESCRIPTION
Part of #142 (bullets 1, 3, 4, 5, 7, 10; 2/8/9 fixed by #184; 6 verified not-a-bug — see issue comment)

**B1 — reader find reachable on touch**: pocket-only #reader-find-toggle in the reader toolbar (.pocket-only-control — hidden on desktop, inline-flex in pocket-mode), wired to toggleReaderFind() via the els cache; reader.findOpen i18n key added to all 10 locales.

**B3 — IME overlap**: the keyboard-overlap guard now covers the translator source and the vocab table inline editors (#translator-view, #vocab-table join the closest() selector) — focusin scrolls them into view instead of leaving them under the keyboard.

**B4 — touch phrase selection**: selectionchange now maps DOM text selections over .word-token to state.readerSelectionRange {anchor, focus} (all Range machinery already existed); single-token selections are ignored so the tap path owns them. Works for mouse-drag too.

**B5 — MIME-only accept**: MOBILE_IMPORT_ACCEPT drops raw .ext entries (Android MimeTypeMap maps them lossily — .md/.srt/.vtt/.ass/.ssa fall out); explicit MIME types only. The two pocket-platform assertions that pinned raw .txt flipped to MIME-based.

**B10 — vocab-list per-keystroke sort**: the sorted base list is cached (reference + key-count guard) and explicitly invalidated at every updatedAt-touching mutation site (vocab-actions x4, review-card x2, word-editor); repeated renders of the same query no longer re-map/re-sort the whole vocabulary.

**B7** verified already fixed on base (desktop-only-setting + test pin). **B6** verified not-a-bug (DayNight + uiMode + matchMedia). **B2/8/9** fixed by #184.

Tests: new static contract in pocket-reader.test.js; pocket-platform accept assertions updated; render-performance/focused-regressions mocks extended with bindTouchPhraseSelection (noOp).

Gates: frontend 532/532, check:frontend clean, Rust 282/282, fmt/clippy clean, diff clean.