### PR TITLE
fix(srs): graduate to known at 21-day maturity, not after 2 ratings

### DIFF
--- a/frontend-tests/shared/reader-srs-features.test.js
+++ b/frontend-tests/shared/reader-srs-features.test.js
@@ -401,11 +401,25 @@ describe("in-text SRS grading", () => {
     });
   }
 
-  it("promotes a repeatedly recalled word through the shared rule", async () => {
+  it("keeps a word in learning until its interval reaches maturity", async () => {
     state.preferences.srsAlgorithm = "sm2";
     setActiveVocab({ wort: { status: "learning", repetition: 1, interval: 1, efactor: 2.5 } });
     const entry = await applyReviewGrade("wort", 4);
     assert.equal(entry.repetition, 2);
+    // The card's new interval is ~3 days — far from the 21-day maturity
+    // threshold, so it must NOT graduate to "known" yet. Graduating after
+    // two good reviews starved the review queue (no future reviews → no
+    // mature cards → degenerate ease/forecast charts).
+    assert.equal(entry.status, "learning");
+    assert.ok(!entry.knownAt);
+  });
+
+  it("graduates a word to known once its interval reaches 21 days", async () => {
+    state.preferences.srsAlgorithm = "sm2";
+    setActiveVocab({ wort: { status: "learning", repetition: 3, interval: 15, efactor: 2.5 } });
+    const entry = await applyReviewGrade("wort", 4);
+    // SM2: nextInterval = round(15 * 2.5) = 38 >= 21 → mature → known.
+    assert.ok((entry.interval ?? 0) >= 21);
     assert.equal(entry.status, "known");
     assert.equal(entry.knownAt, entry.updatedAt);
   });

--- a/src/web/js/vocabulary/review-card.ts
+++ b/src/web/js/vocabulary/review-card.ts
@@ -367,7 +367,12 @@ export async function applyReviewGrade(word: string, quality: number): Promise<W
   });
   const updatedAt = now.toISOString();
   let status = currentEntry.status;
-  if (quality >= 4 && currentEntry.repetition >= 2) status = "known";
+  // Graduate to "known" only when the card is mature (interval >= 21 days).
+  // The old rule (quality >= 4 after two repetitions) retired cards at
+  // ~1-8 day intervals: the review queue never built future reviews, ease
+  // factors never drifted, no card ever reached maturity, and the graphs
+  // (forecast, ease distribution, mature/young) degraded to a single bucket.
+  if (quality >= 4 && (currentEntry.interval ?? 0) >= 21) status = "known";
   else if (quality < 3) status = "learning";
   else if (currentEntry.status === "new") status = "learning";
   setEntryStatus(currentEntry, status, updatedAt);


### PR DESCRIPTION
## Root cause of the degenerate Graphs

`review-card.ts` retired cards to `known` after **two** good ratings (`quality >= 4 && repetition >= 2`) — at ~1-8 day intervals. Consequences visible in the user's data (752 records): only **1 card** has interval ≥ 21, all 183 SM2 cards sit at the untouched ease 2.5, and the review queue never schedules future days — so the forecast shows only today, the ease distribution is one bucket (2.1–2.5), and mature/young is all-young.

## Fix

Cards now graduate to `known` when their (post-review) interval reaches **21 days** — the same threshold the graphs use for maturity. SM2 example: 1 → 3 → 8 → 20 → 50-day intervals; the card graduates at the 38-day step.

## Tests

- Reworked `promotes a repeatedly recalled word` → `keeps a word in learning until its interval reaches maturity` (RED)
- Added `graduates a word to known once its interval reaches 21 days` (interval 15 → 38 → known)
- reader-srs-features 38/38; full suite 625/625; tsc clean