### PR TITLE
fix(state): persist word status changes made through the root vocab path

### DIFF
--- a/frontend-tests/shared/autosave-attribution.test.js
+++ b/frontend-tests/shared/autosave-attribution.test.js
@@ -1,0 +1,147 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { readFile } from "node:fs/promises";
+import vm from "node:vm";
+
+// Loads dist/web/js/state/autosave.js with recording api.js mocks. The
+// harness drives the REAL mutation-tracking proxy: wrap(rawState), mutate
+// through the proxy, then saveState() and inspect what the payload builder
+// received.
+async function loadAutosaveHarness() {
+  const calls = {
+    deltas: [],
+    fulls: [],
+    payloads: [],
+  };
+  const context = vm.createContext({
+    window: { __qtBridge: true, __bridgeState: {}, dispatchEvent() {} },
+    CustomEvent: class CustomEvent {},
+    setTimeout: () => 1,
+    clearTimeout() {},
+    console,
+  });
+  const mocks = {
+    "../api.js": {
+      buildSavePayload: (state) => {
+        const full = { full: true, state };
+        calls.fulls.push(full);
+        return full;
+      },
+      buildDeltaSavePayload: (raw, langs, texts) => {
+        calls.deltas.push({ langs: [...langs], texts });
+        return { delta: true, fullKeys: [], records: {} };
+      },
+      saveToLocalStorage() {},
+      async saveWithRetry(payload) {
+        calls.payloads.push(payload);
+        return { ok: true };
+      },
+      saveSyncXhr() {},
+      readPendingDelta() { return null; },
+      clearPendingDelta() {}
+    }
+  };
+  const modules = new Map();
+  const load = async (specifier, parent = null) => {
+    if (modules.has(specifier)) return modules.get(specifier);
+    if (mocks[specifier]) {
+      const names = Object.keys(mocks[specifier]);
+      const module = new vm.SyntheticModule(names, function define() {
+        for (const name of names) this.setExport(name, mocks[specifier][name]);
+      }, { context, identifier: specifier });
+      modules.set(specifier, module);
+      await module.link(() => {});
+      await module.evaluate();
+      return module;
+    }
+    const url = new URL(specifier, parent ?? import.meta.url);
+    assert.ok(url.pathname.includes("/dist/web/js/"), `unexpected dependency ${specifier}`);
+    const source = await readFile(url, "utf8");
+    const module = new vm.SourceTextModule(source, { context, identifier: String(url) });
+    modules.set(specifier, module);
+    await module.link((dependency) => load(dependency, url));
+    await module.evaluate();
+    return module;
+  };
+  const { createAutosave } = (await load("../../dist/web/js/state/autosave.js")).namespace;
+  return { createAutosave, calls };
+}
+
+function makeRawState() {
+  return {
+    preferences: { learningLanguage: "en" },
+    profiles: {
+      en: { words: { w1: { status: "new" } } }
+    },
+    vocab: {},
+    discover: { query: "" }
+  };
+}
+
+describe("autosave dirty attribution (word status persistence, issue #127 P3)", () => {
+  it("attributes a root state.vocab status mutation to the learning language", async () => {
+    const { createAutosave, calls } = await loadAutosaveHarness();
+    const raw = makeRawState();
+    const autosave = createAutosave(() => raw);
+    const state = autosave.wrap(raw);
+
+    // Mutation through the ROOT vocab path with NO prior
+    // state.profiles[lang].vocab traversal — the reported regression:
+    // the status change existed only in RAM and vanished on restart.
+    state.vocab.w1 = { status: "new" };
+    state.vocab.w1.status = "learning";
+
+    await autosave.saveState();
+
+    assert.equal(calls.deltas.length, 1, "a delta save must run");
+    assert.ok(calls.deltas[0].langs.includes("en"), "the learning language must be dirty");
+  });
+
+  it("still sends a delta (not a full snapshot) for profile-chain mutations", async () => {
+    const { createAutosave, calls } = await loadAutosaveHarness();
+    const raw = makeRawState();
+    const autosave = createAutosave(() => raw);
+    const state = autosave.wrap(raw);
+
+    state.profiles.en.words.w1.status = "learning";
+
+    await autosave.saveState();
+
+    assert.equal(calls.deltas.length, 1);
+    assert.equal(calls.fulls.length, 0, "an attributed mutation must keep using the delta path");
+    assert.ok(calls.deltas[0].langs.includes("en"));
+  });
+
+  it("never sends an empty delta while a real mutation is pending", async () => {
+    const { createAutosave, calls } = await loadAutosaveHarness();
+    const raw = makeRawState();
+    const autosave = createAutosave(() => raw);
+    const state = autosave.wrap(raw);
+
+    // An unattributed mutation (root-level, no vocab/texts/profile context):
+    // the delta would be empty and the backend merge a no-op — the save must
+    // fall back to a full snapshot instead.
+    state.discover.query = "abc";
+
+    await autosave.saveState();
+
+    assert.equal(calls.deltas.length, 0, "an empty delta must not be sent for a pending mutation");
+    assert.equal(calls.fulls.length, 1, "a full snapshot must cover the unattributed mutation");
+  });
+
+  it("falls back to a full snapshot again for a later unattributed mutation", async () => {
+    const { createAutosave, calls } = await loadAutosaveHarness();
+    const raw = makeRawState();
+    const autosave = createAutosave(() => raw);
+    const state = autosave.wrap(raw);
+
+    state.profiles.en.words.w1.status = "known";
+    await autosave.saveState();
+    assert.equal(calls.deltas.length, 1);
+    assert.equal(calls.fulls.length, 0);
+
+    state.discover.query = "xyz";
+    await autosave.saveState();
+    assert.equal(calls.fulls.length, 1, "the second unattributed mutation must also be persisted");
+  });
+});

--- a/frontend-tests/shared/persistence-lifecycle.test.js
+++ b/frontend-tests/shared/persistence-lifecycle.test.js
@@ -382,26 +382,29 @@ describe("persistence lifecycle", () => {
 
     // Case 1 — save built BEFORE the freeze does not cover the delta:
     // start a save (payload sequence 0), then mutate (sequence 1) and freeze
-    // the delta (sequence 1). The completing save must NOT clear it.
+    // the delta (sequence 1). The in-flight save itself must NOT clear it;
+    // the save-pending follow-up is a NEW save built after the freeze whose
+    // full snapshot contains the mutation (sequence 1 > lastPersisted 0 with
+    // the dirty sets already cleared) — superseding the delta is correct.
     const inflight = autosave.saveState();
     state.profiles.de = { words: {} };
     const envelope = autosave.buildPendingDeltaEnvelope();
     pending = envelope;
     releaseSave({ ok: true });
     await inflight;
-    assert.equal(cleared, 0, "a save built before the freeze must not clear the delta");
+    assert.equal(cleared, 1, "only the post-freeze follow-up supersedes the delta");
 
     // Case 2 — a same-session save built after the freeze, carrying records,
     // covers the delta (even for a mutation in an already-dirty language).
     state.profiles.de.words.w1 = { status: "learning" };
     await autosave.saveState();
-    assert.equal(cleared, 1, "a same-session save built after the freeze supersedes the delta");
+    assert.equal(cleared, 2, "a same-session save built after the freeze supersedes the delta");
 
     // Case 3 — a delta from another session is never cleared by this
     // session's saves (only the boot replay delivers and clears it).
     pending = { payload: "{}", session: "other-session", sequence: 0 };
     await autosave.saveState();
-    assert.equal(cleared, 1, "a cross-session delta must not be cleared by this session's saves");
+    assert.equal(cleared, 2, "a cross-session delta must not be cleared by this session's saves");
   });
 
   it("coalesces a burst of completed book counters into one library render", async () => {

--- a/src/web/js/state/autosave.ts
+++ b/src/web/js/state/autosave.ts
@@ -44,6 +44,11 @@ export function createAutosave(getState: () => WhAppState) {
   let durableStateRevision = 0;
   let vocabularyRevision = 0;
   let mutationSequence = 0;
+  // Highest mutation sequence covered by a successful backend save. A
+  // mutation above this line with no dirty-language/text attribution means
+  // the delta would be empty while real changes are pending — the save must
+  // fall back to a full snapshot (order-independent dirty tracking).
+  let lastPersistedSequence = 0;
   let saveStartedMutationSequence = 0;
   // Identity of this autosave session: the pending teardown delta is cleared
   // by a later save only when both come from the same session (cross-session
@@ -149,6 +154,10 @@ export function createAutosave(getState: () => WhAppState) {
       applyBackendSaveStatus(result);
       retryDelayMs = 0;
       lastSaveSucceededAt = Date.now();
+      // The payload built at payloadSequence covers every mutation up to
+      // that sequence — record it so a later unattributed mutation is
+      // detected (and saved as a full snapshot) instead of silently lost.
+      lastPersistedSequence = Math.max(lastPersistedSequence, payloadSequence);
       dirtyVocabLangs.clear();
       dirtyTextIds.clear();
       allTextsDirty = false;
@@ -182,8 +191,14 @@ export function createAutosave(getState: () => WhAppState) {
     // The save-pending follow-up (a save re-run right after markSucceeded
     // cleared the dirty sets) builds an EMPTY payload: it carries no records,
     // so it must not be allowed to clear the pending delta either.
-    const payloadHasRecords = dirtyVocabLangs.size > 0 || dirtyTextIds.size > 0 || allTextsDirty;
-    const payload = buildDeltaSavePayload(current, dirtyVocabLangs, allTextsDirty ? true : dirtyTextIds);
+    const unattributedMutationsPending = dirtyVocabLangs.size === 0 && dirtyTextIds.size === 0 && !allTextsDirty && mutationSequence > lastPersistedSequence;
+    const payloadHasRecords = dirtyVocabLangs.size > 0 || dirtyTextIds.size > 0 || allTextsDirty || unattributedMutationsPending;
+    // An empty delta from a dirty state is always a bug indicator: the dirty
+    // tracking failed to attribute a mutation (or a save-pending follow-up
+    // lost the dirty sets). A full snapshot is unconditionally safe.
+    const payload = unattributedMutationsPending
+      ? buildSavePayload(current)
+      : buildDeltaSavePayload(current, dirtyVocabLangs, allTextsDirty ? true : dirtyTextIds);
     savePromise = saveWithRetry(JSON.stringify(payload), 3).then(markSucceeded).catch(async (error) => {
       // The backend may reject a delta payload (validation edge or an older
       // server build). Retry once with a full snapshot — but only for an
@@ -331,6 +346,13 @@ export function createAutosave(getState: () => WhAppState) {
           const ctx = dirtyContexts.get(object);
           if (ctx?.kind === "vocab" || ctx?.kind === "word" || ctx?.kind === "profile" || ctx?.kind === "books") {
             if (ctx.lang) dirtyVocabLangs.add(ctx.lang);
+          } else if (vocabularyMaps.has(object) || vocabularyEntries.has(object)) {
+            // Root state.vocab path: the mutation was recorded but no
+            // profile-chain traversal attributed it to a language. Attribute
+            // to the active learning language so the delta carries the
+            // change regardless of access order.
+            const lang = rawState()?.preferences?.learningLanguage;
+            if (typeof lang === "string" && lang) dirtyVocabLangs.add(lang);
           } else if (ctx?.kind === "text") {
             const id = (object as WhRecord).id;
             if (typeof id === "string" && id) dirtyTextIds.add(id);
@@ -362,6 +384,11 @@ export function createAutosave(getState: () => WhAppState) {
           const ctx = dirtyContexts.get(object);
           if (ctx?.kind === "vocab" || ctx?.kind === "word" || ctx?.kind === "profile" || ctx?.kind === "books") {
             if (ctx.lang) dirtyVocabLangs.add(ctx.lang);
+          } else if (vocabularyMaps.has(object) || vocabularyEntries.has(object)) {
+            // Root state.vocab path: same order-independent attribution as
+            // the set trap.
+            const lang = rawState()?.preferences?.learningLanguage;
+            if (typeof lang === "string" && lang) dirtyVocabLangs.add(lang);
           } else if (ctx?.kind === "text") {
             const id = (object as WhRecord).id;
             if (typeof id === "string" && id) dirtyTextIds.add(id);


### PR DESCRIPTION
Fixes the 1.0.11-rc.1 report: word status changes (e.g. set to 'learning') vanish after quitting the app.

**Root cause (multiagent research):** the incremental delta-save dirty tracking (feature #83, new in 1.0.11) attributed a vocab mutation to a language ONLY when `state.profiles[lang].vocab[...]` had been traversed through the proxy before the mutation. Mutations through the root `state.vocab` path were counted (save scheduled) but never attributed → the delta save carried an EMPTY vocab payload → the backend merge was a no-op that acknowledged success → the exit flush saw no pending changes → the mutation lived only in RAM. Before deltas, every save was a full snapshot, so a missed attribution was harmless.

**Fix (src/web/js/state/autosave.ts):**
1. set/deleteProperty traps: root-vocab-registry mutations without a profile-chain context are attributed to the active learning language (order-independent dirty tracking)
2. Defense in depth: a pending mutation with no dirty language/text (mutationSequence > lastPersistedSequence, empty dirty sets) forces a FULL snapshot instead of an empty delta

**Tests:** new autosave-attribution.test.js (4 tests); persistence-lifecycle expectations updated for the stronger post-freeze follow-up guarantee (the follow-up is now a full snapshot that legitimately supersedes the frozen delta).