### PR TITLE
fix(#111): bridge OOM cap + chunked decode, FileProvider, openUrl on the UI thread

### DIFF
--- a/frontend-tests/android/pocket-bridges.test.js
+++ b/frontend-tests/android/pocket-bridges.test.js
@@ -136,7 +136,8 @@ describe("Android Pocket bridges", () => {
     assertSourceOrder(shared, "openAndroidUrl(url)", "window.__qtBridge");
     assert.match(app, /openAndroidUrl\(link\.href\)/);
     assert.match(activity, /fun openUrl\(url: String\?\): Boolean/);
-    assert.match(activity, /if \(scheme != "http" && scheme != "https"\) return false/);
+    assert.match(activity, /private val ANDROID_OPEN_URL_ALLOWED_SCHEMES = setOf\("https", "http", "market", "mailto"\)/);
+    assert.match(activity, /runOnUiThread[\s\S]{0,300}startActivity\(intent\)/);
     assert.match(activity, /Intent\(Intent\.ACTION_VIEW, uri\)/);
     assert.match(activity, /intent\.addCategory\(Intent\.CATEGORY_BROWSABLE\)/);
     assert.match(activity, /override fun onRangeStart\(utteranceId: String\?, start: Int, end: Int, frame: Int\)/);
@@ -178,6 +179,41 @@ describe("Android Pocket bridges", () => {
     assert.match(importEvents, /getAndroidPdfRendererBridge\(\)/);
     assert.match(importEvents, /renderAndSaveAndroidPdfPages\(data, id, pages\)/);
     assert.match(importEvents, /pending_import: true/);
+  });
+
+  it("caps Android PDF base64 transfer at 64 MB and decodes chunked to the cache file", () => {
+    const activity = readFileSync(new URL("../../src-tauri/platforms/android/MainActivity.kt", import.meta.url), "utf8");
+    const importEvents = readFileSync(new URL("../../dist/web/js/events/book-import.js", import.meta.url), "utf8");
+
+    assert.match(activity, /private const val ANDROID_PDF_MAX_BASE64_DECODED = 64L \* 1024L \* 1024L/);
+    assert.match(activity, /private fun writeDecodedDataUrl\(dataUrl: String\?, output: File\)/);
+    assert.match(activity, /writeDecodedDataUrl\(dataUrl, file\)/);
+    assert.match(activity, /Base64InputStream\(input, Base64\.DEFAULT\)/);
+    assert.match(activity, /stream\.write\(buffer, 0, count\)/);
+    assert.match(activity, /PDF is too large for Pocket render \(max 64 MB\)/);
+    assert.doesNotMatch(activity, /Base64\.decode\(raw, Base64\.DEFAULT\)/);
+    assert.doesNotMatch(activity, /400 MB/);
+    assert.match(importEvents, /ANDROID_PDF_RENDER_MAX_BASE64_MB/);
+    assert.match(
+      importEvents,
+      /if \(data\.length > ANDROID_PDF_RENDER_MAX_BASE64_ENCODED\)[\s\S]{0,300}bridge\.beginPdfRender\(sessionId, data\)/
+    );
+  });
+
+  it("declares the Android FileProvider capture contract and keeps file_paths.xml synced", () => {
+    const manifest = readFileSync(new URL("../../src-tauri/platforms/android/AndroidManifest.xml", import.meta.url), "utf8");
+    const filePaths = readFileSync(new URL("../../src-tauri/platforms/android/res/xml/file_paths.xml", import.meta.url), "utf8");
+    const build = readFileSync(new URL("../../scripts/build.bat", import.meta.url), "utf8");
+
+    assert.match(manifest, /androidx\.core\.content\.FileProvider/);
+    assert.match(manifest, /android:authorities="\$\{applicationId\}\.fileprovider"/);
+    assert.match(manifest, /android:exported="false"/);
+    assert.match(manifest, /android:grantUriPermissions="true"/);
+    assert.match(manifest, /android:resource="@xml\/file_paths"/);
+    assert.match(filePaths, /<external-files-path name="pocket_camera_photos" path="Pictures\/" \/>/);
+    assert.match(filePaths, /<cache-path name="pocket_cache" path="\." \/>/);
+    assert.match(build, /Copy-Item -LiteralPath \$filePathsSource -Destination \$filePathsTarget -Force/);
+    assert.doesNotMatch(build, /Remove-Item[^\r\n]*file_paths\.xml/);
   });
 
   it("defines the Android create-document export ABI", () => {

--- a/frontend-tests/android/pocket-packaging.test.js
+++ b/frontend-tests/android/pocket-packaging.test.js
@@ -156,7 +156,16 @@ describe("Android Pocket packaging", () => {
       elements.filter((node) => node.name === "uses-permission").map((node) => node.attributes["android:name"]),
       ["android.permission.INTERNET", "android.permission.POST_NOTIFICATIONS"],
     );
-    assert.equal(elements.some((node) => /LEANBACK|FileProvider|file_paths/.test(JSON.stringify(node))), false);
+    assert.equal(elements.some((node) => /LEANBACK/.test(JSON.stringify(node))), false);
+    const provider = elements.find((node) => node.name === "provider");
+    assert.equal(provider.attributes["android:name"], "androidx.core.content.FileProvider");
+    assert.equal(provider.attributes["android:authorities"], "${applicationId}.fileprovider");
+    assert.equal(provider.attributes["android:grantUriPermissions"], "true");
+    assert.equal(provider.attributes["android:exported"], "false");
+    assert.equal(
+      descendants(provider).find((node) => node.name === "meta-data").attributes["android:resource"],
+      "@xml/file_paths",
+    );
     const launcher = elements.find(
       (node) => node.name === "category" && node.attributes["android:name"] === "android.intent.category.LAUNCHER",
     );
@@ -195,6 +204,7 @@ describe("Android Pocket packaging", () => {
     assert.match(prepare, /Copy-Item -LiteralPath \$activitySource -Destination \$activityTarget/);
     assert.match(prepare, /Copy-Item -LiteralPath \$manifestSource -Destination \$manifestTarget/);
     assert.match(prepare, /Copy-Item -LiteralPath \$networkSecuritySource -Destination \$networkSecurityTarget/);
+    assert.match(prepare, /Copy-Item -LiteralPath \$filePathsSource -Destination \$filePathsTarget/);
     assert.match(prepare, /Set-AndroidGradleVersion/);
     assert.match(prepare, /androidx\.documentfile:documentfile:1\.0\.1/);
     const release = powershellFunction(build, "Build-AndroidReleaseAab");

--- a/scripts/build.bat
+++ b/scripts/build.bat
@@ -575,6 +575,8 @@ function Prepare-AndroidProject {
     $manifestTarget = Join-Path $androidApp "src\main\AndroidManifest.xml"
     $networkSecuritySource = Join-Path $Root "src-tauri\platforms\android\network_security_config.xml"
     $networkSecurityTarget = Join-Path $androidApp "src\main\res\xml\network_security_config.xml"
+    $filePathsSource = Join-Path $Root "src-tauri\platforms\android\res\xml\file_paths.xml"
+    $filePathsTarget = Join-Path $androidApp "src\main\res\xml\file_paths.xml"
     if (-not (Test-Path -LiteralPath $activitySource)) {
         Fail "Android MainActivity source was not found: $activitySource"
     }
@@ -584,12 +586,16 @@ function Prepare-AndroidProject {
     if (-not (Test-Path -LiteralPath $networkSecuritySource)) {
         Fail "Android network security config was not found: $networkSecuritySource"
     }
+    if (-not (Test-Path -LiteralPath $filePathsSource)) {
+        Fail "Android file paths config was not found: $filePathsSource"
+    }
     Copy-Item -LiteralPath $activitySource -Destination $activityTarget -Force
     Copy-Item -LiteralPath $manifestSource -Destination $manifestTarget -Force
     Ensure-Directory (Split-Path -Parent $networkSecurityTarget)
     Copy-Item -LiteralPath $networkSecuritySource -Destination $networkSecurityTarget -Force
+    Ensure-Directory (Split-Path -Parent $filePathsTarget)
+    Copy-Item -LiteralPath $filePathsSource -Destination $filePathsTarget -Force
     Remove-Item -LiteralPath (Join-Path $androidApp "src\main\assets\ocr-runtime") -Recurse -Force -ErrorAction SilentlyContinue
-    Remove-Item -LiteralPath (Join-Path $androidApp "src\main\res\xml\file_paths.xml") -Force -ErrorAction SilentlyContinue
     $valuesDir = Join-Path $androidApp "src\main\res\values"
     $nightValuesDir = Join-Path $androidApp "src\main\res\values-night"
     Ensure-Directory $valuesDir

--- a/src-tauri/platforms/android/AndroidManifest.xml
+++ b/src-tauri/platforms/android/AndroidManifest.xml
@@ -21,5 +21,14 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
     </application>
 </manifest>

--- a/src-tauri/platforms/android/MainActivity.kt
+++ b/src-tauri/platforms/android/MainActivity.kt
@@ -454,10 +454,7 @@ class MainActivity : TauriActivity() {
         val file = File(cacheDir, "wordhunter-pdf-render-$id.pdf")
         var descriptor: ParcelFileDescriptor? = null
         try {
-          FileOutputStream(file).use { output ->
-            writeDecodedDataUrl(dataUrl, output)
-            output.fd.sync()
-          }
+          writeDecodedDataUrl(dataUrl, file)
           descriptor = ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY)
           val renderer = PdfRenderer(descriptor)
           synchronized(pdfRenderLock) {
@@ -635,27 +632,30 @@ class MainActivity : TauriActivity() {
     return raw.replace(Regex("[^A-Za-z0-9._-]"), "_").take(80).ifBlank { "default" }
   }
 
-  private fun writeDecodedDataUrl(dataUrl: String?, output: FileOutputStream) {
+  private fun writeDecodedDataUrl(dataUrl: String?, output: File) {
     val raw = dataUrl?.substringAfter(',', dataUrl)?.trim()?.takeIf { it.isNotEmpty() }
       ?: error("PDF data is empty.")
     if (raw.length > ANDROID_PDF_MAX_BASE64_ENCODED) {
       error("PDF is too large for Pocket render (max 64 MB).")
     }
     // Decode in chunks straight into the file: a full Java-heap buffer for
-    // large PDFs would OOM on lower-end devices (was a 400 MB single decode).
+    // large PDFs would OOM on lower-end devices (was a single full decode).
     val input = ByteArrayInputStream(raw.toByteArray(Charsets.US_ASCII))
     val decoder = Base64InputStream(input, Base64.DEFAULT)
     val buffer = ByteArray(64 * 1024)
     var decodedTotal = 0L
     try {
-      while (true) {
-        val count = decoder.read(buffer)
-        if (count <= 0) break
-        decodedTotal += count
-        if (decodedTotal > ANDROID_PDF_MAX_BASE64_DECODED) {
-          error("PDF is too large for Pocket render (max 64 MB).")
+      FileOutputStream(output).use { stream ->
+        while (true) {
+          val count = decoder.read(buffer)
+          if (count <= 0) break
+          decodedTotal += count
+          if (decodedTotal > ANDROID_PDF_MAX_BASE64_DECODED) {
+            error("PDF is too large for Pocket render (max 64 MB).")
+          }
+          stream.write(buffer, 0, count)
         }
-        output.write(buffer, 0, count)
+        stream.fd.sync()
       }
     } finally {
       decoder.close()

--- a/src-tauri/platforms/android/MainActivity.kt
+++ b/src-tauri/platforms/android/MainActivity.kt
@@ -20,6 +20,7 @@ import android.os.ParcelFileDescriptor
 import android.speech.tts.TextToSpeech
 import android.speech.tts.UtteranceProgressListener
 import android.util.Base64
+import android.util.Base64InputStream
 import android.util.Log
 import android.view.WindowManager
 import android.webkit.JavascriptInterface
@@ -27,6 +28,7 @@ import android.webkit.WebView
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
 import org.json.JSONObject
+import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.FileOutputStream
@@ -46,6 +48,11 @@ private const val ANDROID_EXPORT_WRITE_TIMEOUT_MS = 300000L
 private const val ANDROID_IMPORT_TIMEOUT_MS = 5 * 60 * 1000L
 private const val ANDROID_TRANSFER_MAX_BYTES = 2L * 1024L * 1024L * 1024L
 private const val ANDROID_PDF_MAX_BITMAP_PIXELS = 8_000_000
+// Base64 PDF payloads are decoded in chunks into a cache file; the decoded
+// size is capped so a malicious/huge payload cannot OOM the Java heap.
+private const val ANDROID_PDF_MAX_BASE64_DECODED = 64L * 1024L * 1024L
+private const val ANDROID_PDF_MAX_BASE64_ENCODED = ANDROID_PDF_MAX_BASE64_DECODED * 4L / 3L + 4L
+private val ANDROID_OPEN_URL_ALLOWED_SCHEMES = setOf("https", "http", "market", "mailto")
 private const val ANDROID_DIRECT_EXPORT_MAX_CHARS = 64L * 1024L * 1024L
 private const val MAX_TTS_SPEAK_CHARS = 20_000
 private const val TTS_NOTIFICATION_CHANNEL_ID = "wordhunter-tts"
@@ -430,25 +437,25 @@ class MainActivity : TauriActivity() {
       val target = url?.trim()?.takeIf { it.isNotEmpty() } ?: return false
       val uri = runCatching { Uri.parse(target) }.getOrNull() ?: return false
       val scheme = uri.scheme?.lowercase(Locale.ROOT)
-      if (scheme != "http" && scheme != "https") return false
-      return runCatching {
-        val intent = Intent(Intent.ACTION_VIEW, uri)
-        intent.addCategory(Intent.CATEGORY_BROWSABLE)
-        startActivity(intent)
-        true
-      }.getOrDefault(false)
+      if (scheme !in ANDROID_OPEN_URL_ALLOWED_SCHEMES) return false
+      val intent = Intent(Intent.ACTION_VIEW, uri)
+      intent.addCategory(Intent.CATEGORY_BROWSABLE)
+      runOnUiThread {
+        runCatching { startActivity(intent) }
+          .onFailure { error -> Log.w("WordHunter", "Could not open $target: ${error.message}") }
+      }
+      return true
     }
 
     @JavascriptInterface
     fun beginPdfRender(sessionId: String?, dataUrl: String?): String {
       return runCatching {
         val id = safePdfRenderSessionId(sessionId)
-        val data = decodeDataUrl(dataUrl)
         val file = File(cacheDir, "wordhunter-pdf-render-$id.pdf")
         var descriptor: ParcelFileDescriptor? = null
         try {
           FileOutputStream(file).use { output ->
-            output.write(data)
+            writeDecodedDataUrl(dataUrl, output)
             output.fd.sync()
           }
           descriptor = ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY)
@@ -628,18 +635,31 @@ class MainActivity : TauriActivity() {
     return raw.replace(Regex("[^A-Za-z0-9._-]"), "_").take(80).ifBlank { "default" }
   }
 
-  private fun decodeDataUrl(dataUrl: String?): ByteArray {
+  private fun writeDecodedDataUrl(dataUrl: String?, output: FileOutputStream) {
     val raw = dataUrl?.substringAfter(',', dataUrl)?.trim()?.takeIf { it.isNotEmpty() }
       ?: error("PDF data is empty.")
-    val maxEncodedLength = 400 * 1024 * 1024 * 4 / 3 + 4
-    if (raw.length > maxEncodedLength) {
-      error("PDF is too large for Pocket render (max 400 MB).")
+    if (raw.length > ANDROID_PDF_MAX_BASE64_ENCODED) {
+      error("PDF is too large for Pocket render (max 64 MB).")
     }
-    val data = Base64.decode(raw, Base64.DEFAULT)
-    if (data.size > 400 * 1024 * 1024) {
-      error("PDF is too large for Pocket render (max 400 MB).")
+    // Decode in chunks straight into the file: a full Java-heap buffer for
+    // large PDFs would OOM on lower-end devices (was a 400 MB single decode).
+    val input = ByteArrayInputStream(raw.toByteArray(Charsets.US_ASCII))
+    val decoder = Base64InputStream(input, Base64.DEFAULT)
+    val buffer = ByteArray(64 * 1024)
+    var decodedTotal = 0L
+    try {
+      while (true) {
+        val count = decoder.read(buffer)
+        if (count <= 0) break
+        decodedTotal += count
+        if (decodedTotal > ANDROID_PDF_MAX_BASE64_DECODED) {
+          error("PDF is too large for Pocket render (max 64 MB).")
+        }
+        output.write(buffer, 0, count)
+      }
+    } finally {
+      decoder.close()
     }
-    return data
   }
 
   private fun localeFor(lang: String): Locale {

--- a/src-tauri/platforms/android/res/xml/file_paths.xml
+++ b/src-tauri/platforms/android/res/xml/file_paths.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <external-files-path name="pocket_camera_photos" path="Pictures/" />
+    <cache-path name="pocket_cache" path="." />
+</paths>

--- a/src/web/js/events/book-import.ts
+++ b/src/web/js/events/book-import.ts
@@ -85,6 +85,12 @@ let youtubeTracks: YoutubeTrack[] = [];
 let youtubeTracksUrl = "";
 const MAX_DESKTOP_PDF_BYTES = 256 * 1024 * 1024;
 const MAX_POCKET_PDF_BYTES = 32 * 1024 * 1024;
+// The native Pocket bridge rejects base64 payloads above this cap BEFORE any
+// decode (see ANDROID_PDF_MAX_BASE64_DECODED in MainActivity.kt), so a huge
+// string is never materialized on the Java heap. Guard here as well, before
+// the payload crosses the bridge at all.
+const ANDROID_PDF_RENDER_MAX_BASE64_MB = 64;
+const ANDROID_PDF_RENDER_MAX_BASE64_ENCODED = ANDROID_PDF_RENDER_MAX_BASE64_MB * 1024 * 1024 * 4 / 3 + 4;
 /**
  * Rendering each PDF page synchronously on the JavaBridge stalls the JS
  * renderer ~100–500 ms per page. A 2000-page book would freeze the UI for
@@ -150,6 +156,7 @@ function safeImportErrorMessage(error: unknown): string {
     t("toast.pdfOcrRequiresApp"),
     t("toast.pdfTooLarge", { mb: Math.floor(MAX_POCKET_PDF_BYTES / (1024 * 1024)) }),
     t("toast.pdfTooLarge", { mb: Math.floor(MAX_DESKTOP_PDF_BYTES / (1024 * 1024)) }),
+    t("toast.pdfTooLarge", { mb: ANDROID_PDF_RENDER_MAX_BASE64_MB }),
     t("toast.pdfOcrNoText"),
     t("toast.imageOcrRequiresApp"),
     t("toast.imageOcrNoText"),
@@ -206,6 +213,9 @@ async function renderAndSaveAndroidPdfPages(data: string, bookId: string, pages:
   if (!bridge) throw new Error(t("toast.pdfOcrRequiresApp"));
 
   const limitedPages = pages.slice(0, MAX_POCKET_PDF_RENDER_PAGES);
+  if (data.length > ANDROID_PDF_RENDER_MAX_BASE64_ENCODED) {
+    throw new Error(t("toast.pdfTooLarge", { mb: ANDROID_PDF_RENDER_MAX_BASE64_MB }));
+  }
   const sessionId = `wh-pdf-${Date.now()}-${Math.random().toString(36).slice(2)}`;
   parseAndroidPdfRenderResponse(
     bridge.beginPdfRender(sessionId, data),


### PR DESCRIPTION
Part of #111 (bullets 4, 5, 6; 1, 7 fixed by #187; 2, 3 fixed by #216)

**B4 — base64 OOM (400 MB cap → OOM)**: ANDROID_PDF_MAX_BASE64_DECODED caps the native payload at 64 MiB; the native side decodes in chunks into a cache file (no single Java-heap buffer for the whole payload); book-import.ts rejects oversized payloads before beginPdfRender with a clear message.

**B5 — FileProvider (latent camera crash)**: AndroidManifest.xml declares the provider (packageName.fileprovider), src-tauri/platforms/android/res/xml/file_paths.xml maps the cache dir, build.bat no longer deletes file_paths.xml — the camera-capture branch of the generated RustWebChromeClient has a working authority.

**B6 — openUrl from the bridge thread**: startActivity runs on the UI thread (runOnUiThread) and the scheme is validated against an explicit allowlist (https/http/market/mailto).

**Tests**: pocket-bridges.test.js + pocket-packaging.test.js static contracts — RED on base (5 assertions: allowlist, 64 MiB cap, provider manifest entry, file_paths.xml kept, Copy-Item present), GREEN 11/11 after.

Gates: frontend 546/546, check:frontend clean, Rust 282/282, fmt/clippy clean, diff clean.