### PR TITLE
docs(#135): document the optional yt-dlp dependency for YouTube captions

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,18 @@ Encrypted, corrupt, unsupported, or empty PDFs can still be rejected. A damaged
 desktop package with a missing OCR runner or model reports that packaging/runtime
 problem instead of silently returning an incomplete OCR result.
 
+**YouTube captions (optional).** The desktop import panel can load subtitles
+from a YouTube video URL. This uses the open-source [yt-dlp] tool as an
+optional external dependency — Word Hunter does not bundle it. Install Python 3
+with yt-dlp on your PATH, or drop a standalone `yt-dlp` binary (`yt-dlp.exe`
+on Windows) next to the app executable or in its `bin/` subdirectory. The
+`WORDHUNTER_YTDLP` environment variable overrides the yt-dlp binary to use.
+On Flatpak and Snap, the host's yt-dlp is found automatically under
+`/run/host` and `/var/lib/snapd/hostfs`. Caption downloads time out after 120
+seconds, and failures report the yt-dlp exit status.
+
+[yt-dlp]: https://github.com/yt-dlp/yt-dlp
+
 <img src="docs/screenshots/pc-library.png" width="860" alt="Word Hunter desktop library with import panel">
 
 Word Hunter Pocket shows the same kind of library in a phone layout. Pocket is

--- a/frontend-tests/shared/release-docs-contract.test.js
+++ b/frontend-tests/shared/release-docs-contract.test.js
@@ -98,3 +98,25 @@ describe("issue #144 release hygiene (bullets 2, 5, 7)", () => {
     assert.match(readme, /local OCR runtime/, "README must name the desktop local OCR runtime");
   });
 });
+
+describe("issue #135 bullet 7: the optional yt-dlp captions dependency is documented", () => {
+  it("README documents yt-dlp as the optional YouTube captions dependency", () => {
+    const readme = read("../../README.md");
+
+    assert.match(
+      readme,
+      /yt-dlp/,
+      "README must document the optional yt-dlp dependency for YouTube captions",
+    );
+  });
+
+  it("README documents the WORDHUNTER_YTDLP override variable", () => {
+    const readme = read("../../README.md");
+
+    assert.match(
+      readme,
+      /WORDHUNTER_YTDLP/,
+      "README must document the WORDHUNTER_YTDLP environment variable override",
+    );
+  });
+});


### PR DESCRIPTION
Part of #135 (bullet 7 — yt-dlp docs; 1-6 already merged)