### PR TITLE
fix(#127): P1 part 1 — port bookmarks/move-book/delete-book/update dialogs to TS renderers

### DIFF
--- a/frontend-tests/desktop/desktop-reader.test.js
+++ b/frontend-tests/desktop/desktop-reader.test.js
@@ -688,8 +688,8 @@ describe("desktop reader markup and style contracts", () => {
     assert.doesNotMatch(html, /<dialog id="reader-bookmarks-dialog"/);
     const bookmarksModule = readFileSync(new URL("../../dist/web/js/reader/bookmarks.js", import.meta.url), "utf8");
     assert.match(bookmarksModule, /function renderBookmarksDialog/);
-    assert.match(bookmarksModule, /id="reader-bookmarks-dialog"/);
-    assert.equal((bookmarksModule.match(/name="reader-bookmark-color"/g) || []).length, 5);
+    assert.match(bookmarksModule, /dialog\.id = "reader-bookmarks-dialog"/);
+    assert.equal((bookmarksModule.match(/type="radio" name="reader-bookmark-color"/g) || []).length, 5);
     assert.equal(cssDeclarations(css, ".reader-bookmark-tabs").position, "absolute");
     assert.equal(cssDeclarations(css, "button.reader-bookmark-tab")["pointer-events"], "auto");
     assert.equal(cssDeclarations(css, ".word-token.reader-inline-bookmark").position, "relative");

--- a/frontend-tests/desktop/desktop-reader.test.js
+++ b/frontend-tests/desktop/desktop-reader.test.js
@@ -683,8 +683,13 @@ describe("desktop reader markup and style contracts", () => {
     assert.equal(attribute(openingTag(button), "aria-haspopup"), "dialog");
     assert.equal(attribute(openingTag(button), "aria-controls"), "reader-bookmarks-dialog");
     assert.ok(containingElementById(html, "section", "reader-bookmark-tabs"));
-    assert.ok(elementById(html, "reader-bookmarks-dialog"));
-    assert.equal((html.match(/name="reader-bookmark-color"/g) || []).length, 5);
+    // The dialog markup itself is built at boot by renderBookmarksDialog()
+    // (port of #127 P1), so its contract lives in the renderer source.
+    assert.doesNotMatch(html, /<dialog id="reader-bookmarks-dialog"/);
+    const bookmarksModule = readFileSync(new URL("../../dist/web/js/reader/bookmarks.js", import.meta.url), "utf8");
+    assert.match(bookmarksModule, /function renderBookmarksDialog/);
+    assert.match(bookmarksModule, /id="reader-bookmarks-dialog"/);
+    assert.equal((bookmarksModule.match(/name="reader-bookmark-color"/g) || []).length, 5);
     assert.equal(cssDeclarations(css, ".reader-bookmark-tabs").position, "absolute");
     assert.equal(cssDeclarations(css, "button.reader-bookmark-tab")["pointer-events"], "auto");
     assert.equal(cssDeclarations(css, ".word-token.reader-inline-bookmark").position, "relative");

--- a/frontend-tests/shared/dialog-ports.test.js
+++ b/frontend-tests/shared/dialog-ports.test.js
@@ -76,10 +76,10 @@ const HTMLDialogElementInstance = {
 
 const tIdentity = { t: (key) => key };
 
-function assertBootOrder(rendererCall) {
-  const html = read("../../dist/web/index.html");
-  const app = read("../../dist/web/app.js");
-  assert.doesNotMatch(html, /<dialog id="reader-bookmarks-dialog"/);
+function assertBootOrder(rendererCall, dialogId) {
+  const html = read("dist/web/index.html");
+  const app = read("dist/web/app.js");
+  assert.doesNotMatch(html, new RegExp(`<dialog id="${dialogId}"`));
   const renderAt = app.indexOf(rendererCall);
   const cacheAt = app.indexOf("cacheElements();");
   assert.ok(renderAt >= 0, `${rendererCall} must be called in app boot`);
@@ -91,14 +91,14 @@ describe("bookmarks dialog renderer (reader/bookmarks.ts)", () => {
   it("builds the dialog once with the audited ids and i18n attributes", async () => {
     const document = fakeDocument();
     const { renderBookmarksDialog } = await evaluateWithMocks("dist/web/js/reader/bookmarks.js", {
-      "../state.js": {},
+      "../state.js": { state: {}, saveState: async () => {}, saveUiState: async () => {} },
       "../i18n.js": tIdentity,
-      "../utils.js": {},
-      "./scroll.js": {},
-      "./session.js": {},
-      "../tokenizer_v2.js": {},
-      "../translator-preferences.js": {},
-      "./pdf-page-text.js": {}
+      "../utils.js": { escapeAttribute: (value) => value, escapeHtml: (value) => value },
+      "./scroll.js": { rememberReaderScrollPosition: () => {} },
+      "./session.js": { getReaderSession: () => ({ tokens: [], globalWordIndexes: [], globalCharOffsets: [] }) },
+      "../tokenizer_v2.js": { normalizeWord: (value) => value },
+      "../translator-preferences.js": { effectiveLearningLanguage: () => "en" },
+      "./pdf-page-text.js": { buildPdfDocumentText: () => "" }
     }, { document, HTMLDialogElement: HTMLDialogElementInstance });
 
     const dialog = renderBookmarksDialog();
@@ -125,6 +125,118 @@ describe("bookmarks dialog renderer (reader/bookmarks.ts)", () => {
   });
 
   it("keeps the dialog out of static HTML and renders it before cacheElements", () => {
-    assertBootOrder("renderBookmarksDialog();");
+    assertBootOrder("renderBookmarksDialog();", "reader-bookmarks-dialog");
+  });
+});
+
+describe("move-book dialog renderer (events/move-book.ts)", () => {
+  it("builds the dialog once with the audited ids and i18n attributes", async () => {
+    const document = fakeDocument();
+    const { renderMoveBookDialog } = await evaluateWithMocks("dist/web/js/events/move-book.js", {
+      "../state.js": { state: { preferences: {} } },
+      "../i18n.js": tIdentity,
+      "../book-actions.js": { moveBookToProfile: async () => true },
+      "../constants.js": { LEARNING_LANGUAGES: [] }
+    }, { document, HTMLDialogElement: HTMLDialogElementInstance });
+
+    const dialog = renderMoveBookDialog();
+    assert.equal(dialog.id, "move-book-dialog");
+    assert.equal(dialog.className, "panel");
+    assert.equal(dialog.attrs["aria-labelledby"], "move-book-title");
+    assert.equal(document.bodyChildren.length, 1);
+    for (const id of ["move-book-title", "move-book-select", "move-book-cancel", "move-book-confirm"]) {
+      assert.match(dialog.innerHTML, new RegExp(`id="${id}"`), `missing #${id}`);
+    }
+    assert.match(dialog.innerHTML, /data-i18n="moveBook\.title"/);
+    assert.match(dialog.innerHTML, /data-i18n-attr="aria-label=library\.moveBook"/);
+    assert.equal(renderMoveBookDialog(), dialog, "render must be idempotent");
+    assert.equal(document.bodyChildren.length, 1);
+  });
+
+  it("keeps the dialog out of static HTML and renders it before cacheElements", () => {
+    assertBootOrder("renderMoveBookDialog();", "move-book-dialog");
+  });
+});
+
+describe("delete-book dialog renderer (views/library.ts)", () => {
+  it("builds the dialog once with the audited ids and i18n attributes", async () => {
+    const document = fakeDocument();
+    const { renderDeleteBookDialog } = await evaluateWithMocks("dist/web/js/views/library.js", {
+      "../state.js": { state: {}, saveUiState: async () => {} },
+      "../dom.js": { els: {} },
+      "../utils.js": {
+        escapeHtml: (value) => value,
+        escapeAttribute: (value) => value,
+        parseTagList: () => [],
+        calcRoundedStatsPcts: () => ({}),
+        calcStatsPcts: () => ({})
+      },
+      "../icons.js": { icon: () => "", renderCardStat: () => "", renderCardCount: () => "" },
+      "../tokenizer_v2.js": { normalizeSearchVariants: (value) => value },
+      "../books.js": {
+        findBookById: () => undefined,
+        getAllBooks: () => [],
+        bookTexts: new Map(),
+        getLibraryContentGeneration: () => 0,
+        hydrateActiveLibraryTexts: async () => {},
+        isBookTextCacheStale: () => false,
+        loadBookText: async () => "",
+        loadCustomTextContent: async () => ""
+      },
+      "../stats-cache.js": {
+        getCachedBookTextStats: () => null,
+        getCachedTextStats: () => null,
+        prepareTextStats: async () => null
+      },
+      "../i18n.js": { t: (key) => key, getLocale: () => "en" },
+      "../panel-resizer.js": { bindSidebarResizer: () => {} },
+      "../translator-preferences.js": { effectiveLearningLanguage: () => "en" }
+    }, { document, HTMLDialogElement: HTMLDialogElementInstance });
+
+    const dialog = renderDeleteBookDialog();
+    assert.equal(dialog.id, "delete-book-dialog");
+    assert.equal(dialog.className, "panel confirmation-dialog");
+    assert.equal(dialog.attrs["aria-labelledby"], "delete-book-title");
+    assert.equal(document.bodyChildren.length, 1);
+    for (const id of ["delete-book-title", "delete-book-message", "delete-book-cancel", "delete-book-confirm"]) {
+      assert.match(dialog.innerHTML, new RegExp(`id="${id}"`), `missing #${id}`);
+    }
+    assert.match(dialog.innerHTML, /data-i18n="library\.moveCancel"/);
+    assert.match(dialog.innerHTML, /data-i18n="library\.removeConfirmButton"/);
+    assert.equal(renderDeleteBookDialog(), dialog, "render must be idempotent");
+    assert.equal(document.bodyChildren.length, 1);
+  });
+
+  it("keeps the dialog out of static HTML and renders it before cacheElements", () => {
+    assertBootOrder("renderDeleteBookDialog();", "delete-book-dialog");
+  });
+});
+
+describe("update dialog renderer (update-checker.ts)", () => {
+  it("builds the dialog once with the audited ids and i18n attributes", async () => {
+    const document = fakeDocument();
+    const { renderUpdateDialog } = await evaluateWithMocks("dist/web/js/update-checker.js", {
+      "./state.js": { state: {}, saveState: async () => {} },
+      "./platform.js": { openAndroidUrl: () => false },
+      "./i18n.js": tIdentity,
+      "./toast.js": { showToast: () => {} }
+    }, { document, HTMLDialogElement: HTMLDialogElementInstance });
+
+    const dialog = renderUpdateDialog();
+    assert.equal(dialog.id, "update-dialog");
+    assert.equal(dialog.className, "panel dialog-500");
+    assert.equal(dialog.attrs["aria-labelledby"], "update-title");
+    assert.equal(document.bodyChildren.length, 1);
+    for (const id of ["update-title", "update-message", "update-dismiss", "update-skip", "update-disable", "update-open"]) {
+      assert.match(dialog.innerHTML, new RegExp(`id="${id}"`), `missing #${id}`);
+    }
+    assert.match(dialog.innerHTML, /data-i18n="update\.title"/);
+    assert.match(dialog.innerHTML, /data-i18n="update\.openReleases"/);
+    assert.equal(renderUpdateDialog(), dialog, "render must be idempotent");
+    assert.equal(document.bodyChildren.length, 1);
+  });
+
+  it("keeps the dialog out of static HTML and renders it before cacheElements", () => {
+    assertBootOrder("renderUpdateDialog();", "update-dialog");
   });
 });

--- a/frontend-tests/shared/dialog-ports.test.js
+++ b/frontend-tests/shared/dialog-ports.test.js
@@ -1,0 +1,130 @@
+// #127 P1 part 1: the four self-contained dialogs ported from static
+// index.html markup into TS renderers (bookmarks, move-book, delete-book,
+// update). Each renderer runs during app boot before cacheElements()
+// (app.ts), so every boot-time consumer finds its elements in the DOM.
+//
+// Per-dialog contracts:
+//   - behavioral: renderXxxDialog() builds + appends the dialog once and is
+//     idempotent, keeps the audited ids, and seeds data-i18n attributes for
+//     the boot-time applyTranslations() pass;
+//   - static: the dialog markup is gone from dist index.html and the boot
+//     sequence renders it before cacheElements().
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import vm from "node:vm";
+
+const read = (path) => readFileSync(new URL(`../../${path}`, import.meta.url), "utf8");
+
+async function evaluateWithMocks(file, importValues, globals = {}) {
+  const context = vm.createContext({ console, setTimeout, clearTimeout, ...globals });
+  const modules = new Map();
+  for (const [specifier, values] of Object.entries(importValues)) {
+    modules.set(specifier, new vm.SyntheticModule(
+      Object.keys(values),
+      function initialize() {
+        for (const [name, value] of Object.entries(values)) this.setExport(name, value);
+      },
+      { context, identifier: `mock:${specifier}` }
+    ));
+  }
+  const getModule = (specifier) => {
+    const dependency = modules.get(specifier);
+    assert.ok(dependency, `unexpected import ${specifier} from ${file}`);
+    return dependency;
+  };
+  const module = new vm.SourceTextModule(read(file), {
+    context,
+    identifier: new URL(`../../${file}`, import.meta.url).href,
+    importModuleDynamically: async (specifier) => {
+      const dependency = getModule(specifier);
+      if (dependency.status === "unlinked") await dependency.link(() => {});
+      if (dependency.status === "linked") await dependency.evaluate();
+      return dependency;
+    }
+  });
+  await module.link(getModule);
+  await module.evaluate();
+  return module.namespace;
+}
+
+/** Minimal recording DOM: getElementById registry + appendChild tracking. */
+function fakeDocument() {
+  const registry = new Map();
+  const bodyChildren = [];
+  const makeElement = () => ({
+    isDialog: true,
+    id: "",
+    className: "",
+    innerHTML: "",
+    attrs: {},
+    setAttribute(name, value) { this.attrs[name] = String(value); },
+    appendChild() {}
+  });
+  return {
+    registry,
+    bodyChildren,
+    getElementById(id) { return registry.get(id) ?? null; },
+    createElement() { return makeElement(); },
+    body: { appendChild(element) { bodyChildren.push(element); registry.set(element.id, element); } }
+  };
+}
+
+const HTMLDialogElementInstance = {
+  [Symbol.hasInstance](value) { return value?.isDialog === true; }
+};
+
+const tIdentity = { t: (key) => key };
+
+function assertBootOrder(rendererCall) {
+  const html = read("../../dist/web/index.html");
+  const app = read("../../dist/web/app.js");
+  assert.doesNotMatch(html, /<dialog id="reader-bookmarks-dialog"/);
+  const renderAt = app.indexOf(rendererCall);
+  const cacheAt = app.indexOf("cacheElements();");
+  assert.ok(renderAt >= 0, `${rendererCall} must be called in app boot`);
+  assert.ok(cacheAt >= 0, "cacheElements() must exist in app boot");
+  assert.ok(renderAt < cacheAt, `${rendererCall} must run before cacheElements()`);
+}
+
+describe("bookmarks dialog renderer (reader/bookmarks.ts)", () => {
+  it("builds the dialog once with the audited ids and i18n attributes", async () => {
+    const document = fakeDocument();
+    const { renderBookmarksDialog } = await evaluateWithMocks("dist/web/js/reader/bookmarks.js", {
+      "../state.js": {},
+      "../i18n.js": tIdentity,
+      "../utils.js": {},
+      "./scroll.js": {},
+      "./session.js": {},
+      "../tokenizer_v2.js": {},
+      "../translator-preferences.js": {},
+      "./pdf-page-text.js": {}
+    }, { document, HTMLDialogElement: HTMLDialogElementInstance });
+
+    const dialog = renderBookmarksDialog();
+    assert.equal(dialog.id, "reader-bookmarks-dialog");
+    assert.equal(dialog.className, "panel reader-bookmarks-dialog");
+    assert.equal(dialog.attrs["aria-labelledby"], "reader-bookmarks-title");
+    assert.equal(document.bodyChildren.length, 1);
+    for (const id of [
+      "reader-bookmarks-title",
+      "reader-bookmarks-close",
+      "reader-bookmark-form",
+      "reader-bookmark-label",
+      "reader-bookmark-submit",
+      "reader-bookmark-cancel-edit",
+      "reader-bookmark-list"
+    ]) {
+      assert.match(dialog.innerHTML, new RegExp(`id="${id}"`), `missing #${id}`);
+    }
+    assert.match(dialog.innerHTML, /data-i18n="reader\.bookmarksTitle"/);
+    assert.match(dialog.innerHTML, /data-i18n-attr="placeholder=reader\.bookmarkPlaceholder"/);
+    assert.equal((dialog.innerHTML.match(/name="reader-bookmark-color"/g) || []).length, 5);
+    assert.equal(renderBookmarksDialog(), dialog, "render must be idempotent");
+    assert.equal(document.bodyChildren.length, 1);
+  });
+
+  it("keeps the dialog out of static HTML and renders it before cacheElements", () => {
+    assertBootOrder("renderBookmarksDialog();");
+  });
+});

--- a/frontend-tests/shared/persistence-lifecycle.test.js
+++ b/frontend-tests/shared/persistence-lifecycle.test.js
@@ -144,9 +144,11 @@ async function loadAppHarness({
       clearPendingDelta() { calls.push("clear-pending"); },
       saveWithRetry(body) { calls.push(`replay:${body}`); return Promise.resolve({ ok: true }); }
     },
-    "./js/views/library.js": { bindLibraryEvents: noOp, renderLibrary: () => calls.push("render-library") },
+    "./js/views/library.js": { bindLibraryEvents: noOp, renderDeleteBookDialog: noOp, renderLibrary: () => calls.push("render-library") },
     "./js/views/vocabulary.js": { renderReview: noOp, renderVocabulary: noOp },
     "./js/youglish.js": { refreshYouGlishTheme: noOp },
+    "./js/reader/bookmarks.js": { renderBookmarksDialog: noOp },
+    "./js/events/move-book.js": { renderMoveBookDialog: noOp },
     "./js/request.js": { fetchWithTimeout: async () => ({ ok: true, json: async () => ({}) }) },
     "./js/platform.js": {
       applyPlatformUi: noOp,
@@ -166,7 +168,7 @@ async function loadAppHarness({
     console
   }, {
     "./js/views/reader.js": { bindReaderEvents: noOp },
-    "./js/update-checker.js": { checkForUpdates: noOp }
+    "./js/update-checker.js": { checkForUpdates: noOp, renderUpdateDialog: noOp }
   });
 
   return {

--- a/frontend-tests/shared/repo-validation.test.js
+++ b/frontend-tests/shared/repo-validation.test.js
@@ -480,6 +480,23 @@ describe("repository validation wiring", () => {
     "reader-bookmark-cancel-edit", // reader/bookmarks.ts (renderBookmarksDialog)
     "reader-bookmark-list", // reader/bookmarks.ts (renderBookmarksDialog)
     "reader-bookmarks-close", // reader/bookmarks.ts (renderBookmarksDialog)
+    "move-book-dialog", // events/move-book.ts (renderMoveBookDialog)
+    "move-book-title", // events/move-book.ts (renderMoveBookDialog)
+    "move-book-select", // events/move-book.ts (renderMoveBookDialog)
+    "move-book-cancel", // events/move-book.ts (renderMoveBookDialog)
+    "move-book-confirm", // events/move-book.ts (renderMoveBookDialog)
+    "delete-book-dialog", // views/library.ts (renderDeleteBookDialog)
+    "delete-book-title", // views/library.ts (renderDeleteBookDialog)
+    "delete-book-message", // views/library.ts (renderDeleteBookDialog)
+    "delete-book-cancel", // views/library.ts (renderDeleteBookDialog)
+    "delete-book-confirm", // views/library.ts (renderDeleteBookDialog)
+    "update-dialog", // update-checker.ts (renderUpdateDialog)
+    "update-title", // update-checker.ts (renderUpdateDialog)
+    "update-message", // update-checker.ts (renderUpdateDialog)
+    "update-dismiss", // update-checker.ts (renderUpdateDialog)
+    "update-skip", // update-checker.ts (renderUpdateDialog)
+    "update-disable", // update-checker.ts (renderUpdateDialog)
+    "update-open", // update-checker.ts (renderUpdateDialog)
   ]);
 
   it("keeps every byId target in dom.ts present in index.html or on the audited TS-created allowlist", () => {

--- a/frontend-tests/shared/repo-validation.test.js
+++ b/frontend-tests/shared/repo-validation.test.js
@@ -447,8 +447,8 @@ describe("repository validation wiring", () => {
     }
   });
 
-  // Ids created at runtime by TypeScript (audited; the P1 dialog port of #127
-  // will move the remaining runtime-built dialogs into static HTML). Any id
+  // Ids created at runtime by TypeScript (audited; #127 P1 ports the static
+  // dialogs into TS renderers that run before cacheElements()). Any id
   // referenced from TS but absent here must exist in src/web/index.html.
   const TS_CREATED_IDS = new Set([
     "graph-due", // graphs/charts.ts (canvas)
@@ -473,6 +473,13 @@ describe("repository validation wiring", () => {
     "ocr-progress-text", // events/book-import.ts (innerHTML)
     "ocr-whole-book-confirm", // events/book-import.ts (dialog.id)
     "pocket-pdf-scan-warning", // events/book-import.ts (dialog.id)
+    "reader-bookmarks-dialog", // reader/bookmarks.ts (renderBookmarksDialog)
+    "reader-bookmark-form", // reader/bookmarks.ts (renderBookmarksDialog)
+    "reader-bookmark-label", // reader/bookmarks.ts (renderBookmarksDialog)
+    "reader-bookmark-submit", // reader/bookmarks.ts (renderBookmarksDialog)
+    "reader-bookmark-cancel-edit", // reader/bookmarks.ts (renderBookmarksDialog)
+    "reader-bookmark-list", // reader/bookmarks.ts (renderBookmarksDialog)
+    "reader-bookmarks-close", // reader/bookmarks.ts (renderBookmarksDialog)
   ]);
 
   it("keeps every byId target in dom.ts present in index.html or on the audited TS-created allowlist", () => {

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -8,12 +8,14 @@ import { render, ensureCurrentText } from "./js/render.js";
 import { loadLocale, applyTranslations, t, getLocale, initialLocale } from "./js/i18n.js";
 import { applyBridgeSnapshotToState, flushFrontendStateBuffers, flushUiStateSync, saveState, state } from "./js/state.js";
 import { clearPendingDelta, flushPendingDeltaToLocalStorage, readPendingDelta, saveWithRetry } from "./js/api.js";
-import { bindLibraryEvents, renderLibrary } from "./js/views/library.js";
+import { bindLibraryEvents, renderDeleteBookDialog, renderLibrary } from "./js/views/library.js";
 import { renderReview, renderVocabulary } from "./js/views/vocabulary.js";
 import { applyPlatformUi, detectPlatform, isAndroidPlatform, openAndroidUrl } from "./js/platform.js";
 import { refreshYouGlishTheme } from "./js/youglish.js";
 import { fetchWithTimeout } from "./js/request.js";
 import { renderBookmarksDialog } from "./js/reader/bookmarks.js";
+import { renderMoveBookDialog } from "./js/events/move-book.js";
+import { renderUpdateDialog } from "./js/update-checker.js";
 
 detectPlatform();
 
@@ -209,6 +211,9 @@ document.addEventListener("DOMContentLoaded", async () => {
     // TS-rendered dialogs (port of #127 P1): build them before cacheElements()
     // so every boot-time consumer and the els cache find the elements in DOM.
     renderBookmarksDialog();
+    renderMoveBookDialog();
+    renderDeleteBookDialog();
+    renderUpdateDialog();
     cacheElements();
     startBridgeStateLoad();
     recoverPendingFlush();

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -13,6 +13,7 @@ import { renderReview, renderVocabulary } from "./js/views/vocabulary.js";
 import { applyPlatformUi, detectPlatform, isAndroidPlatform, openAndroidUrl } from "./js/platform.js";
 import { refreshYouGlishTheme } from "./js/youglish.js";
 import { fetchWithTimeout } from "./js/request.js";
+import { renderBookmarksDialog } from "./js/reader/bookmarks.js";
 
 detectPlatform();
 
@@ -205,6 +206,9 @@ function showLanguageOnboardingIfNeeded() {
 
 document.addEventListener("DOMContentLoaded", async () => {
   try {
+    // TS-rendered dialogs (port of #127 P1): build them before cacheElements()
+    // so every boot-time consumer and the els cache find the elements in DOM.
+    renderBookmarksDialog();
     cacheElements();
     startBridgeStateLoad();
     recoverPendingFlush();

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -1523,32 +1523,6 @@
     </div>
   </dialog>
 
-  <dialog id="move-book-dialog" class="panel" aria-labelledby="move-book-title">
-    <div class="panel-header">
-      <h2 id="move-book-title" data-i18n="moveBook.title">Move Book</h2>
-    </div>
-    <div class="settings-body p-15-g-1">
-      <p class="muted-copy" data-i18n="moveBook.hint">Select the target language profile for this book:</p>
-      <select id="move-book-select" class="input" data-i18n-attr="aria-label=library.moveBook"></select>
-      <div class="justify-end-m-t-1">
-        <button id="move-book-cancel" class="secondary-button" data-i18n="moveBook.cancel">Cancel</button>
-        <button id="move-book-confirm" class="primary-button" data-i18n="moveBook.confirm">Move</button>
-      </div>
-    </div>
-  </dialog>
-
-  <dialog id="delete-book-dialog" class="panel confirmation-dialog" aria-labelledby="delete-book-title">
-    <div class="panel-header"><h2 id="delete-book-title"></h2></div>
-    <div class="confirmation-dialog-body">
-      <p id="delete-book-message" class="muted-copy"></p>
-      <div class="confirmation-dialog-actions">
-        <button id="delete-book-cancel" type="button" class="secondary-button" data-i18n="library.moveCancel">Cancel</button>
-        <button id="delete-book-confirm" type="button" class="danger-button" data-i18n="library.removeConfirmButton"></button>
-      </div>
-    </div>
-  </dialog>
-
-
   <dialog id="edit-book-dialog" class="panel edit-book-dialog" aria-labelledby="edit-book-title-heading">
     <div class="panel-header">
       <h2 id="edit-book-title-heading" data-i18n="editBook.title">Edit book</h2>
@@ -1641,24 +1615,6 @@
       <div class="justify-end-m-t-1">
         <button id="argos-download-cancel" class="secondary-button" data-i18n="moveBook.cancel">Cancel</button>
         <button id="argos-download-confirm" class="primary-button" data-i18n="settings.argosDownloadConfirm">Download</button>
-      </div>
-    </div>
-  </dialog>
-
-  <dialog id="update-dialog" class="panel dialog-500" aria-labelledby="update-title">
-    <div class="panel-header">
-      <h2 class="row">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-20-green"><polyline points="23 6 13.5 15.5 8.5 10.5 1 18"></polyline><polyline points="17 6 23 6 23 12"></polyline></svg>
-        <span id="update-title" data-i18n="update.title">Update Available</span>
-      </h2>
-    </div>
-    <div class="settings-body p-15-g-1">
-      <p id="update-message" data-i18n="update.message" class="m-0-fs-09-lh-15-muted">Word Hunter {version} is available! (You have {current})</p>
-      <div class="justify-end-wrap-m-t-1">
-        <button id="update-dismiss" class="ghost-button" data-i18n="update.dismiss">Later</button>
-        <button id="update-skip" class="secondary-button" data-i18n="update.skipLabel">Skip this version</button>
-        <button id="update-disable" class="secondary-button" data-i18n="update.disableUpdates">Don't remind me again</button>
-        <button id="update-open" class="primary-button" data-i18n="update.openReleases">See what's new</button>
       </div>
     </div>
   </dialog>

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -1523,52 +1523,6 @@
     </div>
   </dialog>
 
-  <dialog id="reader-bookmarks-dialog" class="panel reader-bookmarks-dialog" aria-labelledby="reader-bookmarks-title">
-    <div class="panel-header">
-      <div>
-        <p class="eyebrow" data-i18n="reader.bookmarks">Bookmarks</p>
-        <h2 id="reader-bookmarks-title" data-i18n="reader.bookmarksTitle">Bookmarks in this book</h2>
-      </div>
-      <button type="button" id="reader-bookmarks-close" class="icon-button" data-i18n-attr="title=reader.close,aria-label=reader.close">×</button>
-    </div>
-    <div class="reader-bookmarks-dialog-body">
-      <form id="reader-bookmark-form" class="reader-bookmark-form">
-        <label for="reader-bookmark-label" data-i18n="reader.bookmarkLabel">Label or comment</label>
-        <input id="reader-bookmark-label" type="text" maxlength="160" autocomplete="off" data-i18n-attr="placeholder=reader.bookmarkPlaceholder">
-        <fieldset class="reader-bookmark-color-field">
-          <legend data-i18n="reader.bookmarkColor">Color</legend>
-          <div class="reader-bookmark-colors">
-            <label class="reader-bookmark-color" data-bookmark-color="amber">
-              <input type="radio" name="reader-bookmark-color" value="amber" data-i18n-attr="title=reader.bookmarkColorAmber,aria-label=reader.bookmarkColorAmber" checked>
-              <span aria-hidden="true"></span>
-            </label>
-            <label class="reader-bookmark-color" data-bookmark-color="red">
-              <input type="radio" name="reader-bookmark-color" value="red" data-i18n-attr="title=reader.bookmarkColorRed,aria-label=reader.bookmarkColorRed">
-              <span aria-hidden="true"></span>
-            </label>
-            <label class="reader-bookmark-color" data-bookmark-color="green">
-              <input type="radio" name="reader-bookmark-color" value="green" data-i18n-attr="title=reader.bookmarkColorGreen,aria-label=reader.bookmarkColorGreen">
-              <span aria-hidden="true"></span>
-            </label>
-            <label class="reader-bookmark-color" data-bookmark-color="blue">
-              <input type="radio" name="reader-bookmark-color" value="blue" data-i18n-attr="title=reader.bookmarkColorBlue,aria-label=reader.bookmarkColorBlue">
-              <span aria-hidden="true"></span>
-            </label>
-            <label class="reader-bookmark-color" data-bookmark-color="purple">
-              <input type="radio" name="reader-bookmark-color" value="purple" data-i18n-attr="title=reader.bookmarkColorPurple,aria-label=reader.bookmarkColorPurple">
-              <span aria-hidden="true"></span>
-            </label>
-          </div>
-        </fieldset>
-        <div class="reader-bookmark-form-actions">
-          <button type="button" id="reader-bookmark-cancel-edit" class="secondary-button" data-i18n="reader.bookmarkCancelEdit" hidden>Cancel editing</button>
-          <button type="submit" id="reader-bookmark-submit" class="primary-button" data-i18n="reader.bookmarkAdd">Add here</button>
-        </div>
-      </form>
-      <div id="reader-bookmark-list" class="reader-bookmark-list" aria-live="polite"></div>
-    </div>
-  </dialog>
-
   <dialog id="move-book-dialog" class="panel" aria-labelledby="move-book-title">
     <div class="panel-header">
       <h2 id="move-book-title" data-i18n="moveBook.title">Move Book</h2>

--- a/src/web/js/events/move-book.ts
+++ b/src/web/js/events/move-book.ts
@@ -69,3 +69,35 @@ export function bindMoveBookEvents() {
     if (event.target === dialog && !moveRunning) dialog.close();
   });
 }
+
+/**
+ * Builds the move-book dialog markup once (idempotent). Called during app
+ * boot before cacheElements() so every consumer finds the elements in the
+ * DOM; data-i18n / data-i18n-attr attributes are applied by the boot-time
+ * applyTranslations() pass (see app.ts).
+ */
+export function renderMoveBookDialog(): HTMLDialogElement {
+  const existing = document.getElementById("move-book-dialog");
+  if (existing instanceof HTMLDialogElement) return existing;
+  if (existing) throw new TypeError("#move-book-dialog must be a dialog element");
+
+  const dialog = document.createElement("dialog");
+  dialog.id = "move-book-dialog";
+  dialog.className = "panel";
+  dialog.setAttribute("aria-labelledby", "move-book-title");
+  dialog.innerHTML = `
+    <div class="panel-header">
+      <h2 id="move-book-title" data-i18n="moveBook.title">Move Book</h2>
+    </div>
+    <div class="settings-body p-15-g-1">
+      <p class="muted-copy" data-i18n="moveBook.hint">Select the target language profile for this book:</p>
+      <select id="move-book-select" class="input" data-i18n-attr="aria-label=library.moveBook"></select>
+      <div class="justify-end-m-t-1">
+        <button id="move-book-cancel" class="secondary-button" data-i18n="moveBook.cancel">Cancel</button>
+        <button id="move-book-confirm" class="primary-button" data-i18n="moveBook.confirm">Move</button>
+      </div>
+    </div>
+  `;
+  document.body.appendChild(dialog);
+  return dialog;
+}

--- a/src/web/js/reader/bookmarks.ts
+++ b/src/web/js/reader/bookmarks.ts
@@ -416,6 +416,70 @@ function editBookmark(id: string): void {
   input.select();
 }
 
+/**
+ * Builds the bookmarks dialog markup once (idempotent). Called during app
+ * boot before cacheElements() so every consumer finds the elements in the
+ * DOM; data-i18n / data-i18n-attr attributes are applied by the boot-time
+ * applyTranslations() pass (see app.ts).
+ */
+export function renderBookmarksDialog(): HTMLDialogElement {
+  const existing = document.getElementById("reader-bookmarks-dialog");
+  if (existing instanceof HTMLDialogElement) return existing;
+  if (existing) throw new TypeError("#reader-bookmarks-dialog must be a dialog element");
+
+  const dialog = document.createElement("dialog");
+  dialog.id = "reader-bookmarks-dialog";
+  dialog.className = "panel reader-bookmarks-dialog";
+  dialog.setAttribute("aria-labelledby", "reader-bookmarks-title");
+  dialog.innerHTML = `
+    <div class="panel-header">
+      <div>
+        <p class="eyebrow" data-i18n="reader.bookmarks">Bookmarks</p>
+        <h2 id="reader-bookmarks-title" data-i18n="reader.bookmarksTitle">Bookmarks in this book</h2>
+      </div>
+      <button type="button" id="reader-bookmarks-close" class="icon-button" data-i18n-attr="title=reader.close,aria-label=reader.close">×</button>
+    </div>
+    <div class="reader-bookmarks-dialog-body">
+      <form id="reader-bookmark-form" class="reader-bookmark-form">
+        <label for="reader-bookmark-label" data-i18n="reader.bookmarkLabel">Label or comment</label>
+        <input id="reader-bookmark-label" type="text" maxlength="160" autocomplete="off" data-i18n-attr="placeholder=reader.bookmarkPlaceholder">
+        <fieldset class="reader-bookmark-color-field">
+          <legend data-i18n="reader.bookmarkColor">Color</legend>
+          <div class="reader-bookmark-colors">
+            <label class="reader-bookmark-color" data-bookmark-color="amber">
+              <input type="radio" name="reader-bookmark-color" value="amber" data-i18n-attr="title=reader.bookmarkColorAmber,aria-label=reader.bookmarkColorAmber" checked>
+              <span aria-hidden="true"></span>
+            </label>
+            <label class="reader-bookmark-color" data-bookmark-color="red">
+              <input type="radio" name="reader-bookmark-color" value="red" data-i18n-attr="title=reader.bookmarkColorRed,aria-label=reader.bookmarkColorRed">
+              <span aria-hidden="true"></span>
+            </label>
+            <label class="reader-bookmark-color" data-bookmark-color="green">
+              <input type="radio" name="reader-bookmark-color" value="green" data-i18n-attr="title=reader.bookmarkColorGreen,aria-label=reader.bookmarkColorGreen">
+              <span aria-hidden="true"></span>
+            </label>
+            <label class="reader-bookmark-color" data-bookmark-color="blue">
+              <input type="radio" name="reader-bookmark-color" value="blue" data-i18n-attr="title=reader.bookmarkColorBlue,aria-label=reader.bookmarkColorBlue">
+              <span aria-hidden="true"></span>
+            </label>
+            <label class="reader-bookmark-color" data-bookmark-color="purple">
+              <input type="radio" name="reader-bookmark-color" value="purple" data-i18n-attr="title=reader.bookmarkColorPurple,aria-label=reader.bookmarkColorPurple">
+              <span aria-hidden="true"></span>
+            </label>
+          </div>
+        </fieldset>
+        <div class="reader-bookmark-form-actions">
+          <button type="button" id="reader-bookmark-cancel-edit" class="secondary-button" data-i18n="reader.bookmarkCancelEdit" hidden>Cancel editing</button>
+          <button type="submit" id="reader-bookmark-submit" class="primary-button" data-i18n="reader.bookmarkAdd">Add here</button>
+        </div>
+      </form>
+      <div id="reader-bookmark-list" class="reader-bookmark-list" aria-live="polite"></div>
+    </div>
+  `;
+  document.body.appendChild(dialog);
+  return dialog;
+}
+
 function openBookmarksDialog(): void {
   if (!state.currentTextId) return;
   pendingPosition = captureCurrentBookmarkPosition();

--- a/src/web/js/update-checker.ts
+++ b/src/web/js/update-checker.ts
@@ -142,3 +142,39 @@ export async function checkForUpdates({ manual = false }: UpdateCheckOptions = {
     if (manual) showToast(t("update.checkFailed"));
   }
 }
+
+/**
+ * Builds the update dialog markup once (idempotent). Called during app
+ * boot before cacheElements() so every consumer finds the elements in the
+ * DOM; data-i18n attributes are applied by the boot-time applyTranslations()
+ * pass (see app.ts).
+ */
+export function renderUpdateDialog(): HTMLDialogElement {
+  const existing = document.getElementById("update-dialog");
+  if (existing instanceof HTMLDialogElement) return existing;
+  if (existing) throw new TypeError("#update-dialog must be a dialog element");
+
+  const dialog = document.createElement("dialog");
+  dialog.id = "update-dialog";
+  dialog.className = "panel dialog-500";
+  dialog.setAttribute("aria-labelledby", "update-title");
+  dialog.innerHTML = `
+    <div class="panel-header">
+      <h2 class="row">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-20-green"><polyline points="23 6 13.5 15.5 8.5 10.5 1 18"></polyline><polyline points="17 6 23 6 23 12"></polyline></svg>
+        <span id="update-title" data-i18n="update.title">Update Available</span>
+      </h2>
+    </div>
+    <div class="settings-body p-15-g-1">
+      <p id="update-message" data-i18n="update.message" class="m-0-fs-09-lh-15-muted">Word Hunter {version} is available! (You have {current})</p>
+      <div class="justify-end-wrap-m-t-1">
+        <button id="update-dismiss" class="ghost-button" data-i18n="update.dismiss">Later</button>
+        <button id="update-skip" class="secondary-button" data-i18n="update.skipLabel">Skip this version</button>
+        <button id="update-disable" class="secondary-button" data-i18n="update.disableUpdates">Don't remind me again</button>
+        <button id="update-open" class="primary-button" data-i18n="update.openReleases">See what's new</button>
+      </div>
+    </div>
+  `;
+  document.body.appendChild(dialog);
+  return dialog;
+}

--- a/src/web/js/views/library.ts
+++ b/src/web/js/views/library.ts
@@ -519,3 +519,32 @@ export function bindLibraryEvents(): void {
     if (control.dataset.action === "edit-custom") actions.openEditBookModal(id);
   });
 }
+
+/**
+ * Builds the delete-book confirmation dialog markup once (idempotent).
+ * Called during app boot before cacheElements() so every consumer finds
+ * the elements in the DOM; data-i18n attributes are applied by the
+ * boot-time applyTranslations() pass (see app.ts).
+ */
+export function renderDeleteBookDialog(): HTMLDialogElement {
+  const existing = document.getElementById("delete-book-dialog");
+  if (existing instanceof HTMLDialogElement) return existing;
+  if (existing) throw new TypeError("#delete-book-dialog must be a dialog element");
+
+  const dialog = document.createElement("dialog");
+  dialog.id = "delete-book-dialog";
+  dialog.className = "panel confirmation-dialog";
+  dialog.setAttribute("aria-labelledby", "delete-book-title");
+  dialog.innerHTML = `
+    <div class="panel-header"><h2 id="delete-book-title"></h2></div>
+    <div class="confirmation-dialog-body">
+      <p id="delete-book-message" class="muted-copy"></p>
+      <div class="confirmation-dialog-actions">
+        <button id="delete-book-cancel" type="button" class="secondary-button" data-i18n="library.moveCancel">Cancel</button>
+        <button id="delete-book-confirm" type="button" class="danger-button" data-i18n="library.removeConfirmButton"></button>
+      </div>
+    </div>
+  `;
+  document.body.appendChild(dialog);
+  return dialog;
+}


### PR DESCRIPTION
Part of #127 (P1 part 1: bookmarks/move-book/delete-book/update dialogs; remaining dialogs tracked in the issue)

**Four dialogs ported from static index.html markup to idempotent TS renderers** (owner-module pattern):
- bookmarks → reader/bookmarks.ts renderBookmarksDialog() (7db688e)
- move-book → events/move-book.ts renderMoveBookDialog()
- delete-book → views/library.ts renderDeleteBookDialog()
- update → update-checker.ts renderUpdateDialog() (loader-dialog intentionally stays static — later part)

Each renderer: createElement-if-absent idempotence, data-i18n/data-i18n-attr on generated markup (before applyTranslations), aria-labelledby. Boot wiring in app.ts before cacheElements() (satisfies the els-cache ordering requirement); the 26 runtime-created ids are on the TS_CREATED_IDS allowlist so the id-drift contract (repo-validation.test.js, #214) stays green; all keyboard shortcuts that click ids keep working.

**Tests**: dialog-ports.test.js (new) — behavioral build-once/ids/i18n-attr/idempotence via evaluateWithMocks + static boot-order/HTML-absence per dialog; desktop-reader + persistence-lifecycle contracts updated. RED on base: 8/8 (TypeError render*Dialog not a function ×4 + dialog blocks still in dist HTML ×4). GREEN: 552/552, check:frontend clean, Rust 282/282, fmt/clippy clean, diff clean.