### PR TITLE
fix(discover): unblock external APIs in the served CSP connect-src

### DIFF
--- a/src-tauri/src/response.rs
+++ b/src-tauri/src/response.rs
@@ -139,7 +139,7 @@ fn standard_headers(content_type: &str, cache: bool) -> Result<Vec<Header>, Stri
         ("X-Frame-Options", "DENY"),
         (
             "Content-Security-Policy",
-            "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self'; media-src 'self' blob:; object-src 'none'; base-uri 'none'; frame-ancestors 'none'",
+            "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https: http://127.0.0.1:* http://localhost:*; media-src 'self' blob:; object-src 'none'; base-uri 'none'; frame-ancestors 'none'",
         ),
     ]
     .into_iter()

--- a/src-tauri/src/tests/http_boundary/tests.rs
+++ b/src-tauri/src/tests/http_boundary/tests.rs
@@ -272,6 +272,12 @@ fn static_responses_include_security_headers() {
     assert!(response.contains("X-Frame-Options: DENY"));
     assert!(response.contains("Content-Security-Policy: default-src 'self'"));
     assert!(response.contains("frame-ancestors 'none'"));
+    // The Discover view (and other user-configurable integrations) fetch
+    // external https APIs (gutendex, wikipedia, youglish, deepl, dictionary,
+    // AI endpoints) and local LM Studio (http://127.0.0.1). connect-src must
+    // allow them — a bare 'self' silently kills every external fetch with a
+    // CSP violation ("Could not fetch results." in Discover).
+    assert!(response.contains("connect-src 'self' https: http://127.0.0.1:* http://localhost:*"));
 }
 
 #[test]


### PR DESCRIPTION
## Root cause (found via WebView2 CDP, 100% reproduced)

The app's custom protocol server hardcodes the CSP header with `connect-src 'self'` (`src-tauri/src/response.rs`). Every external fetch from the webview — **Gutenberg AND Wikipedia alike** — was rejected by the browser before any network I/O:

```
[log.error] Connecting to 'https://gutendex.com/books/...' violates the following
Content Security Policy directive: "connect-src 'self'". The action has been blocked.
```

This is why the previous timeout/retry fix (#237) did not help: the fetch never left the machine. curl works (no CSP), the webview fails (CSP) — hence "Could not fetch results." on every source for every user.

## Fix

`connect-src 'self' https: http://127.0.0.1:* http://localhost:*` — covers all app integrations (gutendex, wikipedia/wikinews/wikisource + upload.wikimedia.org thumbnails, youglish, deepl, google translate, user-configured dictionary/AI endpoints) and local LM Studio.

## Verification

- RED/GREEN: new assertion in `http_boundary::static_responses_include_security_headers` (fails on the old header, passes on the new one); full lib suite 288/288
- **Live proof**: release build with CDP — `[gutenberg] 10 · „goethe"`, `[wikipedia] 10 · „goethe"`, de.wikipedia/de.wikinews/upload.wikimedia all 200