### PR TITLE
fix(#127): P1 part 2 — port the Argos download dialog to a TS renderer

### DIFF
--- a/frontend-tests/desktop/desktop-reader.test.js
+++ b/frontend-tests/desktop/desktop-reader.test.js
@@ -842,11 +842,16 @@ describe("desktop reader markup and style contracts", () => {
   });
 
   it("defines a scrollable edit-book dialog layout", () => {
-    const dialog = elementById(html, "edit-book-dialog");
-    assert.equal(hasClass(dialog, "edit-book-dialog"), true);
-    elementByClass(dialog, "edit-book-body", "div");
-    elementById(dialog, "edit-book-save");
-    assert.equal(hasClass(elementById(dialog, "edit-book-cover-clear"), "edit-book-cover-clear"), true);
+    // The dialog markup itself is built at boot by renderEditBookDialog()
+    // (port of #127 P1), so its contract lives in the renderer source.
+    assert.doesNotMatch(html, /<dialog id="edit-book-dialog"/);
+    const editModalModule = readFileSync(new URL("../../dist/web/js/book-actions/edit-modal.js", import.meta.url), "utf8");
+    assert.match(editModalModule, /function renderEditBookDialog/);
+    assert.match(editModalModule, /dialog\.id = "edit-book-dialog"/);
+    assert.match(editModalModule, /className = "panel edit-book-dialog"/);
+    assert.match(editModalModule, /class="settings-body edit-book-body"/);
+    assert.match(editModalModule, /id="edit-book-save"/);
+    assert.match(editModalModule, /class="edit-book-cover-clear"/);
     assert.deepEqual(
       { display: cssDeclarations(css, ".edit-book-dialog[open]").display, direction: cssDeclarations(css, ".edit-book-dialog[open]")["flex-direction"] },
       { display: "flex", direction: "column" }

--- a/frontend-tests/shared/article-suggestions.test.js
+++ b/frontend-tests/shared/article-suggestions.test.js
@@ -110,8 +110,11 @@ describe("grammatical article suggestions", () => {
     const editor = readFileSync(new URL("../../dist/web/js/events/word-editor.js", import.meta.url), "utf8");
     const reader = readFileSync(new URL("../../dist/web/js/views/reader.js", import.meta.url), "utf8");
 
-    assert.match(html, /id="add-article-input"[^>]*type="text"/);
-    assert.match(html, /data-i18n="vocab\.addArticleLabel"/);
+    // The Add/Edit word dialog markup is built at boot by renderAddWordDialog()
+    // (port of #127 P1 part 2), so its contract lives in the renderer source.
+    assert.doesNotMatch(html, /id="add-article-input"/);
+    assert.match(editor, /id="add-article-input"[^>]*type="text"/);
+    assert.match(editor, /data-i18n="vocab\.addArticleLabel"/);
     assert.match(editor, /addArticleInput/);
     assert.match(editor, /delete entry\.article/);
     assert.match(reader, /data-suggest-article/);

--- a/frontend-tests/shared/dialog-ports.test.js
+++ b/frontend-tests/shared/dialog-ports.test.js
@@ -360,3 +360,81 @@ describe("add-word dialog renderer (events/word-editor.ts)", () => {
     assertBootOrder("renderAddWordDialog();", "add-word-dialog");
   });
 });
+
+describe("argos download dialog renderer (events/settings.ts)", () => {
+  it("builds the dialog once with the audited ids and i18n attributes", async () => {
+    const document = fakeDocument();
+    const { renderArgosDownloadDialog } = await evaluateWithMocks("dist/web/js/events/settings.js", {
+      "../state.js": {
+        applyBridgeSnapshotToState: () => false,
+        flushAllPendingFrontendState: async () => {},
+        getDurableStateRevision: () => 0,
+        runExclusiveStateWrite: async (fn) => fn(),
+        state: {},
+        saveState: async () => {},
+        switchLearningLanguage: () => {}
+      },
+      "../dom.js": { els: {} },
+      "../i18n.js": { t: (key) => key, loadLocale: async () => {}, applyTranslations: () => {} },
+      "../render.js": { render: () => {} },
+      "../views/library.js": { renderLibrary: () => {} },
+      "../reader/renderer.js": { getTextById: () => null, renderReader: () => {} },
+      "../reader/word-panel.js": { renderWordPanel: () => {} },
+      "../views/vocabulary.js": { renderReview: () => {} },
+      "../views/discover.js": { renderDiscover: () => {} },
+      "../preferences.js": {
+        applyPreferences: () => {},
+        syncSettingsControls: () => {},
+        updatePreferenceValue: async () => {},
+        resetPreferences: async () => {},
+        setReaderFontSize: () => {},
+        setUiScale: () => {}
+      },
+      "../toast.js": { showToast: () => {} },
+      "../sync-actions.js": {
+        clearWords: async () => {},
+        clearLibrary: async () => {},
+        exportAnkiTsv: async () => {},
+        importAnkiTsv: async () => {},
+        exportTransfer: async () => {},
+        importTransfer: async () => {}
+      },
+      "../store-bridge.js": { acknowledgeBackendSnapshot: () => {}, loadBackendSnapshot: async () => {} },
+      "../dialog-backdrop.js": { registerUnsavedDialog: () => {}, showConfirmDialog: async () => true },
+      "../loading.js": { setElementBusy: () => {} },
+      "../platform.js": { applyPlatformUi: () => {}, isAndroidPlatform: () => false },
+      "../constants.js": { OFFLINE_TRANSLATOR_LANGUAGES: ["en", "pl", "de", "es", "fr", "zh"] },
+      "../translator-preferences.js": {
+        normalizeTranslationLanguageCode: (value) => value,
+        normalizeTranslatorTextPreference: (key, value) => value,
+        resolveProfileTranslationPair: () => ({ fromCode: "en", toCode: "pl", configured: true })
+      },
+      "../ai-explainer.js": { normalizeAiTextPreference: (value) => value },
+      "../state/normalize.js": { normalizeSelectedWordPanelItems: (items) => items },
+      "../reader/bookmarks.js": { remapReaderBookmarksForAlgorithm: (bookmarks) => bookmarks }
+    }, { document, HTMLDialogElement: HTMLDialogElementInstance });
+
+    const dialog = renderArgosDownloadDialog();
+    assert.equal(dialog.id, "argos-download-dialog");
+    assert.equal(dialog.className, "panel dialog-500");
+    assert.equal(dialog.attrs["aria-labelledby"], "argos-download-title");
+    assert.equal(document.bodyChildren.length, 1);
+    for (const id of [
+      "argos-download-title",
+      "argos-languages-list",
+      "argos-download-cancel",
+      "argos-download-confirm"
+    ]) {
+      assert.match(dialog.innerHTML, new RegExp(`id="${id}"`), `missing #${id}`);
+    }
+    assert.match(dialog.innerHTML, /data-i18n="settings\.argosDownloadTitle"/);
+    assert.match(dialog.innerHTML, /data-i18n="settings\.argosDownloadConfirm"/);
+    assert.match(dialog.innerHTML, /data-i18n="languages\.en"/);
+    assert.equal(renderArgosDownloadDialog(), dialog, "render must be idempotent");
+    assert.equal(document.bodyChildren.length, 1);
+  });
+
+  it("keeps the dialog out of static HTML and renders it before cacheElements", () => {
+    assertBootOrder("renderArgosDownloadDialog();", "argos-download-dialog");
+  });
+});

--- a/frontend-tests/shared/dialog-ports.test.js
+++ b/frontend-tests/shared/dialog-ports.test.js
@@ -438,3 +438,52 @@ describe("argos download dialog renderer (events/settings.ts)", () => {
     assertBootOrder("renderArgosDownloadDialog();", "argos-download-dialog");
   });
 });
+
+describe("edit-book dialog renderer (book-actions/edit-modal.ts)", () => {
+  it("builds the dialog once with the audited ids and i18n attributes", async () => {
+    const document = fakeDocument();
+    const { renderEditBookDialog } = await evaluateWithMocks("dist/web/js/book-actions/edit-modal.js", {
+      "../state.js": { state: {} },
+      "../toast.js": { showToast: () => {} },
+      "../books.js": { bookTexts: new Map(), findBookById: () => null, loadCustomTextContent: async () => "" },
+      "../vocab-index-client.js": { invalidateBookId: () => {} },
+      "../utils.js": { formatTagList: () => "", parseTagList: () => [] },
+      "../i18n.js": { t: (key) => key },
+      "../views/library.js": { renderLibrary: () => {} },
+      "../reader/renderer.js": { renderReader: () => {} },
+      "../bridge-commit.js": { reloadBridgeSnapshot: async () => {}, saveStateAndReloadBridge: async () => {} },
+      "../store-bridge.js": { upsertStoredText: async () => {} }
+    }, { document, HTMLDialogElement: HTMLDialogElementInstance });
+
+    const dialog = renderEditBookDialog();
+    assert.equal(dialog.id, "edit-book-dialog");
+    assert.equal(dialog.className, "panel edit-book-dialog");
+    assert.equal(dialog.attrs["aria-labelledby"], "edit-book-title-heading");
+    assert.equal(document.bodyChildren.length, 1);
+    for (const id of [
+      "edit-book-title-heading",
+      "edit-book-title",
+      "edit-book-author",
+      "edit-book-tags",
+      "edit-book-level",
+      "edit-book-cover-preview",
+      "edit-book-cover-img",
+      "edit-book-cover-clear",
+      "edit-book-cover-dropzone",
+      "edit-book-cover",
+      "edit-book-text",
+      "edit-book-cancel",
+      "edit-book-save"
+    ]) {
+      assert.match(dialog.innerHTML, new RegExp(`id="${id}"`), `missing #${id}`);
+    }
+    assert.match(dialog.innerHTML, /data-i18n="editBook\.title"/);
+    assert.match(dialog.innerHTML, /data-i18n-attr="placeholder=import\.tagsPlaceholder"/);
+    assert.equal(renderEditBookDialog(), dialog, "render must be idempotent");
+    assert.equal(document.bodyChildren.length, 1);
+  });
+
+  it("keeps the dialog out of static HTML and renders it before cacheElements", () => {
+    assertBootOrder("renderEditBookDialog();", "edit-book-dialog");
+  });
+});

--- a/frontend-tests/shared/dialog-ports.test.js
+++ b/frontend-tests/shared/dialog-ports.test.js
@@ -312,3 +312,51 @@ describe("language-onboarding dialog renderer (onboarding.ts)", () => {
     assertBootOrder("renderLanguageOnboardingDialog();", "language-onboarding-dialog");
   });
 });
+describe("add-word dialog renderer (events/word-editor.ts)", () => {
+  it("builds the dialog once with the audited ids and i18n attributes", async () => {
+    const document = fakeDocument();
+    const { renderAddWordDialog } = await evaluateWithMocks("dist/web/js/events/word-editor.js", {
+      "../state.js": { state: {}, saveState: async () => {} },
+      "../i18n.js": tIdentity,
+      "../toast.js": { showToast: () => {} },
+      "../icons.js": { statusIcon: () => "" },
+      "../constants.js": { STATUS_ORDER: ["new", "learning", "known", "ignored"] },
+      "../utils.js": { statusLabel: (status) => status, escapeHtml: (value) => value, escapeAttribute: (value) => value },
+      "../vocabulary/vocab-list.js": { invalidateVocabListCache: () => {} },
+      "../views/vocabulary.js": { getOrCreateEntry: () => ({}), renderVocabulary: () => {} },
+      "../vocabulary/entry-state.js": { setEntryStatus: () => "new" },
+      "../status-sounds.js": { playStatusSound: () => {} },
+      "../vocabulary/review-card.js": { invalidateReviewQueueCache: () => {} },
+      "../reader/smart-suggest.js": { invalidateSuggestIndex: () => {} },
+      "../dialog-backdrop.js": { registerUnsavedDialog: () => {} },
+      "./vocab-status.js": { VOCAB_STATUS_FILTERS: [] }
+    }, { document, HTMLDialogElement: HTMLDialogElementInstance });
+
+    const dialog = renderAddWordDialog();
+    assert.equal(dialog.id, "add-word-dialog");
+    assert.equal(dialog.className, "panel word-editor-dialog dialog-680");
+    assert.equal(dialog.attrs["aria-labelledby"], "add-word-dialog-title");
+    assert.equal(document.bodyChildren.length, 1);
+    for (const id of [
+      "add-word-dialog-title",
+      "add-word-input",
+      "add-article-input",
+      "add-translation-input",
+      "add-word-status-buttons",
+      "add-example-input",
+      "add-word-cancel",
+      "add-word-confirm",
+      "add-word-editing"
+    ]) {
+      assert.match(dialog.innerHTML, new RegExp(`id="${id}"`), `missing #${id}`);
+    }
+    assert.match(dialog.innerHTML, /data-i18n="vocab\.addWordTitle"/);
+    assert.match(dialog.innerHTML, /data-i18n="vocab\.addWordConfirm"/);
+    assert.equal(renderAddWordDialog(), dialog, "render must be idempotent");
+    assert.equal(document.bodyChildren.length, 1);
+  });
+
+  it("keeps the dialog out of static HTML and renders it before cacheElements", () => {
+    assertBootOrder("renderAddWordDialog();", "add-word-dialog");
+  });
+});

--- a/frontend-tests/shared/focused-regressions.test.js
+++ b/frontend-tests/shared/focused-regressions.test.js
@@ -611,21 +611,21 @@ describe("focused frontend regressions", () => {
 
     let closeCount = 0;
     const els = {
-      editBookTitle: { value: "" },
-      editBookAuthor: { value: "" },
-      editBookTags: { value: "" },
-      editBookLevel: { value: "" },
-      editBookText: { value: "", readOnly: false },
-      editBookCoverImg: { src: "" },
-      editBookCoverPreview: { hidden: true },
-      editBookDialog: { showModal() {}, close() { closeCount += 1; } },
-      editBookCancel: { disabled: false },
-      editBookSave: { disabled: false }
+      "edit-book-title": { value: "" },
+      "edit-book-author": { value: "" },
+      "edit-book-tags": { value: "" },
+      "edit-book-level": { value: "" },
+      "edit-book-text": { value: "", readOnly: false },
+      "edit-book-cover-img": { src: "" },
+      "edit-book-cover-preview": { hidden: true },
+      "edit-book-dialog": { showModal() {}, close() { closeCount += 1; } },
+      "edit-book-cancel": { disabled: false },
+      "edit-book-save": { disabled: false }
     };
+    const document = { getElementById: (id) => els[id] ?? null };
     const state = { customTexts: [{ id: "custom-1", title: "Title", text: "Body" }], userBooks: [] };
     const module = await evaluateWithMocks("dist/web/js/book-actions/edit-modal.js", {
       "../state.js": { state },
-      "../dom.js": { els },
       "../toast.js": { showToast() {} },
       "../books.js": {
         bookTexts: new Map([["custom-1", "stale body"]]),
@@ -639,10 +639,10 @@ describe("focused frontend regressions", () => {
       "../reader/renderer.js": { renderReader() {} },
       "../bridge-commit.js": { reloadBridgeSnapshot() {}, saveStateAndReloadBridge() {} },
       "../store-bridge.js": { upsertStoredText() {} }
-    }, { window: { __qtBridge: false } });
+    }, { window: { __qtBridge: false }, document });
 
     await module.openEditBookModal("custom-1");
-    assert.equal(els.editBookText.value, "fresh synced body");
+    assert.equal(els["edit-book-text"].value, "fresh synced body");
     module.setPendingEditCoverDataUrl("data:image/png;base64,test");
     assert.equal(module.isEditBookDirty(), true);
 
@@ -650,7 +650,7 @@ describe("focused frontend regressions", () => {
 
     assert.equal(module.pendingEditCoverDataUrl, null);
     assert.equal(module.isEditBookDirty(), false);
-    assert.equal(els.editBookText.readOnly, false);
+    assert.equal(els["edit-book-text"].readOnly, false);
     assert.equal(closeCount, 1);
   });
 
@@ -672,21 +672,21 @@ describe("focused frontend regressions", () => {
     let showCount = 0;
     const toasts = [];
     const els = {
-      editBookTitle: { value: "" },
-      editBookAuthor: { value: "" },
-      editBookTags: { value: "" },
-      editBookLevel: { value: "" },
-      editBookText: { value: "stale body", readOnly: false },
-      editBookCoverImg: { src: "" },
-      editBookCoverPreview: { hidden: true },
-      editBookDialog: { showModal() { showCount += 1; }, close() {} },
-      editBookCancel: { disabled: false },
-      editBookSave: { disabled: false }
+      "edit-book-title": { value: "" },
+      "edit-book-author": { value: "" },
+      "edit-book-tags": { value: "" },
+      "edit-book-level": { value: "" },
+      "edit-book-text": { value: "stale body", readOnly: false },
+      "edit-book-cover-img": { src: "" },
+      "edit-book-cover-preview": { hidden: true },
+      "edit-book-dialog": { showModal() { showCount += 1; }, close() {} },
+      "edit-book-cancel": { disabled: false },
+      "edit-book-save": { disabled: false }
     };
+    const document = { getElementById: (id) => els[id] ?? null };
     const state = { customTexts: [{ id: "custom-1", title: "Title" }], userBooks: [] };
     const module = await evaluateWithMocks("dist/web/js/book-actions/edit-modal.js", {
       "../state.js": { state },
-      "../dom.js": { els },
       "../toast.js": { showToast(message) { toasts.push(message); } },
       "../books.js": {
         bookTexts: new Map([["custom-1", "stale body"]]),
@@ -700,7 +700,7 @@ describe("focused frontend regressions", () => {
       "../reader/renderer.js": { renderReader() {} },
       "../bridge-commit.js": { reloadBridgeSnapshot() {}, saveStateAndReloadBridge() {} },
       "../store-bridge.js": { upsertStoredText() {} }
-    }, { window: { __qtBridge: true }, console: { warn() {} } });
+    }, { window: { __qtBridge: true }, document, console: { warn() {} } });
 
     await module.openEditBookModal("custom-1");
 

--- a/frontend-tests/shared/focused-regressions.test.js
+++ b/frontend-tests/shared/focused-regressions.test.js
@@ -766,9 +766,9 @@ describe("focused frontend regressions", () => {
 
   it("keeps Argos cancellation disabled and inert while installation is running", () => {
     const settings = read("dist/web/js/events/settings.js");
-    assert.match(settings, /function cancelArgosDownload\(\) \{[\s\S]*?if \(argosDownloadRunning\)\s*return;[\s\S]*?argosDownloadDialog\)\s*els\.argosDownloadDialog\.close\(\)/);
-    assert.match(settings, /argosDownloadRunning = true;[\s\S]*?argosDownloadCancel\)\s*els\.argosDownloadCancel\.disabled = true/);
-    assert.match(settings, /finally \{[\s\S]*?argosDownloadRunning = false;[\s\S]*?argosDownloadCancel\)\s*els\.argosDownloadCancel\.disabled = false/);
+    assert.match(settings, /function cancelArgosDownload\(\) \{[^]*?if \(argosDownloadRunning\)\s*return;[^]*?getElementById\("argos-download-dialog"\)\?\.close\(\)/);
+    assert.match(settings, /argosDownloadRunning = true;[^]*?argosCancelButton\)\s*argosCancelButton\.disabled = true/);
+    assert.match(settings, /finally \{[^]*?argosDownloadRunning = false;[^]*?argosCancelButton\)\s*argosCancelButton\.disabled = false/);
   });
 
   it("disables inaccessible Translator navigation and rejects its click handler", async () => {

--- a/frontend-tests/shared/persistence-lifecycle.test.js
+++ b/frontend-tests/shared/persistence-lifecycle.test.js
@@ -151,6 +151,7 @@ async function loadAppHarness({
     "./js/events/move-book.js": { renderMoveBookDialog: noOp },
     "./js/events/word-editor.js": { renderAddWordDialog: noOp },
     "./js/events/settings.js": { renderArgosDownloadDialog: noOp },
+    "./js/book-actions/edit-modal.js": { renderEditBookDialog: noOp },
     "./js/request.js": { fetchWithTimeout: async () => ({ ok: true, json: async () => ({}) }) },
     "./js/platform.js": {
       applyPlatformUi: noOp,

--- a/frontend-tests/shared/persistence-lifecycle.test.js
+++ b/frontend-tests/shared/persistence-lifecycle.test.js
@@ -150,6 +150,7 @@ async function loadAppHarness({
     "./js/reader/bookmarks.js": { renderBookmarksDialog: noOp },
     "./js/events/move-book.js": { renderMoveBookDialog: noOp },
     "./js/events/word-editor.js": { renderAddWordDialog: noOp },
+    "./js/events/settings.js": { renderArgosDownloadDialog: noOp },
     "./js/request.js": { fetchWithTimeout: async () => ({ ok: true, json: async () => ({}) }) },
     "./js/platform.js": {
       applyPlatformUi: noOp,

--- a/frontend-tests/shared/persistence-lifecycle.test.js
+++ b/frontend-tests/shared/persistence-lifecycle.test.js
@@ -149,6 +149,7 @@ async function loadAppHarness({
     "./js/youglish.js": { refreshYouGlishTheme: noOp },
     "./js/reader/bookmarks.js": { renderBookmarksDialog: noOp },
     "./js/events/move-book.js": { renderMoveBookDialog: noOp },
+    "./js/events/word-editor.js": { renderAddWordDialog: noOp },
     "./js/request.js": { fetchWithTimeout: async () => ({ ok: true, json: async () => ({}) }) },
     "./js/platform.js": {
       applyPlatformUi: noOp,

--- a/frontend-tests/shared/repo-validation.test.js
+++ b/frontend-tests/shared/repo-validation.test.js
@@ -514,6 +514,11 @@ describe("repository validation wiring", () => {
     "add-word-cancel", // events/word-editor.ts (renderAddWordDialog)
     "add-word-confirm", // events/word-editor.ts (renderAddWordDialog)
     "add-word-editing", // events/word-editor.ts (renderAddWordDialog)
+    "argos-download-dialog", // events/settings.ts (renderArgosDownloadDialog)
+    "argos-download-title", // events/settings.ts (renderArgosDownloadDialog)
+    "argos-languages-list", // events/settings.ts (renderArgosDownloadDialog)
+    "argos-download-cancel", // events/settings.ts (renderArgosDownloadDialog)
+    "argos-download-confirm", // events/settings.ts (renderArgosDownloadDialog)
   ]);
 
   it("keeps every byId target in dom.ts present in index.html or on the audited TS-created allowlist", () => {

--- a/frontend-tests/shared/repo-validation.test.js
+++ b/frontend-tests/shared/repo-validation.test.js
@@ -504,6 +504,16 @@ describe("repository validation wiring", () => {
     "language-onboarding-done", // onboarding.ts (renderLanguageOnboardingDialog)
     "pref-locale-onboarding", // onboarding.ts (renderLanguageOnboardingDialog)
     "pref-learning-language-onboarding", // onboarding.ts (renderLanguageOnboardingDialog)
+    "add-word-dialog", // events/word-editor.ts (renderAddWordDialog)
+    "add-word-dialog-title", // events/word-editor.ts (renderAddWordDialog)
+    "add-word-input", // events/word-editor.ts (renderAddWordDialog)
+    "add-article-input", // events/word-editor.ts (renderAddWordDialog)
+    "add-translation-input", // events/word-editor.ts (renderAddWordDialog)
+    "add-word-status-buttons", // events/word-editor.ts (renderAddWordDialog)
+    "add-example-input", // events/word-editor.ts (renderAddWordDialog)
+    "add-word-cancel", // events/word-editor.ts (renderAddWordDialog)
+    "add-word-confirm", // events/word-editor.ts (renderAddWordDialog)
+    "add-word-editing", // events/word-editor.ts (renderAddWordDialog)
   ]);
 
   it("keeps every byId target in dom.ts present in index.html or on the audited TS-created allowlist", () => {

--- a/frontend-tests/shared/repo-validation.test.js
+++ b/frontend-tests/shared/repo-validation.test.js
@@ -519,6 +519,20 @@ describe("repository validation wiring", () => {
     "argos-languages-list", // events/settings.ts (renderArgosDownloadDialog)
     "argos-download-cancel", // events/settings.ts (renderArgosDownloadDialog)
     "argos-download-confirm", // events/settings.ts (renderArgosDownloadDialog)
+    "edit-book-dialog", // book-actions/edit-modal.ts (renderEditBookDialog)
+    "edit-book-title-heading", // book-actions/edit-modal.ts (renderEditBookDialog)
+    "edit-book-title", // book-actions/edit-modal.ts (renderEditBookDialog)
+    "edit-book-author", // book-actions/edit-modal.ts (renderEditBookDialog)
+    "edit-book-tags", // book-actions/edit-modal.ts (renderEditBookDialog)
+    "edit-book-level", // book-actions/edit-modal.ts (renderEditBookDialog)
+    "edit-book-cover-preview", // book-actions/edit-modal.ts (renderEditBookDialog)
+    "edit-book-cover-img", // book-actions/edit-modal.ts (renderEditBookDialog)
+    "edit-book-cover-clear", // book-actions/edit-modal.ts (renderEditBookDialog)
+    "edit-book-cover-dropzone", // book-actions/edit-modal.ts (renderEditBookDialog)
+    "edit-book-cover", // book-actions/edit-modal.ts (renderEditBookDialog)
+    "edit-book-text", // book-actions/edit-modal.ts (renderEditBookDialog)
+    "edit-book-cancel", // book-actions/edit-modal.ts (renderEditBookDialog)
+    "edit-book-save", // book-actions/edit-modal.ts (renderEditBookDialog)
   ]);
 
   it("keeps every byId target in dom.ts present in index.html or on the audited TS-created allowlist", () => {

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -19,6 +19,7 @@ import { renderAddWordDialog } from "./js/events/word-editor.js";
 import { renderArgosDownloadDialog } from "./js/events/settings.js";
 import { renderUpdateDialog } from "./js/update-checker.js";
 import { renderLanguageOnboardingDialog } from "./js/onboarding.js";
+import { renderEditBookDialog } from "./js/book-actions/edit-modal.js";
 
 detectPlatform();
 
@@ -228,6 +229,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     renderYouGlishModal();
     renderAddWordDialog();
     renderArgosDownloadDialog();
+    renderEditBookDialog();
     cacheElements();
     startBridgeStateLoad();
     recoverPendingFlush();

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -15,6 +15,7 @@ import { refreshYouGlishTheme, renderYouGlishModal } from "./js/youglish.js";
 import { fetchWithTimeout } from "./js/request.js";
 import { renderBookmarksDialog } from "./js/reader/bookmarks.js";
 import { renderMoveBookDialog } from "./js/events/move-book.js";
+import { renderAddWordDialog } from "./js/events/word-editor.js";
 import { renderUpdateDialog } from "./js/update-checker.js";
 import { renderLanguageOnboardingDialog } from "./js/onboarding.js";
 
@@ -224,6 +225,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     renderUpdateDialog();
     renderLanguageOnboardingDialog();
     renderYouGlishModal();
+    renderAddWordDialog();
     cacheElements();
     startBridgeStateLoad();
     recoverPendingFlush();

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -16,6 +16,7 @@ import { fetchWithTimeout } from "./js/request.js";
 import { renderBookmarksDialog } from "./js/reader/bookmarks.js";
 import { renderMoveBookDialog } from "./js/events/move-book.js";
 import { renderAddWordDialog } from "./js/events/word-editor.js";
+import { renderArgosDownloadDialog } from "./js/events/settings.js";
 import { renderUpdateDialog } from "./js/update-checker.js";
 import { renderLanguageOnboardingDialog } from "./js/onboarding.js";
 
@@ -226,6 +227,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     renderLanguageOnboardingDialog();
     renderYouGlishModal();
     renderAddWordDialog();
+    renderArgosDownloadDialog();
     cacheElements();
     startBridgeStateLoad();
     recoverPendingFlush();

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -1570,41 +1570,6 @@
     </div>
   </dialog>
 
-  <dialog id="add-word-dialog" class="panel word-editor-dialog dialog-680" aria-labelledby="add-word-dialog-title">
-    <div class="panel-header">
-      <h2 id="add-word-dialog-title" data-i18n="vocab.addWordTitle">Add word</h2>
-    </div>
-    <div class="word-editor-body">
-      <div class="word-editor-grid">
-        <label class="word-editor-field word-editor-word">
-          <span data-i18n="vocab.addWordLabel">Word</span>
-          <input id="add-word-input" type="text" class="input" autocomplete="off" autofocus>
-        </label>
-        <label class="word-editor-field word-editor-article">
-          <span data-i18n="vocab.addArticleLabel">Article (optional)</span>
-          <input id="add-article-input" type="text" class="input" autocomplete="off" spellcheck="false">
-        </label>
-        <label class="word-editor-field word-editor-translation">
-          <span data-i18n="vocab.addTranslationLabel">Translation (optional)</span>
-          <input id="add-translation-input" type="text" class="input" autocomplete="off">
-        </label>
-        <fieldset class="word-editor-status">
-          <legend data-i18n="vocab.status">Status</legend>
-          <div id="add-word-status-buttons" class="status-options"></div>
-        </fieldset>
-        <label class="word-editor-field word-editor-example">
-          <span data-i18n="vocab.addExampleLabel">Example sentence (optional)</span>
-          <textarea id="add-example-input" class="input" rows="4" autocomplete="off" spellcheck="false"></textarea>
-        </label>
-      </div>
-      <div class="word-editor-actions">
-        <button id="add-word-cancel" class="secondary-button" data-i18n="moveBook.cancel">Cancel</button>
-        <button id="add-word-confirm" class="primary-button" data-i18n="vocab.addWordConfirm">Add</button>
-      </div>
-    </div>
-    <input id="add-word-editing" type="hidden" value="">
-  </dialog>
-
   <script type="module" src="app.js"></script>
 </body>
 </html>

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -1474,62 +1474,6 @@
     </div>
   </dialog>
 
-  <dialog id="edit-book-dialog" class="panel edit-book-dialog" aria-labelledby="edit-book-title-heading">
-    <div class="panel-header">
-      <h2 id="edit-book-title-heading" data-i18n="editBook.title">Edit book</h2>
-    </div>
-    <div class="settings-body edit-book-body">
-      <label class="setting-row edit-book-field">
-        <span data-i18n="editBook.titleLabel">Title</span>
-        <input id="edit-book-title" type="text" class="input w-100">
-      </label>
-      <label class="setting-row edit-book-field">
-        <span data-i18n="editBook.authorLabel">Author</span>
-        <input id="edit-book-author" type="text" class="input w-100">
-      </label>
-      <label class="setting-row edit-book-field">
-        <span data-i18n="editBook.tagsLabel">Tags</span>
-        <input id="edit-book-tags" type="text" class="input w-100" data-i18n-attr="placeholder=import.tagsPlaceholder">
-      </label>
-      <label class="setting-row edit-book-field">
-        <span data-i18n="editBook.levelLabel">Level</span>
-        <select id="edit-book-level" class="input w-100">
-          <option value="" data-i18n="library.levelAny">Any</option>
-          <option value="A1">A1</option>
-          <option value="A2">A2</option>
-          <option value="B1">B1</option>
-          <option value="B2">B2</option>
-          <option value="C1">C1</option>
-          <option value="C2">C2</option>
-        </select>
-      </label>
-      <div class="setting-row edit-book-field">
-        <span data-i18n="editBook.coverLabel">Cover</span>
-        <div class="edit-book-cover-row">
-          <div id="edit-book-cover-preview" class="edit-book-cover-preview" hidden>
-            <img id="edit-book-cover-img" src="" data-i18n-attr="alt=editBook.coverPreviewAlt" alt="Cover preview">
-            <button id="edit-book-cover-clear" class="edit-book-cover-clear" type="button" data-i18n-attr="title=editBook.deleteCover">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-14"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
-            </button>
-          </div>
-          <label for="edit-book-cover" class="edit-book-cover-dropzone" id="edit-book-cover-dropzone" data-i18n-attr="title=editBook.changeCover">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-28-muted-m-b-05"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect><circle cx="8.5" cy="8.5" r="1.5"></circle><polyline points="21 15 16 10 5 21"></polyline></svg>
-            <span data-i18n="import.coverPasteHint" class="fs-085-muted-center">Click to select or paste</span>
-            <input id="edit-book-cover" type="file" accept="image/*" class="visually-hidden">
-          </label>
-        </div>
-      </div>
-      <label class="setting-row edit-book-field edit-book-text-field">
-        <span data-i18n="editBook.textLabel">Text (You can paste images with Ctrl+V)</span>
-        <textarea id="edit-book-text" class="input" spellcheck="false"></textarea>
-      </label>
-      <div class="edit-book-actions">
-        <button id="edit-book-cancel" class="secondary-button" data-i18n="editBook.cancel">Cancel</button>
-        <button id="edit-book-save" class="primary-button" data-i18n="editBook.save">Save</button>
-      </div>
-    </div>
-  </dialog>
-
   <script type="module" src="app.js"></script>
 </body>
 </html>

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -1530,46 +1530,6 @@
     </div>
   </dialog>
 
-  <dialog id="argos-download-dialog" class="panel dialog-500" aria-labelledby="argos-download-title">
-    <div class="panel-header">
-      <h2 id="argos-download-title" data-i18n="settings.argosDownloadTitle">Download offline models</h2>
-    </div>
-    <div class="settings-body p-15-g-1">
-      <p class="muted-copy" data-i18n="settings.argosDownloadHint">Downloads local translation packages for the selected languages, including pairs with English and your learning language when available.</p>
-      <div id="argos-languages-list" class="stack-g-05">
-        <label class="status-check justify-start">
-          <input type="checkbox" value="en" checked>
-          <span data-i18n="languages.en">English</span>
-        </label>
-        <label class="status-check justify-start">
-          <input type="checkbox" value="pl" checked>
-          <span data-i18n="languages.pl">Polish</span>
-        </label>
-        <label class="status-check justify-start">
-          <input type="checkbox" value="de">
-          <span data-i18n="languages.de">German</span>
-        </label>
-        <label class="status-check justify-start">
-          <input type="checkbox" value="es">
-          <span data-i18n="languages.es">Spanish</span>
-        </label>
-        <label class="status-check justify-start">
-          <input type="checkbox" value="fr">
-          <span data-i18n="languages.fr">French</span>
-        </label>
-        <label class="status-check justify-start">
-          <input type="checkbox" value="zh">
-          <span data-i18n="languages.zh">Chinese (Simplified)</span>
-        </label>
-      </div>
-      <p data-i18n="settings.argosDownloadWarning" class="error-text">Note: downloading models will take a while. Do not close the app during the process.</p>
-      <div class="justify-end-m-t-1">
-        <button id="argos-download-cancel" class="secondary-button" data-i18n="moveBook.cancel">Cancel</button>
-        <button id="argos-download-confirm" class="primary-button" data-i18n="settings.argosDownloadConfirm">Download</button>
-      </div>
-    </div>
-  </dialog>
-
   <script type="module" src="app.js"></script>
 </body>
 </html>

--- a/src/web/js/book-actions/edit-modal.ts
+++ b/src/web/js/book-actions/edit-modal.ts
@@ -2,7 +2,6 @@
  * Edit-book modal: module state, dirty tracking, open/cancel/save, image paste.
  */
 import { state } from "../state.js";
-import { els as domElements } from "../dom.js";
 import { showToast as displayToast } from "../toast.js";
 import { bookTexts, findBookById, loadCustomTextContent } from "../books.js";
 import { invalidateBookId } from "../vocab-index-client.js";
@@ -13,29 +12,85 @@ import { renderReader } from "../reader/renderer.js";
 import { reloadBridgeSnapshot, saveStateAndReloadBridge } from "../bridge-commit.js";
 import { upsertStoredText } from "../store-bridge.js";
 
-interface EditBookElements {
-  editBookTitle: HTMLInputElement;
-  editBookAuthor: HTMLInputElement;
-  editBookTags?: HTMLInputElement;
-  editBookLevel?: HTMLSelectElement;
-  editBookText: HTMLTextAreaElement;
-  editBookCoverImg: HTMLImageElement;
-  editBookCoverPreview: HTMLElement;
-  editBookDialog: HTMLDialogElement;
-  editBookCancel?: HTMLButtonElement;
-  editBookSave?: HTMLButtonElement;
+/**
+ * Builds the edit-book dialog markup once (idempotent). Called during app
+ * boot before cacheElements() (app.ts); the edit-book consumers resolve the
+ * elements via getElementById (editBookEl), so boot order guarantees they
+ * exist.
+ */
+export function renderEditBookDialog(): HTMLDialogElement {
+  const existing = document.getElementById("edit-book-dialog");
+  if (existing instanceof HTMLDialogElement) return existing;
+  if (existing) throw new TypeError("#edit-book-dialog must be a dialog element");
+
+  const dialog = document.createElement("dialog");
+  dialog.id = "edit-book-dialog";
+  dialog.className = "panel edit-book-dialog";
+  dialog.setAttribute("aria-labelledby", "edit-book-title-heading");
+  dialog.innerHTML = `
+    <div class="panel-header">
+      <h2 id="edit-book-title-heading" data-i18n="editBook.title">Edit book</h2>
+    </div>
+    <div class="settings-body edit-book-body">
+      <label class="setting-row edit-book-field">
+        <span data-i18n="editBook.titleLabel">Title</span>
+        <input id="edit-book-title" type="text" class="input w-100">
+      </label>
+      <label class="setting-row edit-book-field">
+        <span data-i18n="editBook.authorLabel">Author</span>
+        <input id="edit-book-author" type="text" class="input w-100">
+      </label>
+      <label class="setting-row edit-book-field">
+        <span data-i18n="editBook.tagsLabel">Tags</span>
+        <input id="edit-book-tags" type="text" class="input w-100" data-i18n-attr="placeholder=import.tagsPlaceholder">
+      </label>
+      <label class="setting-row edit-book-field">
+        <span data-i18n="editBook.levelLabel">Level</span>
+        <select id="edit-book-level" class="input w-100">
+          <option value="" data-i18n="library.levelAny">Any</option>
+          <option value="A1">A1</option>
+          <option value="A2">A2</option>
+          <option value="B1">B1</option>
+          <option value="B2">B2</option>
+          <option value="C1">C1</option>
+          <option value="C2">C2</option>
+        </select>
+      </label>
+      <div class="setting-row edit-book-field">
+        <span data-i18n="editBook.coverLabel">Cover</span>
+        <div class="edit-book-cover-row">
+          <div id="edit-book-cover-preview" class="edit-book-cover-preview" hidden>
+            <img id="edit-book-cover-img" src="" data-i18n-attr="alt=editBook.coverPreviewAlt" alt="Cover preview">
+            <button id="edit-book-cover-clear" class="edit-book-cover-clear" type="button" data-i18n-attr="title=editBook.deleteCover">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-14"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
+            </button>
+          </div>
+          <label for="edit-book-cover" class="edit-book-cover-dropzone" id="edit-book-cover-dropzone" data-i18n-attr="title=editBook.changeCover">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-28-muted-m-b-05"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect><circle cx="8.5" cy="8.5" r="1.5"></circle><polyline points="21 15 16 10 5 21"></polyline></svg>
+            <span data-i18n="import.coverPasteHint" class="fs-085-muted-center">Click to select or paste</span>
+            <input id="edit-book-cover" type="file" accept="image/*" class="visually-hidden">
+          </label>
+        </div>
+      </div>
+      <label class="setting-row edit-book-field edit-book-text-field">
+        <span data-i18n="editBook.textLabel">Text (You can paste images with Ctrl+V)</span>
+        <textarea id="edit-book-text" class="input" spellcheck="false"></textarea>
+      </label>
+      <div class="edit-book-actions">
+        <button id="edit-book-cancel" class="secondary-button" data-i18n="editBook.cancel">Cancel</button>
+        <button id="edit-book-save" class="primary-button" data-i18n="editBook.save">Save</button>
+      </div>
+    </div>
+  `;
+  document.body.appendChild(dialog);
+  return dialog;
 }
 
-interface EditBookOriginalValues {
-  title: string;
-  author: string;
-  tags: string;
-  level: string;
-  text: string;
-  cover: string | null;
+/** Resolves an edit-book dialog element by id (rendered at boot, so present). */
+function editBookEl<T extends HTMLElement>(id: string): T | null {
+  return document.getElementById(id) as T | null;
 }
 
-const els = domElements as EditBookElements;
 const t = translate as (key: string, vars?: WhRecord) => string;
 const showToast = displayToast as (message: string, kind?: string) => void;
 
@@ -46,17 +101,26 @@ let editBookOriginalValues: EditBookOriginalValues | null = null;
 let editBookGeneration = 0;
 let editBookSaveRunning = false;
 
+interface EditBookOriginalValues {
+  title: string;
+  author: string;
+  tags: string;
+  level: string;
+  text: string;
+  cover: string | null;
+}
+
 export function setPendingEditCoverDataUrl(url: string | null): void {
   pendingEditCoverDataUrl = url;
 }
 
 export function isEditBookDirty(): boolean {
   if (!editBookOriginalValues) return false;
-  const title = els.editBookTitle.value;
-  const author = els.editBookAuthor.value;
-  const tags = els.editBookTags?.value || "";
-  const level = els.editBookLevel?.value || "";
-  const text = els.editBookText.value;
+  const title = editBookEl<HTMLInputElement>("edit-book-title")?.value ?? "";
+  const author = editBookEl<HTMLInputElement>("edit-book-author")?.value ?? "";
+  const tags = editBookEl<HTMLInputElement>("edit-book-tags")?.value ?? "";
+  const level = editBookEl<HTMLSelectElement>("edit-book-level")?.value ?? "";
+  const text = editBookEl<HTMLTextAreaElement>("edit-book-text")?.value ?? "";
   return title !== editBookOriginalValues.title
     || author !== editBookOriginalValues.author
     || tags !== editBookOriginalValues.tags
@@ -76,10 +140,19 @@ export async function openEditBookModal(id: string): Promise<void> {
   editingBookId = id;
   editingBookKind = customText ? "custom" : "user";
 
-  els.editBookTitle.value = book.title || "";
-  els.editBookAuthor.value = book.author || "";
-  if (els.editBookTags) els.editBookTags.value = formatTagList(book.tags);
-  if (els.editBookLevel) els.editBookLevel.value = book.level || "";
+  const titleInput = editBookEl<HTMLInputElement>("edit-book-title");
+  const authorInput = editBookEl<HTMLInputElement>("edit-book-author");
+  const tagsInput = editBookEl<HTMLInputElement>("edit-book-tags");
+  const levelSelect = editBookEl<HTMLSelectElement>("edit-book-level");
+  const textArea = editBookEl<HTMLTextAreaElement>("edit-book-text");
+  const coverImg = editBookEl<HTMLImageElement>("edit-book-cover-img");
+  const coverPreview = editBookEl<HTMLElement>("edit-book-cover-preview");
+  const dialog = editBookEl<HTMLDialogElement>("edit-book-dialog");
+
+  if (titleInput) titleInput.value = book.title || "";
+  if (authorInput) authorInput.value = book.author || "";
+  if (tagsInput) tagsInput.value = formatTagList(book.tags);
+  if (levelSelect) levelSelect.value = book.level || "";
 
   let customBody = "";
   if (customText) {
@@ -97,29 +170,31 @@ export async function openEditBookModal(id: string): Promise<void> {
     }
   }
   if (generation !== editBookGeneration || editingBookId !== id) return;
-  els.editBookText.value = customText ? customBody : bookTexts.get(id) || "";
-  els.editBookText.readOnly = editingBookKind !== "custom" || Array.isArray(customText?.pdfOcrPages);
+  if (textArea) {
+    textArea.value = customText ? customBody : bookTexts.get(id) || "";
+    textArea.readOnly = editingBookKind !== "custom" || Array.isArray(customText?.pdfOcrPages);
+  }
 
   const coverUrl = typeof book.coverDataUrl === "string" ? book.coverDataUrl : "";
   pendingEditCoverDataUrl = coverUrl;
   if (pendingEditCoverDataUrl) {
-    els.editBookCoverImg.src = pendingEditCoverDataUrl;
-    els.editBookCoverPreview.hidden = false;
+    if (coverImg) coverImg.src = pendingEditCoverDataUrl;
+    if (coverPreview) coverPreview.hidden = false;
   } else {
-    els.editBookCoverImg.src = "";
-    els.editBookCoverPreview.hidden = true;
+    if (coverImg) coverImg.src = "";
+    if (coverPreview) coverPreview.hidden = true;
   }
 
   editBookOriginalValues = {
-    title: els.editBookTitle.value,
-    author: els.editBookAuthor.value,
-    tags: els.editBookTags?.value || "",
-    level: els.editBookLevel?.value || "",
-    text: els.editBookText.value,
+    title: titleInput?.value ?? "",
+    author: authorInput?.value ?? "",
+    tags: tagsInput?.value || "",
+    level: levelSelect?.value || "",
+    text: textArea?.value ?? "",
     cover: pendingEditCoverDataUrl
   };
 
-  els.editBookDialog.showModal();
+  dialog?.showModal();
 }
 
 export function cancelEditBook(): void {
@@ -129,8 +204,9 @@ export function cancelEditBook(): void {
   pendingEditCoverDataUrl = null;
   editingBookId = null;
   editingBookKind = null;
-  if (els.editBookText) els.editBookText.readOnly = false;
-  els.editBookDialog.close();
+  const textArea = editBookEl<HTMLTextAreaElement>("edit-book-text");
+  if (textArea) textArea.readOnly = false;
+  editBookEl<HTMLDialogElement>("edit-book-dialog")?.close();
 }
 
 export async function saveEditedBook(): Promise<void> {
@@ -139,22 +215,30 @@ export async function saveEditedBook(): Promise<void> {
   const targetBookId = editingBookId;
   const customText = state.customTexts.find(t => t.id === targetBookId);
   const userBook = !customText ? state.userBooks.find((book) => book.id === targetBookId) : null;
-  if (els.editBookCancel) els.editBookCancel.disabled = true;
-  if (els.editBookSave) els.editBookSave.disabled = true;
+  const cancelButton = editBookEl<HTMLButtonElement>("edit-book-cancel");
+  const saveButton = editBookEl<HTMLButtonElement>("edit-book-save");
+  const titleInput = editBookEl<HTMLInputElement>("edit-book-title");
+  const authorInput = editBookEl<HTMLInputElement>("edit-book-author");
+  const tagsInput = editBookEl<HTMLInputElement>("edit-book-tags");
+  const levelSelect = editBookEl<HTMLSelectElement>("edit-book-level");
+  const textArea = editBookEl<HTMLTextAreaElement>("edit-book-text");
+  const dialog = editBookEl<HTMLDialogElement>("edit-book-dialog");
+  if (cancelButton) cancelButton.disabled = true;
+  if (saveButton) saveButton.disabled = true;
   if (!customText && !userBook) {
     editBookSaveRunning = false;
-    if (els.editBookCancel) els.editBookCancel.disabled = false;
-    if (els.editBookSave) els.editBookSave.disabled = false;
+    if (cancelButton) cancelButton.disabled = false;
+    if (saveButton) saveButton.disabled = false;
     return;
   }
 
-  const cleanTitle = els.editBookTitle.value.trim();
-  const cleanText = els.editBookText.value.trim();
+  const cleanTitle = (titleInput?.value ?? "").trim();
+  const cleanText = (textArea?.value ?? "").trim();
   if (!cleanTitle || (customText && !cleanText)) {
     showToast(t("toast.emptyFields"));
     editBookSaveRunning = false;
-    if (els.editBookCancel) els.editBookCancel.disabled = false;
-    if (els.editBookSave) els.editBookSave.disabled = false;
+    if (cancelButton) cancelButton.disabled = false;
+    if (saveButton) saveButton.disabled = false;
     return;
   }
 
@@ -162,10 +246,10 @@ export async function saveEditedBook(): Promise<void> {
     const nextCustomText = {
       ...customText,
       title: cleanTitle,
-      author: els.editBookAuthor.value.trim(),
-      tags: parseTagList(els.editBookTags?.value),
+      author: (authorInput?.value ?? "").trim(),
+      tags: parseTagList(tagsInput?.value),
       coverDataUrl: pendingEditCoverDataUrl,
-      level: els.editBookLevel?.value || "",
+      level: levelSelect?.value || "",
       updatedAt: new Date().toISOString()
     };
     try {
@@ -174,8 +258,8 @@ export async function saveEditedBook(): Promise<void> {
       console.warn("upsert_text failed", e);
       showToast(t("toast.saveUnavailable"), "error");
       editBookSaveRunning = false;
-      if (els.editBookCancel) els.editBookCancel.disabled = false;
-      if (els.editBookSave) els.editBookSave.disabled = false;
+      if (cancelButton) cancelButton.disabled = false;
+      if (saveButton) saveButton.disabled = false;
       return;
     }
     Object.assign(customText, nextCustomText);
@@ -184,10 +268,10 @@ export async function saveEditedBook(): Promise<void> {
   } else if (userBook) {
     Object.assign(userBook, {
       title: cleanTitle,
-      author: els.editBookAuthor.value.trim(),
-      tags: parseTagList(els.editBookTags?.value),
+      author: (authorInput?.value ?? "").trim(),
+      tags: parseTagList(tagsInput?.value),
       coverDataUrl: pendingEditCoverDataUrl,
-      level: els.editBookLevel?.value || "",
+      level: levelSelect?.value || "",
       updatedAt: new Date().toISOString()
     });
   }
@@ -202,8 +286,8 @@ export async function saveEditedBook(): Promise<void> {
     });
     showToast(t("toast.saveUnavailable"), "error");
     editBookSaveRunning = false;
-    if (els.editBookCancel) els.editBookCancel.disabled = false;
-    if (els.editBookSave) els.editBookSave.disabled = false;
+    if (cancelButton) cancelButton.disabled = false;
+    if (saveButton) saveButton.disabled = false;
     return;
   }
   renderLibrary();
@@ -213,13 +297,13 @@ export async function saveEditedBook(): Promise<void> {
   if (state.currentTextId === targetBookId && state.currentView === "reader") renderReader();
   showToast(t("toast.textSaved"));
   editBookOriginalValues = null;
-  if (els.editBookText) els.editBookText.readOnly = false;
-  els.editBookDialog.close();
+  if (textArea) textArea.readOnly = false;
+  dialog?.close();
   editingBookId = null;
   editingBookKind = null;
   editBookSaveRunning = false;
-  if (els.editBookCancel) els.editBookCancel.disabled = false;
-  if (els.editBookSave) els.editBookSave.disabled = false;
+  if (cancelButton) cancelButton.disabled = false;
+  if (saveButton) saveButton.disabled = false;
 }
 
 export async function pasteImageToEditBook(file: File): Promise<void> {
@@ -237,7 +321,8 @@ export async function pasteImageToEditBook(file: File): Promise<void> {
   reader.onload = async () => {
     if (generation !== editBookGeneration || editingBookId !== targetBookId) return;
     const base64Data = typeof reader.result === "string" ? reader.result : "";
-    const textarea = els.editBookText;
+    const textarea = editBookEl<HTMLTextAreaElement>("edit-book-text");
+    if (!textarea) return;
     const startPos = textarea.selectionStart;
     const endPos = textarea.selectionEnd;
     const textToInsert = `\n[IMG:${imgName}]\n`;

--- a/src/web/js/dom.ts
+++ b/src/web/js/dom.ts
@@ -158,10 +158,6 @@ export function cacheElements() {
   els.prefAiAutoTriggerRow = byId("pref-ai-auto-trigger-row");
   els.prefArgosAsDict = byId("pref-argos-as-dict");
   els.prefArgosAsDictRow = byId("pref-argos-as-dict-row");
-  els.argosDownloadDialog = byId("argos-download-dialog");
-  els.argosDownloadConfirm = byId("argos-download-confirm");
-  els.argosDownloadCancel = byId("argos-download-cancel");
-  els.argosLanguagesList = byId("argos-languages-list");
   els.prefDictionaryUrl = byId("pref-dictionary-url");
   els.prefDictionaryMode = byId("pref-dictionary-mode");
   els.prefYouglishMode = byId("pref-youglish-mode");

--- a/src/web/js/dom.ts
+++ b/src/web/js/dom.ts
@@ -199,17 +199,4 @@ export function cacheElements() {
   els.discoverClear = byId("discover-clear");
   els.discoverAddSelected = byId("discover-add-selected");
   els.userBooksList = byId("user-books-list");
-  
-  els.editBookDialog = byId("edit-book-dialog");
-  els.editBookTitle = byId("edit-book-title");
-  els.editBookAuthor = byId("edit-book-author");
-  els.editBookTags = byId("edit-book-tags");
-  els.editBookLevel = byId("edit-book-level");
-  els.editBookCoverPreview = byId("edit-book-cover-preview");
-  els.editBookCoverImg = byId("edit-book-cover-img");
-  els.editBookCoverClear = byId("edit-book-cover-clear");
-  els.editBookCover = byId("edit-book-cover");
-  els.editBookText = byId("edit-book-text");
-  els.editBookCancel = byId("edit-book-cancel");
-  els.editBookSave = byId("edit-book-save");
 }

--- a/src/web/js/events/book-import.ts
+++ b/src/web/js/events/book-import.ts
@@ -902,15 +902,18 @@ function handleEditCoverFile(file: File | undefined): void {
   if (!file) return;
   if (file.size > 1_500_000) {
     showToast(t("toast.coverTooBig"));
-    if (els.editBookCover) els.editBookCover.value = "";
+    const editCoverInput = document.getElementById("edit-book-cover") as HTMLInputElement | null;
+    if (editCoverInput) editCoverInput.value = "";
     return;
   }
   const reader = new FileReader();
   reader.onload = () => {
     const dataUrl = String(reader.result || "");
     import("../book-actions.js").then(m => m.setPendingEditCoverDataUrl(dataUrl));
-    if (els.editBookCoverImg) els.editBookCoverImg.src = dataUrl;
-    if (els.editBookCoverPreview) els.editBookCoverPreview.hidden = false;
+    const editCoverImg = document.getElementById("edit-book-cover-img") as HTMLImageElement | null;
+    if (editCoverImg) editCoverImg.src = dataUrl;
+    const editCoverPreview = document.getElementById("edit-book-cover-preview");
+    if (editCoverPreview) editCoverPreview.hidden = false;
     const dropzone = document.getElementById("edit-book-cover-dropzone");
     if (dropzone) dropzone.style.display = "none";
   };
@@ -1008,11 +1011,17 @@ function bindImportFormEvents() {
 
 function bindEditBookEvents() {
   registerUnsavedDialog("edit-book-dialog", isEditBookDirty, () => saveEditedBook(), () => cancelEditBook());
-  if (els.editBookCancel) els.editBookCancel.addEventListener("click", () => cancelEditBook());
-  if (els.editBookSave) els.editBookSave.addEventListener("click", () => saveEditedBook());
+  const editBookDialog = document.getElementById("edit-book-dialog") as HTMLDialogElement | null;
+  const editBookCancel = document.getElementById("edit-book-cancel") as HTMLButtonElement | null;
+  const editBookSave = document.getElementById("edit-book-save") as HTMLButtonElement | null;
+  const editBookCoverClear = document.getElementById("edit-book-cover-clear") as HTMLButtonElement | null;
+  const editBookCover = document.getElementById("edit-book-cover") as HTMLInputElement | null;
+  const editBookText = document.getElementById("edit-book-text") as HTMLTextAreaElement | null;
+  if (editBookCancel) editBookCancel.addEventListener("click", () => cancelEditBook());
+  if (editBookSave) editBookSave.addEventListener("click", () => saveEditedBook());
 
-  if (els.editBookDialog) {
-    els.editBookDialog.addEventListener("keydown", (e) => {
+  if (editBookDialog) {
+    editBookDialog.addEventListener("keydown", (e) => {
       if (e.key === "Enter" && !e.shiftKey && !(e.target instanceof HTMLTextAreaElement)
         && !(e.target instanceof HTMLSelectElement) && !(e.target instanceof HTMLButtonElement)) {
         e.preventDefault();
@@ -1021,23 +1030,26 @@ function bindEditBookEvents() {
     });
   }
 
-  if (els.editBookCoverClear) {
-    els.editBookCoverClear.addEventListener("click", () => {
+  if (editBookCoverClear) {
+    editBookCoverClear.addEventListener("click", () => {
       import("../book-actions.js").then(m => m.setPendingEditCoverDataUrl(null));
-      if (els.editBookCoverImg) els.editBookCoverImg.src = "";
-      if (els.editBookCoverPreview) els.editBookCoverPreview.hidden = true;
-      if (els.editBookCover) els.editBookCover.value = "";
+      const coverImg = document.getElementById("edit-book-cover-img") as HTMLImageElement | null;
+      if (coverImg) coverImg.src = "";
+      const coverPreview = document.getElementById("edit-book-cover-preview");
+      if (coverPreview) coverPreview.hidden = true;
+      const coverInput = document.getElementById("edit-book-cover") as HTMLInputElement | null;
+      if (coverInput) coverInput.value = "";
       const dropzone = document.getElementById("edit-book-cover-dropzone");
       if (dropzone) dropzone.style.display = "flex";
     });
   }
 
-  if (els.editBookCover) {
-    els.editBookCover.addEventListener("change", () => handleEditCoverFile(els.editBookCover.files?.[0]));
+  if (editBookCover) {
+    editBookCover.addEventListener("change", () => handleEditCoverFile(editBookCover.files?.[0]));
   }
 
-  if (els.editBookText) {
-    els.editBookText.addEventListener("paste", (e) => {
+  if (editBookText) {
+    editBookText.addEventListener("paste", (e) => {
       const clipboardEvent = e as ClipboardEventWithOriginal;
       const items = (clipboardEvent.clipboardData || clipboardEvent.originalEvent?.clipboardData)?.items;
       if (!items) return;
@@ -1061,7 +1073,7 @@ function bindCoverPasteEvents() {
   document.addEventListener("paste", (e) => {
     if (isTextEditingPasteTarget(e.target)) return;
     const importOpen = state.currentView === "library";
-    const editOpen = els.editBookDialog && els.editBookDialog.open;
+    const editOpen = (document.getElementById("edit-book-dialog") as HTMLDialogElement | null)?.open ?? false;
     if (!importOpen && !editOpen) return;
     const clipboardEvent = e as ClipboardEventWithOriginal;
     const items = (clipboardEvent.clipboardData || clipboardEvent.originalEvent?.clipboardData)?.items;

--- a/src/web/js/events/settings.ts
+++ b/src/web/js/events/settings.ts
@@ -28,6 +28,64 @@ type ApplyBridgeSnapshotOptions = {
 
 let wordAlgorithmChangeGeneration = 0;
 
+/**
+ * Builds the offline-model download dialog markup once (idempotent). Called
+ * during app boot before cacheElements() (app.ts); bindSettingsEvents()
+ * resolves the elements via getElementById, so boot order guarantees they
+ * exist.
+ */
+export function renderArgosDownloadDialog(): HTMLDialogElement {
+  const existing = document.getElementById("argos-download-dialog");
+  if (existing instanceof HTMLDialogElement) return existing;
+  if (existing) throw new TypeError("#argos-download-dialog must be a dialog element");
+
+  const dialog = document.createElement("dialog");
+  dialog.id = "argos-download-dialog";
+  dialog.className = "panel dialog-500";
+  dialog.setAttribute("aria-labelledby", "argos-download-title");
+  dialog.innerHTML = `
+    <div class="panel-header">
+      <h2 id="argos-download-title" data-i18n="settings.argosDownloadTitle">Download offline models</h2>
+    </div>
+    <div class="settings-body p-15-g-1">
+      <p class="muted-copy" data-i18n="settings.argosDownloadHint">Downloads local translation packages for the selected languages, including pairs with English and your learning language when available.</p>
+      <div id="argos-languages-list" class="stack-g-05">
+        <label class="status-check justify-start">
+          <input type="checkbox" value="en" checked>
+          <span data-i18n="languages.en">English</span>
+        </label>
+        <label class="status-check justify-start">
+          <input type="checkbox" value="pl" checked>
+          <span data-i18n="languages.pl">Polish</span>
+        </label>
+        <label class="status-check justify-start">
+          <input type="checkbox" value="de">
+          <span data-i18n="languages.de">German</span>
+        </label>
+        <label class="status-check justify-start">
+          <input type="checkbox" value="es">
+          <span data-i18n="languages.es">Spanish</span>
+        </label>
+        <label class="status-check justify-start">
+          <input type="checkbox" value="fr">
+          <span data-i18n="languages.fr">French</span>
+        </label>
+        <label class="status-check justify-start">
+          <input type="checkbox" value="zh">
+          <span data-i18n="languages.zh">Chinese (Simplified)</span>
+        </label>
+      </div>
+      <p data-i18n="settings.argosDownloadWarning" class="error-text">Note: downloading models will take a while. Do not close the app during the process.</p>
+      <div class="justify-end-m-t-1">
+        <button id="argos-download-cancel" class="secondary-button" data-i18n="moveBook.cancel">Cancel</button>
+        <button id="argos-download-confirm" class="primary-button" data-i18n="settings.argosDownloadConfirm">Download</button>
+      </div>
+    </div>
+  `;
+  document.body.appendChild(dialog);
+  return dialog;
+}
+
 function resetReaderScrollForCurrentText() {
   if (!state.currentTextId) return;
   if (!state.readerScrolls) state.readerScrolls = {};
@@ -224,9 +282,8 @@ export function bindSettingsEvents() {
   async function cancelArgosDownload() {
     if (argosDownloadRunning) return;
     argosSelectionDirty = false;
-    if (els.argosDownloadDialog) els.argosDownloadDialog.close();
+    (document.getElementById("argos-download-dialog") as HTMLDialogElement | null)?.close();
     if (els.prefOfflineTranslator) els.prefOfflineTranslator.checked = false;
-    updatePreferenceValue("offlineTranslator", false);
     if (els.prefArgosAsDictRow) {
       els.prefArgosAsDictRow.style.opacity = "0.5";
       els.prefArgosAsDictRow.style.pointerEvents = "none";
@@ -237,7 +294,7 @@ export function bindSettingsEvents() {
   }
 
   registerUnsavedDialog("argos-download-dialog", isArgosDirty, () => {
-    els.argosDownloadConfirm.click();
+    document.getElementById("argos-download-confirm")?.click();
   }, cancelArgosDownload);
   // Settings
   bindPreferenceControls();
@@ -533,8 +590,9 @@ export function bindSettingsEvents() {
         const { t: translate } = await import("../i18n.js");
         const supported = Array.from(new Set([...OFFLINE_TRANSLATOR_LANGUAGES, pair.fromCode, pair.toCode].filter(Boolean)));
         
-        if (els.argosLanguagesList) {
-          els.argosLanguagesList.innerHTML = supported.map(lang => `
+        const languagesList = document.getElementById("argos-languages-list");
+        if (languagesList) {
+          languagesList.innerHTML = supported.map(lang => `
             <label class="status-check justify-start">
               <input type="checkbox" value="${lang}" ${lang === pair.fromCode || lang === pair.toCode ? "checked" : ""}>
               <span>${translate(`languages.${lang}`) === `languages.${lang}` ? lang.toUpperCase() : translate(`languages.${lang}`)} (${lang.toUpperCase()})</span>
@@ -543,20 +601,19 @@ export function bindSettingsEvents() {
           
           // Update button text with size
           const updateBtnText = () => {
-            const count = els.argosLanguagesList.querySelectorAll("input:checked").length;
-            els.argosDownloadConfirm.textContent = translate("settings.argosDownloadSize", { label: translate("settings.argosDownloadConfirm"), size: count * 150 });
+            const count = languagesList.querySelectorAll("input:checked").length;
+            const confirmButton = document.getElementById("argos-download-confirm");
+            if (confirmButton) confirmButton.textContent = translate("settings.argosDownloadSize", { label: translate("settings.argosDownloadConfirm"), size: count * 150 });
           };
           
-          (els.argosLanguagesList as HTMLElement).querySelectorAll<HTMLInputElement>("input").forEach((checkbox) => {
+          languagesList.querySelectorAll<HTMLInputElement>("input").forEach((checkbox) => {
             checkbox.addEventListener("change", updateBtnText);
             checkbox.addEventListener("change", () => { argosSelectionDirty = true; });
           });
           updateBtnText();
         }
 
-        if (els.argosDownloadDialog) {
-          els.argosDownloadDialog.showModal();
-        }
+        (document.getElementById("argos-download-dialog") as HTMLDialogElement | null)?.showModal();
       } else {
         updatePreferenceValue("offlineTranslator", false);
         if (els.prefArgosAsDictRow) {
@@ -574,13 +631,16 @@ export function bindSettingsEvents() {
     });
   }
 
-  if (els.argosDownloadCancel) {
-    els.argosDownloadCancel.addEventListener("click", cancelArgosDownload);
+  const argosCancelButton = document.getElementById("argos-download-cancel");
+  if (argosCancelButton) {
+    argosCancelButton.addEventListener("click", cancelArgosDownload);
   }
 
-  if (els.argosDownloadConfirm) {
-    els.argosDownloadConfirm.addEventListener("click", async () => {
-      const languagesList = els.argosLanguagesList as HTMLElement;
+  const argosConfirmButton = document.getElementById("argos-download-confirm");
+  if (argosConfirmButton) {
+    argosConfirmButton.addEventListener("click", async () => {
+      const languagesList = document.getElementById("argos-languages-list");
+      if (!(languagesList instanceof HTMLElement)) return;
       const checkedBoxes = Array.from(languagesList.querySelectorAll<HTMLInputElement>("input:checked"));
       const toCodes = checkedBoxes.map(cb => cb.value);
       
@@ -589,12 +649,12 @@ export function bindSettingsEvents() {
         return;
       }
       
-      setElementBusy(els.argosDownloadConfirm, true, { disable: true });
-      setElementBusy(els.argosDownloadDialog, true);
+      setElementBusy(argosConfirmButton, true, { disable: true });
+      setElementBusy(document.getElementById("argos-download-dialog"), true);
       argosDownloadRunning = true;
       argosSelectionDirty = false;
-      if (els.argosDownloadCancel) els.argosDownloadCancel.disabled = true;
-      els.argosDownloadConfirm.textContent = t("toast.downloadingWait");
+      if (argosCancelButton) (argosCancelButton as HTMLButtonElement).disabled = true;
+      argosConfirmButton.textContent = t("toast.downloadingWait");
       
       try {
         const pair = resolveProfileTranslationPair(state.preferences);
@@ -621,7 +681,7 @@ export function bindSettingsEvents() {
           els.prefArgosAsDictRow.style.pointerEvents = "auto";
         }
         syncSettingsControls();
-        if (els.argosDownloadDialog) els.argosDownloadDialog.close();
+        (document.getElementById("argos-download-dialog") as HTMLDialogElement | null)?.close();
         renderTranslator();
         import("../toast.js").then(m => m.showToast(t("toast.modelsDownloaded")));
       } catch (err) {
@@ -638,10 +698,10 @@ export function bindSettingsEvents() {
         renderTranslator();
       } finally {
         argosDownloadRunning = false;
-        if (els.argosDownloadCancel) els.argosDownloadCancel.disabled = false;
-        setElementBusy(els.argosDownloadDialog, false);
-        setElementBusy(els.argosDownloadConfirm, false, { disable: true });
-        els.argosDownloadConfirm.textContent = t("settings.argosDownloadConfirm");
+        if (argosCancelButton) (argosCancelButton as HTMLButtonElement).disabled = false;
+        setElementBusy(document.getElementById("argos-download-dialog"), false);
+        setElementBusy(argosConfirmButton, false, { disable: true });
+        argosConfirmButton.textContent = t("settings.argosDownloadConfirm");
       }
     });
   }

--- a/src/web/js/events/word-editor.ts
+++ b/src/web/js/events/word-editor.ts
@@ -21,6 +21,58 @@ type AddWordOriginalValues = {
   status: VocabStatus;
 };
 
+/**
+ * Builds the add/edit-word dialog markup once (idempotent). Called during
+ * app boot before cacheElements() (app.ts); bindWordEditorEvents() resolves
+ * the elements via querySelector, so boot order guarantees they exist.
+ */
+export function renderAddWordDialog(): HTMLDialogElement {
+  const existing = document.getElementById("add-word-dialog");
+  if (existing instanceof HTMLDialogElement) return existing;
+  if (existing) throw new TypeError("#add-word-dialog must be a dialog element");
+
+  const dialog = document.createElement("dialog");
+  dialog.id = "add-word-dialog";
+  dialog.className = "panel word-editor-dialog dialog-680";
+  dialog.setAttribute("aria-labelledby", "add-word-dialog-title");
+  dialog.innerHTML = `
+    <div class="panel-header">
+      <h2 id="add-word-dialog-title" data-i18n="vocab.addWordTitle">Add word</h2>
+    </div>
+    <div class="word-editor-body">
+      <div class="word-editor-grid">
+        <label class="word-editor-field word-editor-word">
+          <span data-i18n="vocab.addWordLabel">Word</span>
+          <input id="add-word-input" type="text" class="input" autocomplete="off" autofocus>
+        </label>
+        <label class="word-editor-field word-editor-article">
+          <span data-i18n="vocab.addArticleLabel">Article (optional)</span>
+          <input id="add-article-input" type="text" class="input" autocomplete="off" spellcheck="false">
+        </label>
+        <label class="word-editor-field word-editor-translation">
+          <span data-i18n="vocab.addTranslationLabel">Translation (optional)</span>
+          <input id="add-translation-input" type="text" class="input" autocomplete="off">
+        </label>
+        <fieldset class="word-editor-status">
+          <legend data-i18n="vocab.status">Status</legend>
+          <div id="add-word-status-buttons" class="status-options"></div>
+        </fieldset>
+        <label class="word-editor-field word-editor-example">
+          <span data-i18n="vocab.addExampleLabel">Example sentence (optional)</span>
+          <textarea id="add-example-input" class="input" rows="4" autocomplete="off" spellcheck="false"></textarea>
+        </label>
+      </div>
+      <div class="word-editor-actions">
+        <button id="add-word-cancel" class="secondary-button" data-i18n="moveBook.cancel">Cancel</button>
+        <button id="add-word-confirm" class="primary-button" data-i18n="vocab.addWordConfirm">Add</button>
+      </div>
+    </div>
+    <input id="add-word-editing" type="hidden" value="">
+  `;
+  document.body.appendChild(dialog);
+  return dialog;
+}
+
 let addWordStatusButtons: HTMLButtonElement[] = [];
 
 function renderAddWordStatusButtons() {

--- a/types/wordhunter-browser.d.ts
+++ b/types/wordhunter-browser.d.ts
@@ -359,16 +359,6 @@ interface WhDomCache {
     discoverSort?: HTMLSelectElement | null;
     discoverLevel?: HTMLSelectElement | null;
     discoverSelectAll?: HTMLButtonElement | null;
-    editBookDialog?: HTMLDialogElement | null;
-    editBookTitle?: HTMLInputElement | null;
-    editBookAuthor?: HTMLInputElement | null;
-    editBookTags?: HTMLInputElement | null;
-    editBookLevel?: HTMLSelectElement | null;
-    editBookCoverImg?: HTMLImageElement | null;
-    editBookCover?: HTMLInputElement | null;
-    editBookText?: HTMLTextAreaElement | null;
-    editBookCancel?: HTMLButtonElement | null;
-    editBookSave?: HTMLButtonElement | null;
     bookList?: HTMLElement | null;
     chooseDataDirectory?: HTMLElement | null;
     clearLibrary?: HTMLElement | null;
@@ -381,8 +371,6 @@ interface WhDomCache {
     discoverResults?: HTMLElement | null;
     discoverStatus?: HTMLElement | null;
     discoverToolbar?: HTMLElement | null;
-    editBookCoverClear?: HTMLElement | null;
-    editBookCoverPreview?: HTMLElement | null;
     exportAnkiTsv?: HTMLElement | null;
     exportVocabAnki?: HTMLElement | null;
     exportVocabTxt?: HTMLElement | null;

--- a/types/wordhunter-browser.d.ts
+++ b/types/wordhunter-browser.d.ts
@@ -353,7 +353,6 @@ interface WhDomCache {
     prefLearningLanguage?: HTMLSelectElement | null;
     prefTheme?: HTMLSelectElement | null;
     prefLearningColors?: HTMLInputElement[];
-    argosDownloadDialog?: HTMLDialogElement | null;
     discoverForm?: HTMLFormElement | null;
     discoverQuery?: HTMLInputElement | null;
     discoverSource?: HTMLSelectElement | null;
@@ -370,9 +369,6 @@ interface WhDomCache {
     editBookText?: HTMLTextAreaElement | null;
     editBookCancel?: HTMLButtonElement | null;
     editBookSave?: HTMLButtonElement | null;
-    argosDownloadCancel?: HTMLButtonElement | null;
-    argosDownloadConfirm?: HTMLElement | null;
-    argosLanguagesList?: HTMLElement | null;
     bookList?: HTMLElement | null;
     chooseDataDirectory?: HTMLElement | null;
     clearLibrary?: HTMLElement | null;


### PR DESCRIPTION
Part of #127 (P1 part 2: argos-download-dialog ported; edit-book dialog in a follow-up PR; P2/P3 tracked in the issue)

Fifth of six P1-part-2 elements (toast/onboarding/youglish/add-word merged in #227): renderArgosDownloadDialog() in events/settings.ts — idempotent build (aria-labelledby, data-i18n/data-i18n-attr, own confirm/cancel bindings), els.argos* dropped from dom.ts + WhDomCache, consumers refactored to getElementById, boot call before cacheElements(), TS_CREATED_IDS +5, dialog-ports behavioral + boot-order sections, focused-regressions + persistence-lifecycle updated.

GREEN: build 0 TS errors, focused 106/106.