### PR TITLE
fix(graphs): mature/young counts known cards as mature

### DIFF
--- a/frontend-tests/shared/graphs-maturity.test.js
+++ b/frontend-tests/shared/graphs-maturity.test.js
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { readFile } from "node:fs/promises";
+import vm from "node:vm";
+
+// countMatureYoung: mature = interval >= 21 days (Anki convention).
+// Ignored cards are suspended and excluded. KNOWN cards count — after the
+// PR #243 graduation fix they reach "known" at the 21-day threshold and
+// are the classic mature cards; excluding them made the mature/young chart
+// permanently one-sided ("everything in young").
+
+function source(path) {
+  return readFile(path, "utf8");
+}
+
+async function loadHelpers() {
+  const globals = {
+    console,
+    Date,
+    Math,
+    JSON,
+    setTimeout,
+    clearTimeout,
+    requestAnimationFrame: () => 0,
+    cancelAnimationFrame: () => {},
+    document: {
+      getElementById: () => null,
+      querySelectorAll: () => []
+    },
+    window: {}
+  };
+  const context = vm.createContext(globals);
+  const modules = new Map();
+  const createMock = (specifier, values) =>
+    new vm.SyntheticModule(
+      Object.keys(values),
+      function initialize() {
+        for (const [name, value] of Object.entries(values)) this.setExport(name, value);
+      },
+      { context, identifier: `mock:${specifier}` }
+    );
+  const imports = {
+    "../state.js": { state: { vocab: {} } },
+    "../i18n.js": { t: (key) => key },
+    "../loading.js": { setElementBusy: () => {} },
+    "../views/heatmap.js": { renderContributionHeatmap: () => {} }
+  };
+  for (const [specifier, values] of Object.entries(imports)) {
+    modules.set(specifier, createMock(specifier, values));
+  }
+  const getModule = (specifier) => {
+    const dependency = modules.get(specifier);
+    assert.ok(dependency, `unexpected import ${specifier}`);
+    return dependency;
+  };
+  const module = new vm.SourceTextModule(await source("dist/web/js/graphs/helpers.js"), {
+    context,
+    identifier: "helpers.js"
+  });
+  await module.link(getModule);
+  await module.evaluate();
+  return module.namespace;
+}
+
+describe("countMatureYoung (graphs/helpers)", () => {
+  it("counts a known card with a 30-day interval as mature", async () => {
+    const { countMatureYoung } = await loadHelpers();
+    const r1 = countMatureYoung([{ status: "known", interval: 30 }]);
+    assert.equal(r1.young, 0);
+    assert.equal(r1.mature, 1);
+  });
+
+  it("counts a learning card below 21 days as young", async () => {
+    const { countMatureYoung } = await loadHelpers();
+    const r2 = countMatureYoung([
+      { status: "learning", interval: 3 },
+      { status: "learning", interval: 20 }
+    ]);
+    assert.equal(r2.young, 2);
+    assert.equal(r2.mature, 0);
+  });
+
+  it("excludes ignored cards (suspended), regardless of interval", async () => {
+    const { countMatureYoung } = await loadHelpers();
+    const r3 = countMatureYoung([
+      { status: "ignored", interval: 40 },
+      { status: "learning", interval: 5 }
+    ]);
+    assert.equal(r3.young, 1);
+    assert.equal(r3.mature, 0);
+  });
+
+  it("treats a missing interval as young (new cards)", async () => {
+    const { countMatureYoung } = await loadHelpers();
+    const r4 = countMatureYoung([{ status: "new" }, { status: "known", interval: 21 }]);
+    assert.equal(r4.young, 1);
+    assert.equal(r4.mature, 1);
+  });
+});

--- a/frontend-tests/shared/graphs-maturity.test.js
+++ b/frontend-tests/shared/graphs-maturity.test.js
@@ -43,7 +43,8 @@ async function loadHelpers() {
     "../state.js": { state: { vocab: {} } },
     "../i18n.js": { t: (key) => key },
     "../loading.js": { setElementBusy: () => {} },
-    "../views/heatmap.js": { renderContributionHeatmap: () => {} }
+    "../views/heatmap.js": { renderContributionHeatmap: () => {} },
+    "../sm2.js": { todayISO: () => "2026-08-12" }
   };
   for (const [specifier, values] of Object.entries(imports)) {
     modules.set(specifier, createMock(specifier, values));

--- a/src/web/js/graphs/charts.ts
+++ b/src/web/js/graphs/charts.ts
@@ -9,6 +9,7 @@ import {
   DAYS, canvas, daysBetween, showTooltip, hideTooltip, drawBarChart, drawChartBar, colorWithAlpha,
   buildEaseFactorBins
 } from "./helpers.js";
+import { countMatureYoung } from "./helpers.js";
 import type { ChartBin, ChartOptions, VocabEntry } from "./helpers.js";
 
 type TranslationVars = Record<string, string | number | boolean | null | undefined>;
@@ -544,11 +545,7 @@ export function renderMatureVsYoung(_chartEntries?: readonly VocabEntry[], _opti
   const W = ctx.w, H = ctx.h;
   const cx = W / 2, cy = H / 2 + 4;
   const r = Math.min(W, H) / 2 - 34, ir = r * 0.55;
-  let young = 0, mature = 0;
-  for (const e of _chartEntries || stateVocabEntries()) {
-    if (e.status === "ignored" || e.status === "known") continue;
-    if ((e.interval || 0) >= 21) mature++; else young++;
-  }
+  const { young, mature } = countMatureYoung(_chartEntries || stateVocabEntries());
   const total = Math.max(1, young + mature);
 
   ctx.fillStyle = panelBg; ctx.fillRect(0, 0, W, H);

--- a/src/web/js/graphs/helpers.ts
+++ b/src/web/js/graphs/helpers.ts
@@ -68,6 +68,21 @@ export function buildEaseFactorBins(
 
 export type ChartContext = CanvasRenderingContext2D & { w: number; h: number };
 
+// Mature = interval >= 21 days (Anki convention). Ignored cards are
+// suspended and excluded; known cards COUNT — they graduated at the
+// 21-day threshold and are the classic mature cards (excluding them made
+// the chart permanently one-sided).
+export function countMatureYoung(entries: readonly VocabEntry[]): { young: number; mature: number } {
+  let young = 0;
+  let mature = 0;
+  for (const e of entries) {
+    if (e.status === "ignored") continue;
+    if ((e.interval || 0) >= 21) mature++;
+    else young++;
+  }
+  return { young, mature };
+}
+
 const t = rawT as (key: string, vars?: TranslationVars) => string;
 
 // Theme colors (initialized by updateColors)
@@ -295,7 +310,7 @@ export function renderStatsSummary(_chartEntries?: readonly VocabEntry[]): void 
       if (d < 0) overdue++;
       else if (d === 0) due++;
     }
-    if (e.status !== "known" && (e.interval || 0) >= 21) matureCount++;
+    if ((e.interval || 0) >= 21) matureCount++;
   }
   const dueTotal = due + overdue;
   const srsActive = total - known;


### PR DESCRIPTION
The pie (charts.ts:547) and the stats summary (helpers.ts:298) excluded `known` cards from the mature/young classification. Since cards graduate to `known` only at the 21-day interval (PR #243), known cards are by definition mature — excluding them made the chart one-sided ('wszystko w jednej kategorii').

- Extracted shared `countMatureYoung` helper (mature = interval >= 21; ignored excluded as suspended)
- New test file graphs-maturity.test.js (4 cases) — RED/GREEN
- Full suite 628/628, tsc clean

Companion to #243 — together they fix the degenerate Graphs view reported by the user.