### PR TITLE
fix(#127): P1 part 2 — port toast/onboarding/YouGlish dialogs to TS renderers

### DIFF
--- a/frontend-tests/android/pocket-navigation.test.js
+++ b/frontend-tests/android/pocket-navigation.test.js
@@ -80,12 +80,15 @@ function elementSource(html, tagName) {
 describe("Android Pocket navigation", () => {
   it("declares settings and onboarding language controls", () => {
     const html = readFileSync(new URL("../../dist/web/index.html", import.meta.url), "utf8");
+    const onboarding = readFileSync(new URL("../../dist/web/js/onboarding.js", import.meta.url), "utf8");
 
     openingTagByAttribute(html, "select", "id", "pref-locale-settings");
     openingTagByAttribute(html, "select", "id", "pref-learning-language-settings");
-    openingTagByAttribute(html, "dialog", "id", "language-onboarding-dialog");
-    openingTagByAttribute(html, "select", "id", "pref-locale-onboarding");
-    openingTagByAttribute(html, "img", "data-language-flag", "learning");
+    // The onboarding dialog is built at boot by renderLanguageOnboardingDialog()
+    // (port of #127 P1) — its contract lives in the renderer source.
+    assert.match(onboarding, /dialog\.id = "language-onboarding-dialog"/);
+    openingTagByAttribute(onboarding, "select", "id", "pref-locale-onboarding");
+    openingTagByAttribute(onboarding, "img", "data-language-flag", "learning");
   });
 
   it("includes Discover and Export in the Pocket navigation drawer", () => {

--- a/frontend-tests/shared/dialog-ports.test.js
+++ b/frontend-tests/shared/dialog-ports.test.js
@@ -275,3 +275,40 @@ describe("toast renderer (toast.ts)", () => {
     assertBootOrder("renderToast();", "toast", "div");
   });
 });
+
+describe("language-onboarding dialog renderer (onboarding.ts)", () => {
+  it("builds the dialog once with the audited ids and i18n attributes", async () => {
+    const document = fakeDocument();
+    const { renderLanguageOnboardingDialog } = await evaluateWithMocks("dist/web/js/onboarding.js", {
+      "./state.js": { state: { preferences: { locale: "en", learningLanguage: "de" } }, saveState: async () => {}, switchLearningLanguage: () => {} },
+      "./i18n.js": { t: (key) => key, loadLocale: async () => {}, applyTranslations: () => {} },
+      "./render.js": { render: () => {} },
+      "./preferences.js": { applyPreferences: () => {}, syncSettingsControls: () => {} },
+      "./platform.js": { applyPlatformUi: () => {} },
+      "./toast.js": { showToast: () => {} }
+    }, { document, HTMLDialogElement: HTMLDialogElementInstance });
+
+    const dialog = renderLanguageOnboardingDialog();
+    assert.equal(dialog.id, "language-onboarding-dialog");
+    assert.equal(dialog.className, "panel language-onboarding-dialog");
+    assert.equal(dialog.attrs["aria-labelledby"], "language-onboarding-title");
+    assert.equal(document.bodyChildren.length, 1);
+    for (const id of [
+      "language-onboarding-title",
+      "language-onboarding-done",
+      "pref-locale-onboarding",
+      "pref-learning-language-onboarding"
+    ]) {
+      assert.match(dialog.innerHTML, new RegExp(`id="${id}"`), `missing #${id}`);
+    }
+    assert.match(dialog.innerHTML, /data-i18n="onboarding\.languageHeading"/);
+    assert.match(dialog.innerHTML, /data-i18n-attr="aria-label=settings\.interfaceLanguageTitle"/);
+    assert.equal((dialog.innerHTML.match(/<option value="/g) || []).length, 23);
+    assert.equal(renderLanguageOnboardingDialog(), dialog, "render must be idempotent");
+    assert.equal(document.bodyChildren.length, 1);
+  });
+
+  it("keeps the dialog out of static HTML and renders it before cacheElements", () => {
+    assertBootOrder("renderLanguageOnboardingDialog();", "language-onboarding-dialog");
+  });
+});

--- a/frontend-tests/shared/dialog-ports.test.js
+++ b/frontend-tests/shared/dialog-ports.test.js
@@ -57,9 +57,18 @@ function fakeDocument() {
     id: "",
     className: "",
     innerHTML: "",
+    textContent: "",
+    type: "",
+    children: [],
+    listeners: {},
     attrs: {},
     setAttribute(name, value) { this.attrs[name] = String(value); },
-    appendChild() {}
+    appendChild(child) { this.children.push(child); },
+    addEventListener(type, listener) { (this.listeners[type] ??= []).push(listener); },
+    querySelector(selector) {
+      const id = selector.replace(/^#/, "");
+      return this.children.find((child) => child.id === id) ?? null;
+    }
   });
   return {
     registry,
@@ -76,10 +85,10 @@ const HTMLDialogElementInstance = {
 
 const tIdentity = { t: (key) => key };
 
-function assertBootOrder(rendererCall, dialogId) {
+function assertBootOrder(rendererCall, elementId, tag = "dialog") {
   const html = read("dist/web/index.html");
   const app = read("dist/web/app.js");
-  assert.doesNotMatch(html, new RegExp(`<dialog id="${dialogId}"`));
+  assert.doesNotMatch(html, new RegExp(`<${tag} id="${elementId}"`));
   const renderAt = app.indexOf(rendererCall);
   const cacheAt = app.indexOf("cacheElements();");
   assert.ok(renderAt >= 0, `${rendererCall} must be called in app boot`);
@@ -238,5 +247,31 @@ describe("update dialog renderer (update-checker.ts)", () => {
 
   it("keeps the dialog out of static HTML and renders it before cacheElements", () => {
     assertBootOrder("renderUpdateDialog();", "update-dialog");
+  });
+});
+
+describe("toast renderer (toast.ts)", () => {
+  it("builds the toast once with the audited ids, i18n attributes and close binding", async () => {
+    const document = fakeDocument();
+    const { renderToast } = await evaluateWithMocks("dist/web/js/toast.js", {}, { document, HTMLDialogElement: HTMLDialogElementInstance });
+
+    const toast = renderToast();
+    assert.equal(toast.id, "toast");
+    assert.equal(toast.className, "toast");
+    assert.equal(toast.attrs["role"], "status");
+    assert.equal(document.bodyChildren.length, 1);
+    assert.equal(toast.children.length, 2);
+    assert.equal(toast.children[0].id, "toast-message");
+    const close = toast.children[1];
+    assert.equal(close.id, "toast-close");
+    assert.equal(close.className, "toast-close");
+    assert.equal(close.attrs["data-i18n-attr"], "aria-label=reader.close");
+    assert.equal(typeof close.listeners.click?.[0], "function", "close button must hide the toast");
+    assert.equal(renderToast(), toast, "render must be idempotent");
+    assert.equal(document.bodyChildren.length, 1);
+  });
+
+  it("keeps the toast out of static HTML and renders it before cacheElements", () => {
+    assertBootOrder("renderToast();", "toast", "div");
   });
 });

--- a/frontend-tests/shared/language-options.test.js
+++ b/frontend-tests/shared/language-options.test.js
@@ -6,12 +6,13 @@ const { APP_LOCALES, LEARNING_LANGUAGES } = await import("../../dist/web/js/cons
 const { normalizeState } = await import("../../dist/web/js/state/normalize.js");
 
 const html = fs.readFileSync("dist/web/index.html", "utf8");
+const onboardingSource = fs.readFileSync("dist/web/js/onboarding.js", "utf8");
 const discoverView = fs.readFileSync("dist/web/js/views/discover.js", "utf8");
 const discoverEvents = fs.readFileSync("dist/web/js/events/discover.js", "utf8");
 const defaults = fs.readFileSync("dist/web/js/state/defaults.js", "utf8");
 
-function selectBody(id) {
-  const match = html.match(new RegExp(`<select id="${id}"[\\s\\S]*?<\\/select>`));
+function selectBody(source, id) {
+  const match = source.match(new RegExp(`<select id="${id}"[\\s\\S]*?<\\/select>`));
   assert.ok(match, `missing select: ${id}`);
   return match[0];
 }
@@ -22,15 +23,19 @@ function optionValues(selectHtml) {
 
 describe("language selectors", () => {
   it("keeps app locale selectors limited to shipped locale files", () => {
-    for (const id of ["pref-locale-sidebar", "pref-locale-settings", "pref-locale-onboarding"]) {
-      assert.deepEqual(optionValues(selectBody(id)), APP_LOCALES);
+    for (const id of ["pref-locale-sidebar", "pref-locale-settings"]) {
+      assert.deepEqual(optionValues(selectBody(html, id)), APP_LOCALES);
     }
+    // The onboarding dialog is built at boot by renderLanguageOnboardingDialog()
+    // (port of #127 P1) — its selects live in the renderer source.
+    assert.deepEqual(optionValues(selectBody(onboardingSource, "pref-locale-onboarding")), APP_LOCALES);
   });
 
   it("offers every learning profile in every learning-language selector", () => {
-    for (const id of ["pref-learning-language-sidebar", "pref-learning-language-settings", "pref-learning-language-onboarding"]) {
-      assert.deepEqual(optionValues(selectBody(id)), LEARNING_LANGUAGES);
+    for (const id of ["pref-learning-language-sidebar", "pref-learning-language-settings"]) {
+      assert.deepEqual(optionValues(selectBody(html, id)), LEARNING_LANGUAGES);
     }
+    assert.deepEqual(optionValues(selectBody(onboardingSource, "pref-learning-language-onboarding")), LEARNING_LANGUAGES);
   });
 
   it("uses the active learning profile instead of a separate discover language selector", () => {

--- a/frontend-tests/shared/persistence-lifecycle.test.js
+++ b/frontend-tests/shared/persistence-lifecycle.test.js
@@ -117,7 +117,7 @@ async function loadAppHarness({
 
   await evaluateWithMocks("../../dist/web/app.js", {
     "./js/dom.js": { cacheElements: noOp, els: {} },
-    "./js/toast.js": { showToast: noOp },
+    "./js/toast.js": { showToast: noOp, renderToast: noOp },
     "./js/events.js": { bindEvents: noOp },
     "./js/preferences.js": { applyPreferences, setSyncStatus: noOp, syncSettingsControls: noOp },
     "./js/books.js": {

--- a/frontend-tests/shared/persistence-lifecycle.test.js
+++ b/frontend-tests/shared/persistence-lifecycle.test.js
@@ -168,7 +168,8 @@ async function loadAppHarness({
     console
   }, {
     "./js/views/reader.js": { bindReaderEvents: noOp },
-    "./js/update-checker.js": { checkForUpdates: noOp, renderUpdateDialog: noOp }
+    "./js/update-checker.js": { checkForUpdates: noOp, renderUpdateDialog: noOp },
+    "./js/onboarding.js": { renderLanguageOnboardingDialog: noOp }
   });
 
   return {

--- a/frontend-tests/shared/persistence-lifecycle.test.js
+++ b/frontend-tests/shared/persistence-lifecycle.test.js
@@ -169,7 +169,8 @@ async function loadAppHarness({
   }, {
     "./js/views/reader.js": { bindReaderEvents: noOp },
     "./js/update-checker.js": { checkForUpdates: noOp, renderUpdateDialog: noOp },
-    "./js/onboarding.js": { renderLanguageOnboardingDialog: noOp }
+    "./js/onboarding.js": { renderLanguageOnboardingDialog: noOp },
+    "./js/youglish.js": { renderYouGlishModal: noOp, openYouGlish: noOp, closeYouGlish: noOp, refreshYouGlishTheme: noOp }
   });
 
   return {

--- a/frontend-tests/shared/repo-validation.test.js
+++ b/frontend-tests/shared/repo-validation.test.js
@@ -499,6 +499,11 @@ describe("repository validation wiring", () => {
     "update-open", // update-checker.ts (renderUpdateDialog)
     "toast", // toast.ts (renderToast)
     "toast-message", // toast.ts (renderToast)
+    "language-onboarding-dialog", // onboarding.ts (renderLanguageOnboardingDialog)
+    "language-onboarding-title", // onboarding.ts (renderLanguageOnboardingDialog)
+    "language-onboarding-done", // onboarding.ts (renderLanguageOnboardingDialog)
+    "pref-locale-onboarding", // onboarding.ts (renderLanguageOnboardingDialog)
+    "pref-learning-language-onboarding", // onboarding.ts (renderLanguageOnboardingDialog)
   ]);
 
   it("keeps every byId target in dom.ts present in index.html or on the audited TS-created allowlist", () => {

--- a/frontend-tests/shared/repo-validation.test.js
+++ b/frontend-tests/shared/repo-validation.test.js
@@ -497,6 +497,8 @@ describe("repository validation wiring", () => {
     "update-skip", // update-checker.ts (renderUpdateDialog)
     "update-disable", // update-checker.ts (renderUpdateDialog)
     "update-open", // update-checker.ts (renderUpdateDialog)
+    "toast", // toast.ts (renderToast)
+    "toast-message", // toast.ts (renderToast)
   ]);
 
   it("keeps every byId target in dom.ts present in index.html or on the audited TS-created allowlist", () => {

--- a/frontend-tests/shared/ui-events.test.js
+++ b/frontend-tests/shared/ui-events.test.js
@@ -2,7 +2,6 @@ import { after, describe, it } from "node:test";
 import assert from "node:assert/strict";
 
 const documentListeners = new Map();
-let closeToast;
 
 globalThis.window = {
   WH_TOKEN: "test-token",
@@ -19,17 +18,12 @@ globalThis.localStorage = {
 };
 globalThis.document = {
   addEventListener(type, listener) { documentListeners.set(type, listener); },
-  getElementById(id) {
-    if (id !== "toast-close") return null;
-    return {
-      addEventListener(type, listener) {
-        if (type === "click") closeToast = listener;
-      },
-    };
-  },
+  getElementById() { return null; },
+  querySelector() { return null; },
+  createElement() { return { setAttribute() {}, appendChild() {}, addEventListener() {} }; },
+  body: { appendChild() {} },
 };
 
-const { els } = await import("../../dist/web/js/dom.js");
 const { showToast } = await import("../../dist/web/js/toast.js");
 
 describe("shared UI event behavior", () => {
@@ -45,17 +39,17 @@ describe("shared UI event behavior", () => {
     Object.defineProperty(toast, "textContent", {
       set() { throw new Error("replacing toast children removes the close button"); },
     });
-    els.toast = toast;
-    els.toastMessage = { textContent: "" };
+    const toastMessage = { textContent: "" };
+    globalThis.document.getElementById = (id) => {
+      if (id === "toast") return toast;
+      if (id === "toast-message") return toastMessage;
+      return null;
+    };
 
-    documentListeners.get("DOMContentLoaded")?.();
     showToast("Saved");
 
-    assert.equal(els.toastMessage.textContent, "Saved");
+    assert.equal(toastMessage.textContent, "Saved");
     assert.equal(visible, true);
-    assert.equal(typeof closeToast, "function");
-    closeToast();
-    assert.equal(visible, false);
   });
 
   it("imports an image after the file input change event", async () => {
@@ -108,5 +102,5 @@ describe("shared UI event behavior", () => {
 });
 
 after(() => {
-  closeToast?.();
+  documentListeners.clear();
 });

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -11,7 +11,7 @@ import { clearPendingDelta, flushPendingDeltaToLocalStorage, readPendingDelta, s
 import { bindLibraryEvents, renderDeleteBookDialog, renderLibrary } from "./js/views/library.js";
 import { renderReview, renderVocabulary } from "./js/views/vocabulary.js";
 import { applyPlatformUi, detectPlatform, isAndroidPlatform, openAndroidUrl } from "./js/platform.js";
-import { refreshYouGlishTheme } from "./js/youglish.js";
+import { refreshYouGlishTheme, renderYouGlishModal } from "./js/youglish.js";
 import { fetchWithTimeout } from "./js/request.js";
 import { renderBookmarksDialog } from "./js/reader/bookmarks.js";
 import { renderMoveBookDialog } from "./js/events/move-book.js";
@@ -223,6 +223,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     renderDeleteBookDialog();
     renderUpdateDialog();
     renderLanguageOnboardingDialog();
+    renderYouGlishModal();
     cacheElements();
     startBridgeStateLoad();
     recoverPendingFlush();

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -1,5 +1,5 @@
 // Punkt wejścia aplikacji. Składa moduły, nie zawiera logiki domenowej.
-import { cacheElements, els } from "./js/dom.js";
+import { cacheElements } from "./js/dom.js";
 import { renderToast, showToast } from "./js/toast.js";
 import { bindEvents } from "./js/events.js";
 import { applyPreferences, syncSettingsControls } from "./js/preferences.js";
@@ -16,6 +16,7 @@ import { fetchWithTimeout } from "./js/request.js";
 import { renderBookmarksDialog } from "./js/reader/bookmarks.js";
 import { renderMoveBookDialog } from "./js/events/move-book.js";
 import { renderUpdateDialog } from "./js/update-checker.js";
+import { renderLanguageOnboardingDialog } from "./js/onboarding.js";
 
 detectPlatform();
 
@@ -194,9 +195,15 @@ function startBridgeStateLoad(): void {
 
 function showLanguageOnboardingIfNeeded() {
   if (!isAndroidPlatform() || state.preferences.languageOnboardingDone === true) return;
-  const dialog = els.languageOnboardingDialog;
-  const doneButton = els.languageOnboardingDone;
+  const dialog = document.getElementById("language-onboarding-dialog");
+  const doneButton = document.getElementById("language-onboarding-done");
   if (!(dialog instanceof HTMLDialogElement) || !(doneButton instanceof HTMLButtonElement)) return;
+  // The renderer seeds the selects at boot; re-sync in case the bridge
+  // snapshot changed the preferences between boot and first show.
+  const localeSelect = document.getElementById("pref-locale-onboarding") as HTMLSelectElement | null;
+  if (localeSelect) localeSelect.value = state.preferences.locale || "pl";
+  const learningSelect = document.getElementById("pref-learning-language-onboarding") as HTMLSelectElement | null;
+  if (learningSelect) learningSelect.value = state.preferences.learningLanguage || "en";
   dialog.addEventListener("cancel", (event) => event.preventDefault());
   doneButton.addEventListener("click", () => {
     state.preferences.languageOnboardingDone = true;
@@ -215,6 +222,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     renderMoveBookDialog();
     renderDeleteBookDialog();
     renderUpdateDialog();
+    renderLanguageOnboardingDialog();
     cacheElements();
     startBridgeStateLoad();
     recoverPendingFlush();

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -1,6 +1,6 @@
 // Punkt wejścia aplikacji. Składa moduły, nie zawiera logiki domenowej.
 import { cacheElements, els } from "./js/dom.js";
-import { showToast } from "./js/toast.js";
+import { renderToast, showToast } from "./js/toast.js";
 import { bindEvents } from "./js/events.js";
 import { applyPreferences, syncSettingsControls } from "./js/preferences.js";
 import { hydrateCurrentReaderText, loadBooksCatalog } from "./js/books.js";
@@ -210,6 +210,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   try {
     // TS-rendered dialogs (port of #127 P1): build them before cacheElements()
     // so every boot-time consumer and the els cache find the elements in DOM.
+    renderToast();
     renderBookmarksDialog();
     renderMoveBookDialog();
     renderDeleteBookDialog();

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -1463,11 +1463,6 @@
     </main>
   </div>
 
-  <div class="toast" id="toast" role="status" aria-live="polite">
-    <span id="toast-message"></span>
-    <button type="button" class="toast-close" id="toast-close" data-i18n-attr="aria-label=reader.close" aria-label="Close">×</button>
-  </div>
-
   <dialog id="language-onboarding-dialog" class="panel language-onboarding-dialog" aria-labelledby="language-onboarding-title">
     <div class="language-onboarding-body">
       <p class="eyebrow" data-i18n="onboarding.languageEyebrow">Word Hunter Pocket</p>

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -1463,53 +1463,6 @@
     </main>
   </div>
 
-  <dialog id="language-onboarding-dialog" class="panel language-onboarding-dialog" aria-labelledby="language-onboarding-title">
-    <div class="language-onboarding-body">
-      <p class="eyebrow" data-i18n="onboarding.languageEyebrow">Word Hunter Pocket</p>
-      <h2 id="language-onboarding-title" data-i18n="onboarding.languageHeading">Choose your languages</h2>
-      <p class="muted-copy" data-i18n="onboarding.languageCopy">Pick the app language and the language profile you want to learn first. You can change both later in Settings.</p>
-      <label class="language-setting-row language-onboarding-row">
-        <span class="language-setting-title" data-i18n="settings.interfaceLanguageTitle">App interface language</span>
-        <span class="language-select-wrap">
-          <img class="language-select-flag" data-language-flag="locale" src="flags/en.svg" alt="" aria-hidden="true">
-          <select id="pref-locale-onboarding" aria-label="App interface language" data-i18n-attr="aria-label=settings.interfaceLanguageTitle">
-            <option value="pl" data-i18n="languages.pl">Polish</option>
-            <option value="en" data-i18n="languages.en">English</option>
-            <option value="de" data-i18n="languages.de">German</option>
-            <option value="es" data-i18n="languages.es">Spanish</option>
-            <option value="fr" data-i18n="languages.fr">French</option>
-            <option value="it" data-i18n="languages.it">Italian</option>
-            <option value="uk" data-i18n="languages.uk">Українська</option>
-            <option value="ru" data-i18n="languages.ru">Muscovite State</option>
-            <option value="ja" data-i18n="languages.ja">Japanese</option>
-            <option value="zh" data-i18n="languages.zh">Chinese (Simplified)</option>
-          </select>
-        </span>
-      </label>
-      <label class="language-setting-row language-onboarding-row">
-        <span class="language-setting-title" data-i18n="settings.learningLanguageTitle">Learning language (profile)</span>
-        <span class="language-select-wrap">
-          <img class="language-select-flag" data-language-flag="learning" src="flags/de.svg" alt="" aria-hidden="true">
-          <select id="pref-learning-language-onboarding" aria-label="Learning language (profile)" data-i18n-attr="aria-label=settings.learningLanguageTitle">
-            <option value="en" data-i18n="languages.en">English</option>
-            <option value="de" data-i18n="languages.de">German</option>
-            <option value="es" data-i18n="languages.es">Spanish</option>
-            <option value="it" data-i18n="languages.it">Italian</option>
-            <option value="fr" data-i18n="languages.fr">French</option>
-            <option value="pl" data-i18n="languages.pl">Polish</option>
-            <option value="uk" data-i18n="languages.uk">Українська</option>
-            <option value="ru" data-i18n="languages.ru">Muscovite State</option>
-            <option value="ja" data-i18n="languages.ja">Japanese</option>
-            <option value="zh" data-i18n="languages.zh">Chinese (Simplified)</option>
-            <option value="la" data-i18n="languages.la">Latin</option>
-            <option value="grc" data-i18n="languages.grc">Ancient Greek</option>
-            <option value="other" data-i18n="languages.other">Other</option>
-          </select>
-        </span>
-      </label>
-      <button id="language-onboarding-done" class="primary-button" type="button" data-i18n="onboarding.continue">Continue</button>
-    </div>
-  </dialog>
 
   <dialog id="youglish-modal" class="panel max-w-700" aria-labelledby="youglish-modal-title">
     <div class="dialog-header">

--- a/src/web/js/dom.ts
+++ b/src/web/js/dom.ts
@@ -220,7 +220,4 @@ export function cacheElements() {
   els.editBookText = byId("edit-book-text");
   els.editBookCancel = byId("edit-book-cancel");
   els.editBookSave = byId("edit-book-save");
-
-  els.toast = byId("toast");
-  els.toastMessage = byId("toast-message");
 }

--- a/src/web/js/dom.ts
+++ b/src/web/js/dom.ts
@@ -102,17 +102,13 @@ export function cacheElements() {
   els.prefLocales = [
     byId<HTMLSelectElement>("pref-locale-sidebar"),
     byId<HTMLSelectElement>("pref-locale-settings"),
-    byId<HTMLSelectElement>("pref-locale-onboarding"),
   ].filter(Boolean);
   els.prefLearningLanguages = [
     byId<HTMLSelectElement>("pref-learning-language-sidebar"),
     byId<HTMLSelectElement>("pref-learning-language-settings"),
-    byId<HTMLSelectElement>("pref-learning-language-onboarding"),
   ].filter(Boolean);
   els.prefLocale = els.prefLocales[0] || null;
   els.prefLearningLanguage = els.prefLearningLanguages[0] || null;
-  els.languageOnboardingDialog = byId("language-onboarding-dialog");
-  els.languageOnboardingDone = byId("language-onboarding-done");
   els.prefColorNew = byId("pref-color-new");
   els.prefColorLearning = byId("pref-color-learning");
   els.prefColorKnown = byId("pref-color-known");

--- a/src/web/js/onboarding.ts
+++ b/src/web/js/onboarding.ts
@@ -1,0 +1,112 @@
+/**
+ * Language-onboarding dialog (Android first run). Built once at app boot
+ * before cacheElements() (app.ts), so els-free consumers and the boot-time
+ * applyTranslations() pass find the elements in the DOM. The two selects
+ * bind their own change handlers here — they are intentionally left out of
+ * the shared prefLocales / prefLearningLanguages els arrays (dom.ts), whose
+ * loops drive the Settings dialog controls only (events/settings.ts,
+ * preferences.ts). The dialog open/close flow stays in app.ts
+ * (showLanguageOnboardingIfNeeded).
+ */
+import { state, saveState, switchLearningLanguage } from "./state.js";
+import { t, loadLocale, applyTranslations } from "./i18n.js";
+import { render } from "./render.js";
+import { applyPreferences, syncSettingsControls } from "./preferences.js";
+import { applyPlatformUi } from "./platform.js";
+import { showToast } from "./toast.js";
+
+/**
+ * Builds the language-onboarding dialog markup once (idempotent). Options
+ * are kept as literal markup (like the ported static block) so audits can
+ * diff them against the shipped locale lists.
+ */
+export function renderLanguageOnboardingDialog(): HTMLDialogElement {
+  const existing = document.getElementById("language-onboarding-dialog");
+  if (existing instanceof HTMLDialogElement) return existing;
+  if (existing) throw new TypeError("#language-onboarding-dialog must be a dialog element");
+
+  const dialog = document.createElement("dialog");
+  dialog.id = "language-onboarding-dialog";
+  dialog.className = "panel language-onboarding-dialog";
+  dialog.setAttribute("aria-labelledby", "language-onboarding-title");
+  dialog.innerHTML = `
+    <div class="language-onboarding-body">
+      <p class="eyebrow" data-i18n="onboarding.languageEyebrow">Word Hunter Pocket</p>
+      <h2 id="language-onboarding-title" data-i18n="onboarding.languageHeading">Choose your languages</h2>
+      <p class="muted-copy" data-i18n="onboarding.languageCopy">Pick the app language and the language profile you want to learn first. You can change both later in Settings.</p>
+      <label class="language-setting-row language-onboarding-row">
+        <span class="language-setting-title" data-i18n="settings.interfaceLanguageTitle">App interface language</span>
+        <span class="language-select-wrap">
+          <img class="language-select-flag" data-language-flag="locale" src="flags/en.svg" alt="" aria-hidden="true">
+          <select id="pref-locale-onboarding" aria-label="App interface language" data-i18n-attr="aria-label=settings.interfaceLanguageTitle">
+            <option value="pl" data-i18n="languages.pl">Polish</option>
+            <option value="en" data-i18n="languages.en">English</option>
+            <option value="de" data-i18n="languages.de">German</option>
+            <option value="es" data-i18n="languages.es">Spanish</option>
+            <option value="fr" data-i18n="languages.fr">French</option>
+            <option value="it" data-i18n="languages.it">Italian</option>
+            <option value="uk" data-i18n="languages.uk">Українська</option>
+            <option value="ru" data-i18n="languages.ru">Muscovite State</option>
+            <option value="ja" data-i18n="languages.ja">Japanese</option>
+            <option value="zh" data-i18n="languages.zh">Chinese (Simplified)</option>
+          </select>
+        </span>
+      </label>
+      <label class="language-setting-row language-onboarding-row">
+        <span class="language-setting-title" data-i18n="settings.learningLanguageTitle">Learning language (profile)</span>
+        <span class="language-select-wrap">
+          <img class="language-select-flag" data-language-flag="learning" src="flags/de.svg" alt="" aria-hidden="true">
+          <select id="pref-learning-language-onboarding" aria-label="Learning language (profile)" data-i18n-attr="aria-label=settings.learningLanguageTitle">
+            <option value="en" data-i18n="languages.en">English</option>
+            <option value="de" data-i18n="languages.de">German</option>
+            <option value="es" data-i18n="languages.es">Spanish</option>
+            <option value="it" data-i18n="languages.it">Italian</option>
+            <option value="fr" data-i18n="languages.fr">French</option>
+            <option value="pl" data-i18n="languages.pl">Polish</option>
+            <option value="uk" data-i18n="languages.uk">Українська</option>
+            <option value="ru" data-i18n="languages.ru">Muscovite State</option>
+            <option value="ja" data-i18n="languages.ja">Japanese</option>
+            <option value="zh" data-i18n="languages.zh">Chinese (Simplified)</option>
+            <option value="la" data-i18n="languages.la">Latin</option>
+            <option value="grc" data-i18n="languages.grc">Ancient Greek</option>
+            <option value="other" data-i18n="languages.other">Other</option>
+          </select>
+        </span>
+      </label>
+      <button id="language-onboarding-done" class="primary-button" type="button" data-i18n="onboarding.continue">Continue</button>
+    </div>
+  `;
+  document.body.appendChild(dialog);
+
+  // Keep the controls in sync with the current preferences (the shared
+  // syncSettingsControls() pass skips these selects) and apply the same
+  // change behavior the Settings dialog controls have.
+  const localeSelect = dialog.querySelector<HTMLSelectElement>("#pref-locale-onboarding");
+  const learningSelect = dialog.querySelector<HTMLSelectElement>("#pref-learning-language-onboarding");
+  if (localeSelect) {
+    localeSelect.value = state.preferences?.locale || "pl";
+    localeSelect.addEventListener("change", async () => {
+      const value = localeSelect.value;
+      state.preferences.locale = value;
+      saveState();
+      await loadLocale(value);
+      applyTranslations();
+      applyPlatformUi();
+      applyPreferences();
+      syncSettingsControls();
+      render();
+      showToast(t("toast.languageChanged", { name: t(`languages.${value}`) }));
+    });
+  }
+  if (learningSelect) {
+    learningSelect.value = state.preferences?.learningLanguage || "en";
+    learningSelect.addEventListener("change", () => {
+      switchLearningLanguage(learningSelect.value);
+      applyPreferences();
+      syncSettingsControls();
+      render();
+      showToast(t("toast.learningLanguageChanged"));
+    });
+  }
+  return dialog;
+}

--- a/src/web/js/toast.ts
+++ b/src/web/js/toast.ts
@@ -1,19 +1,47 @@
-import { els } from "./dom.js";
-
-type ToastElements = {
-  toast?: HTMLElement | null;
-  toastMessage?: HTMLElement | null;
-};
-
 export type ToastType = "error" | "success" | "info";
 
-const toastElements = els as ToastElements;
 let toastTimer: ReturnType<typeof setTimeout> | null = null;
 
+/**
+ * Builds the toast element once (idempotent). Called during app boot
+ * before cacheElements() (app.ts); the close button binds itself here, so
+ * the old DOMContentLoaded pass is not needed and the element is available
+ * to every consumer from boot on. data-i18n-attr is applied by the
+ * boot-time applyTranslations() pass.
+ */
+export function renderToast(): HTMLElement {
+  const existing = document.getElementById("toast");
+  if (existing) return existing;
+
+  const toast = document.createElement("div");
+  toast.id = "toast";
+  toast.className = "toast";
+  toast.setAttribute("role", "status");
+  toast.setAttribute("aria-live", "polite");
+
+  const message = document.createElement("span");
+  message.id = "toast-message";
+
+  const close = document.createElement("button");
+  close.type = "button";
+  close.className = "toast-close";
+  close.id = "toast-close";
+  close.setAttribute("data-i18n-attr", "aria-label=reader.close");
+  close.setAttribute("aria-label", "Close");
+  close.textContent = "×";
+  close.addEventListener("click", hideToast);
+
+  toast.appendChild(message);
+  toast.appendChild(close);
+  document.body.appendChild(toast);
+  return toast;
+}
+
 export function showToast(message: string, type: ToastType = "info") {
-  if (!toastElements.toast || !toastElements.toastMessage) return;
-  toastElements.toastMessage.textContent = message;
-  const toast = toastElements.toast;
+  const toast = document.getElementById("toast");
+  const toastMessage = document.getElementById("toast-message");
+  if (!toast || !toastMessage) return;
+  toastMessage.textContent = message;
   toast.classList.remove("toast-error", "toast-success", "toast-info");
   toast.classList.add(type === "error" ? "toast-error" : type === "success" ? "toast-success" : "toast-info");
   // Errors should be announced with alert semantics, not polite status.
@@ -25,12 +53,8 @@ export function showToast(message: string, type: ToastType = "info") {
 }
 
 function hideToast() {
-  if (!toastElements.toast) return;
-  toastElements.toast.classList.remove("visible");
+  const toast = document.getElementById("toast");
+  if (!toast) return;
+  toast.classList.remove("visible");
   clearTimeout(toastTimer);
 }
-
-document.addEventListener("DOMContentLoaded", () => {
-  const closeBtn = document.getElementById("toast-close");
-  if (closeBtn) closeBtn.addEventListener("click", hideToast);
-});

--- a/src/web/js/youglish.ts
+++ b/src/web/js/youglish.ts
@@ -269,21 +269,43 @@ export function refreshYouGlishTheme(): void {
   }
 }
 
-// Bind close events
-document.addEventListener("DOMContentLoaded", () => {
-  const closeBtn = document.getElementById("youglish-close");
-  const modal = document.getElementById("youglish-modal") as HTMLDialogElement | null;
+/**
+ * Builds the YouGlish modal markup once (idempotent) and binds its close
+ * surface (close button, backdrop click, cancel, close). Called during app
+ * boot before cacheElements() (app.ts); openYouGlish/closeYouGlish resolve
+ * the elements via getElementById, so the old DOMContentLoaded pass is gone.
+ */
+export function renderYouGlishModal(): HTMLDialogElement {
+  const existing = document.getElementById("youglish-modal");
+  if (existing instanceof HTMLDialogElement) return existing;
+  if (existing) throw new TypeError("#youglish-modal must be a dialog element");
+
+  const dialog = document.createElement("dialog");
+  dialog.id = "youglish-modal";
+  dialog.className = "panel max-w-700";
+  dialog.setAttribute("aria-labelledby", "youglish-modal-title");
+  dialog.innerHTML = `
+    <div class="dialog-header">
+      <h2 id="youglish-modal-title" data-i18n="reader.youglishModalTitle" class="dialog-title">Pronunciation (YouGlish)</h2>
+      <button type="button" id="youglish-close" class="icon-button" data-i18n-attr="title=reader.close">×</button>
+    </div>
+    <div id="youglish-modal-body" class="flex-center-p-1">
+      <div id="youglish-widget"></div>
+    </div>
+  `;
+  document.body.appendChild(dialog);
+
+  const closeBtn = dialog.querySelector<HTMLButtonElement>("#youglish-close");
   if (closeBtn) closeBtn.addEventListener("click", closeYouGlish);
-  if (modal) {
-    modal.addEventListener("click", (e) => {
-      if (e.target === modal) closeYouGlish();
-    });
-    modal.addEventListener("cancel", (event) => {
-      event.preventDefault();
-      closeYouGlish();
-    });
-    modal.addEventListener("close", () => {
-      if (youglishWidget) youglishWidget.pause();
-    });
-  }
-});
+  dialog.addEventListener("click", (e) => {
+    if (e.target === dialog) closeYouGlish();
+  });
+  dialog.addEventListener("cancel", (event) => {
+    event.preventDefault();
+    closeYouGlish();
+  });
+  dialog.addEventListener("close", () => {
+    if (youglishWidget) youglishWidget.pause();
+  });
+  return dialog;
+}

--- a/types/wordhunter-browser.d.ts
+++ b/types/wordhunter-browser.d.ts
@@ -353,7 +353,6 @@ interface WhDomCache {
     prefLearningLanguage?: HTMLSelectElement | null;
     prefTheme?: HTMLSelectElement | null;
     prefLearningColors?: HTMLInputElement[];
-    languageOnboardingDialog?: HTMLDialogElement | null;
     argosDownloadDialog?: HTMLDialogElement | null;
     discoverForm?: HTMLFormElement | null;
     discoverQuery?: HTMLInputElement | null;
@@ -398,7 +397,6 @@ interface WhDomCache {
     importModeSelect?: HTMLSelectElement | null;
     importYoutubeMode?: HTMLElement | null;
     importYoutubeStatus?: HTMLElement | null;
-    languageOnboardingDone?: HTMLElement | null;
     libraryFiltersToggle?: HTMLElement | null;
     libraryPanel?: HTMLElement | null;
     librarySidebarResizer?: HTMLElement | null;

--- a/types/wordhunter-browser.d.ts
+++ b/types/wordhunter-browser.d.ts
@@ -505,8 +505,6 @@ interface WhDomCache {
     reviewUpcoming?: HTMLElement | null;
     storageSummary?: HTMLElement | null;
     themeToggle?: HTMLElement | null;
-    toast?: HTMLElement | null;
-    toastMessage?: HTMLElement | null;
     trackingSummary?: HTMLElement | null;
     translatorAiExplain?: HTMLElement | null;
     translatorAiResult?: HTMLElement | null;


### PR DESCRIPTION
Part of #127 (P1 part 2: toast + language-onboarding + youglish-modal ported; add-word/argos/edit-book in follow-up commits on this branch) — P2/P3 tracked in the issue

Three of six P1-part-2 elements ported from static index.html markup to idempotent TS renderers (owner-module pattern from #222):
- toast → js/toast.ts renderToast() (els.toast/els.toastMessage dropped from dom.ts + WhDomCache)
- language-onboarding-dialog → js/onboarding.ts renderLanguageOnboardingDialog() (selects bound in the renderer, excluded from els.prefLocales/els.prefLearningLanguages loops)
- youglish-modal → js/youglish.ts renderYouGlishModal() (DOMContentLoaded pass replaced by boot call before cacheElements())

Each: createElement-if-absent idempotence, data-i18n/data-i18n-attr, aria-labelledby, TS_CREATED_IDS allowlist entries, dialog-ports.test.js sections (behavioral + static), consumer tests updated (ui-events, persistence-lifecycle mocks, pocket-navigation, language-options).

RED: 12/12 focused + 8/8 boot-harness on base. GREEN: 576/576, check:frontend clean, Rust 282/282.