### PR TITLE
fix(discover): timeout + retry on search fetches

### DIFF
--- a/frontend-tests/shared/discover-fetch-retry.test.js
+++ b/frontend-tests/shared/discover-fetch-retry.test.js
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { readFile } from "node:fs/promises";
+import vm from "node:vm";
+
+// Loads dist/web/js/discover/fetch-discover.js with a stubbed fetch and the
+// real ../request.js fetchWithTimeout (runs in the same vm context).
+async function loadFetchDiscover(fetchImpl) {
+  const context = vm.createContext({
+    AbortController,
+    DOMException,
+    URLSearchParams,
+    setTimeout,
+    clearTimeout,
+    fetch: fetchImpl,
+  });
+  const modules = new Map();
+  const load = async (specifier, parent = null) => {
+    if (modules.has(specifier)) return modules.get(specifier);
+    const url = new URL(specifier, parent ?? import.meta.url);
+    assert.ok(
+      url.pathname.includes("/dist/web/js/"),
+      `unexpected dependency ${specifier}`
+    );
+    const source = await readFile(url, "utf8");
+    const module = new vm.SourceTextModule(source, { context, identifier: String(url) });
+    modules.set(specifier, module);
+    await module.link((dependency) => load(dependency, url));
+    await module.evaluate();
+    return module;
+  };
+  return (await load("../../dist/web/js/discover/fetch-discover.js")).namespace;
+}
+
+describe("Discover fetch retry (fetch-discover.ts)", () => {
+  it("retries once when the first attempt fails and succeeds on the second", async () => {
+    let calls = 0;
+    const { fetchDiscover } = await loadFetchDiscover(async () => {
+      calls += 1;
+      if (calls === 1) throw new TypeError("Failed to fetch");
+      return { ok: true, json: async () => ({}) };
+    });
+    const response = await fetchDiscover("https://gutendex.test/books", new AbortController().signal);
+    assert.equal(calls, 2);
+    assert.equal(response.ok, true);
+  });
+
+  it("propagates the last error when both attempts fail", async () => {
+    const { fetchDiscover } = await loadFetchDiscover(async () => {
+      throw new TypeError("Failed to fetch");
+    });
+    await assert.rejects(
+      fetchDiscover("https://gutendex.test/books", new AbortController().signal),
+      /Failed to fetch/
+    );
+  });
+
+  it("propagates the HTTP status when both attempts get a non-ok response", async () => {
+    const { fetchDiscover } = await loadFetchDiscover(async () => ({ ok: false, status: 503 }));
+    await assert.rejects(
+      fetchDiscover("https://gutendex.test/books", new AbortController().signal),
+      /HTTP 503/
+    );
+  });
+
+  it("does not retry when the caller has already aborted", async () => {
+    let calls = 0;
+    const { fetchDiscover } = await loadFetchDiscover(async () => {
+      calls += 1;
+      return { ok: true, json: async () => ({}) };
+    });
+    const controller = new AbortController();
+    controller.abort();
+    await assert.rejects(
+      fetchDiscover("https://gutendex.test/books", controller.signal),
+      (error) => error != null && error.name === "AbortError"
+    );
+    assert.equal(calls, 0);
+  });
+});

--- a/frontend-tests/shared/gutendex.test.js
+++ b/frontend-tests/shared/gutendex.test.js
@@ -15,6 +15,9 @@ async function loadGutendex(fetchImpl) {
     "../utils.js": {
       cleanCatalogTitle: (value) => (typeof value === "string" ? value : ""),
     },
+    "./fetch-discover.js": {
+      fetchDiscover: (url, signal) => fetchImpl(url, { signal }),
+    },
   };
   const modules = new Map();
   const load = async (specifier) => {

--- a/src/web/js/discover/fetch-discover.ts
+++ b/src/web/js/discover/fetch-discover.ts
@@ -28,7 +28,7 @@ export async function fetchDiscover(url: string, signal: AbortSignal | null): Pr
       if (response.ok) return response;
       lastError = new Error(`HTTP ${response.status}`);
     } catch (error) {
-      if (error instanceof Error && error.name === "AbortError") throw error;
+      if (error != null && typeof error === "object" && (error as { name?: unknown }).name === "AbortError") throw error;
       lastError = error;
     }
     if (attempt + 1 < MAX_DISCOVER_ATTEMPTS) {

--- a/src/web/js/discover/fetch-discover.ts
+++ b/src/web/js/discover/fetch-discover.ts
@@ -1,0 +1,39 @@
+/**
+ * Discover fetch with a bounded timeout and one retry.
+ *
+ * gutendex.com is Cloudflare-fronted and intermittently black-holes requests
+ * (15s+ with zero bytes) from some networks; a bare fetch would surface a
+ * "Could not fetch results. Try again." error for every search during such an
+ * outage window. A 15s timeout plus a single retry converts those transient
+ * hangs into a bounded, usually-successful search while keeping the caller's
+ * abort semantics intact.
+ */
+import { fetchWithTimeout } from "../request.js";
+
+const DISCOVER_TIMEOUT_MS = 15_000;
+const DISCOVER_RETRY_DELAY_MS = 1_000;
+const MAX_DISCOVER_ATTEMPTS = 2;
+
+export async function fetchDiscover(url: string, signal: AbortSignal | null): Promise<Response> {
+  const activeSignal = signal ?? new AbortController().signal;
+  let lastError: unknown = new Error("discover fetch failed");
+  for (let attempt = 0; attempt < MAX_DISCOVER_ATTEMPTS; attempt += 1) {
+    if (activeSignal.aborted) {
+      throw activeSignal.reason instanceof Error
+        ? activeSignal.reason
+        : Object.assign(new Error("Aborted"), { name: "AbortError" });
+    }
+    try {
+      const response = await fetchWithTimeout(url, { signal: activeSignal }, DISCOVER_TIMEOUT_MS);
+      if (response.ok) return response;
+      lastError = new Error(`HTTP ${response.status}`);
+    } catch (error) {
+      if (error instanceof Error && error.name === "AbortError") throw error;
+      lastError = error;
+    }
+    if (attempt + 1 < MAX_DISCOVER_ATTEMPTS) {
+      await new Promise((resolve) => setTimeout(resolve, DISCOVER_RETRY_DELAY_MS));
+    }
+  }
+  throw lastError;
+}

--- a/src/web/js/discover/gutendex.ts
+++ b/src/web/js/discover/gutendex.ts
@@ -4,6 +4,7 @@
 import { GUTENDEX_URL } from "../constants.js";
 import { t } from "../i18n.js";
 import { cleanCatalogTitle } from "../utils.js";
+import { fetchDiscover } from "./fetch-discover.js";
 
 const LEVEL_TOPICS: Record<string, string> = {
   A1: "children",
@@ -62,7 +63,7 @@ export async function searchGutendex(
   if (topic) params.set("topic", topic);
   params.set("page", String(discover.page || 1));
 
-  const response = await fetch(`${GUTENDEX_URL}?${params.toString()}`, { signal });
+  const response = await fetchDiscover(`${GUTENDEX_URL}?${params.toString()}`, signal);
   if (!response.ok) throw new Error(`HTTP ${response.status}`);
   const rawData: unknown = await response.json();
   const data = asRecord(rawData) || {};

--- a/src/web/js/discover/mediawiki.ts
+++ b/src/web/js/discover/mediawiki.ts
@@ -2,6 +2,7 @@
  * Wikipedia / Wikinews API client for the Discover view.
  */
 import { t as translate } from "../i18n.js";
+import { fetchDiscover } from "./fetch-discover.js";
 
 const t = translate as (key: string, vars?: WhRecord) => string;
 
@@ -78,7 +79,7 @@ export async function searchMediaWiki(
     apiUrl = `${baseUrl}?action=query&generator=random&grnnamespace=0&grnlimit=10&prop=pageimages|extracts&exintro=1&explaintext=1&pithumbsize=300&format=json&origin=*`;
   }
 
-  const response = await fetch(apiUrl, { signal });
+  const response = await fetchDiscover(apiUrl, signal);
   if (!response.ok) throw new Error(`HTTP ${response.status}`);
   const rawData: unknown = await response.json();
   const data = asRecord(rawData) || {};


### PR DESCRIPTION
Addresses the 1.0.11-rc.1 report that Discover search fails with 'Could not fetch results. Try again.'.

**Root cause (research):** not a code regression — the search fetches Gutendex directly from the webview with a bare fetch (no timeout, no retry), and gutendex.com intermittently black-holes requests for 15s+ from some networks, making every search fail deterministically-looking during an outage window.

**Fix:** new `fetchDiscover()` (`src/web/js/discover/fetch-discover.ts`): 15s timeout via the existing `fetchWithTimeout`, one retry (~1s backoff), caller abort honored (no retry after abort, AbortError propagates for the search-run guard). Used by `gutendex.ts` and `mediawiki.ts`.

**Tests:** new `discover-fetch-retry.test.js` (4 tests: retry-then-success, last-error propagation, HTTP-status propagation, no-retry-after-abort) + full suite 617/617.