### PR TITLE
fix(graphs): readability — labels, tooltip clamp, overlap

### DIFF
--- a/frontend-tests/shared/graphs-readability.test.js
+++ b/frontend-tests/shared/graphs-readability.test.js
@@ -37,7 +37,8 @@ async function loadHelpers() {
     "../state.js": { state: { vocab: {} } },
     "../i18n.js": { t: (key) => key },
     "../loading.js": { setElementBusy: () => {} },
-    "../views/heatmap.js": { renderContributionHeatmap: () => {} }
+    "../views/heatmap.js": { renderContributionHeatmap: () => {} },
+    "../sm2.js": { todayISO: () => "2026-08-12" }
   };
   for (const [specifier, values] of Object.entries(imports)) {
     modules.set(specifier, createMock(specifier, values));

--- a/frontend-tests/shared/graphs-readability.test.js
+++ b/frontend-tests/shared/graphs-readability.test.js
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { readFile } from "node:fs/promises";
+import vm from "node:vm";
+
+// clampTooltipPosition: keeps the chart tooltip inside the viewport with an
+// 8 px margin. Readability fix — near the right/bottom edges the tooltip
+// used to render off-screen.
+
+async function loadHelpers() {
+  const globals = {
+    console,
+    Date,
+    Math,
+    JSON,
+    setTimeout,
+    clearTimeout,
+    requestAnimationFrame: () => 0,
+    cancelAnimationFrame: () => {},
+    document: {
+      getElementById: () => null,
+      querySelectorAll: () => []
+    },
+    window: {}
+  };
+  const context = vm.createContext(globals);
+  const modules = new Map();
+  const createMock = (specifier, values) =>
+    new vm.SyntheticModule(
+      Object.keys(values),
+      function initialize() {
+        for (const [name, value] of Object.entries(values)) this.setExport(name, value);
+      },
+      { context, identifier: `mock:${specifier}` }
+    );
+  const imports = {
+    "../state.js": { state: { vocab: {} } },
+    "../i18n.js": { t: (key) => key },
+    "../loading.js": { setElementBusy: () => {} },
+    "../views/heatmap.js": { renderContributionHeatmap: () => {} }
+  };
+  for (const [specifier, values] of Object.entries(imports)) {
+    modules.set(specifier, createMock(specifier, values));
+  }
+  const getModule = (specifier) => {
+    const dependency = modules.get(specifier);
+    assert.ok(dependency, `unexpected import ${specifier}`);
+    return dependency;
+  };
+  const module = new vm.SourceTextModule(await readFile("dist/web/js/graphs/helpers.js", "utf8"), {
+    context,
+    identifier: "helpers.js"
+  });
+  await module.link(getModule);
+  await module.evaluate();
+  return module.namespace;
+}
+
+describe("clampTooltipPosition (graphs/helpers)", () => {
+  it("keeps a tooltip near the top-left corner as-is", async () => {
+    const { clampTooltipPosition } = await loadHelpers();
+    const r = clampTooltipPosition(100, 60, 120, 40, 1280, 720);
+    assert.equal(r.x, 100);
+    assert.equal(r.y, 60);
+  });
+
+  it("clamps a tooltip that would overflow the right edge", async () => {
+    const { clampTooltipPosition } = await loadHelpers();
+    const r = clampTooltipPosition(1200, 300, 200, 40, 1280, 720);
+    assert.equal(r.x, 1280 - 200 - 8);
+    assert.equal(r.y, 300);
+  });
+
+  it("clamps a tooltip that would overflow the bottom edge", async () => {
+    const { clampTooltipPosition } = await loadHelpers();
+    const r = clampTooltipPosition(500, 700, 160, 60, 1280, 720);
+    assert.equal(r.x, 500);
+    assert.equal(r.y, 720 - 60 - 8);
+  });
+
+  it("clamps negative coordinates to the 8 px margin", async () => {
+    const { clampTooltipPosition } = await loadHelpers();
+    const r = clampTooltipPosition(-50, -20, 120, 40, 1280, 720);
+    assert.equal(r.x, 8);
+    assert.equal(r.y, 8);
+  });
+});

--- a/src/web/i18n/pl.json
+++ b/src/web/i18n/pl.json
@@ -705,7 +705,7 @@
     "aiExplainNotConfigured": "AI nie jest skonfigurowane. Najpierw dodaj ustawienia API.",
     "fsrsTitle": "Stabilność a trudność",
     "monthLabels": "sty|lut|mar|kwi|maj|cze|lip|sie|wrz|paź|lis|gru",
-    "binIntervalLabels": "0 dni|1–3 dni|4–7 dni|8–14 dni|15–30 dni|31–90 dni|>90 dni",
+    "binIntervalLabels": "0 d.|1–3 d.|4–7 d.|8–14 d.|15–30 d.|31–90 d.|>90 d.",
     "binEaseLabels": "1,4–1,6|1,7–2,0|2,1–2,5|2,6–3,0|>3,0",
     "binRepsLabels": "0|1|2–3|4–7|8–15|>15",
     "sunday": "niedz.",

--- a/src/web/js/graphs/charts.ts
+++ b/src/web/js/graphs/charts.ts
@@ -284,7 +284,7 @@ export function renderDueForecast(_chartEntries?: readonly VocabEntry[], options
     drawChartBar(ctx, x, y, barW, h, d === 0 ? green : blue, 2);
     hotAreas.push({ x, y, w: barW, h, label: buckets[d] + ' ' + t("graphs.cards") });
   }
-  ctx.fillStyle = labelMuted; ctx.font = "10px Inter, sans-serif"; ctx.textAlign = "right"; ctx.textBaseline = "middle";
+  ctx.fillStyle = labelMuted; ctx.font = "11px Inter, sans-serif"; ctx.textAlign = "right"; ctx.textBaseline = "middle";
   for (let i = 0; i <= 4; i++) ctx.fillText(String(Math.round((i / 4) * maxVal)), pad.left - 6, pad.top + ph - (i / 4) * ph);
   ctx.textAlign = "center"; ctx.textBaseline = "top";
   for (let d = 0; d < DAYS; d += 5) {
@@ -517,7 +517,7 @@ export function renderFsrsScatter(_chartEntries?: readonly VocabEntry[], _option
     ctx.beginPath(); ctx.moveTo(x, pad.top); ctx.lineTo(x, pad.top + ph); ctx.stroke();
   }
   const fmt = (v: number) => maxS < 10 ? v.toFixed(1) : Math.round(v).toString();
-  ctx.fillStyle = labelMuted; ctx.font = "10px Inter, sans-serif"; ctx.textAlign = "right"; ctx.textBaseline = "middle";
+  ctx.fillStyle = labelMuted; ctx.font = "11px Inter, sans-serif"; ctx.textAlign = "right"; ctx.textBaseline = "middle";
   for (let i = 0; i <= 4; i++) { ctx.fillText(fmt((i / 4) * maxS), pad.left - 6, pad.top + ph - (i / 4) * ph); }
   ctx.textAlign = "center"; ctx.textBaseline = "top";
   for (let i = 0; i <= 4; i++) ctx.fillText(Math.round((i / 4) * maxD).toString(), pad.left + (i / 4) * pw, H - pad.bottom + 16);

--- a/src/web/js/graphs/helpers.ts
+++ b/src/web/js/graphs/helpers.ts
@@ -114,7 +114,7 @@ export function canvas(id: string): ChartContext | null {
   const p = c.parentElement;
   if (!p) return null;
   const ps = getComputedStyle(p);
-  const w = Math.max(280, p.clientWidth - parseFloat(ps.paddingLeft) - parseFloat(ps.paddingRight)) || 400;
+  const w = Math.max(240, p.clientWidth - parseFloat(ps.paddingLeft) - parseFloat(ps.paddingRight)) || 400;
   const h = Math.round(parseFloat(getComputedStyle(c).height)) || Math.round(w / 1.5);
   const pixelWidth = Math.max(1, Math.round(w * dpr));
   const pixelHeight = Math.max(1, Math.round(h * dpr));
@@ -133,9 +133,34 @@ export function canvas(id: string): ChartContext | null {
 export function showTooltip(evt: MouseEvent, tipText: string): void {
   if (!tooltipEl) { tooltipEl = document.createElement("div"); tooltipEl.className = "chart-tooltip"; document.body.appendChild(tooltipEl); }
   tooltipEl.textContent = tipText;
-  tooltipEl.style.left = (evt.clientX + 14) + "px";
-  tooltipEl.style.top = (evt.clientY - 32) + "px";
+  const pos = clampTooltipPosition(
+    evt.clientX + 14,
+    evt.clientY - 32,
+    tooltipEl.offsetWidth,
+    tooltipEl.offsetHeight,
+    window.innerWidth,
+    window.innerHeight
+  );
+  tooltipEl.style.left = pos.x + "px";
+  tooltipEl.style.top = pos.y + "px";
   tooltipEl.style.display = "block";
+}
+
+// Keeps the tooltip inside the viewport (8 px margin) — near the right/bottom
+// edges it would otherwise render off-screen.
+export function clampTooltipPosition(
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  viewportWidth: number,
+  viewportHeight: number
+): { x: number; y: number } {
+  const margin = 8;
+  return {
+    x: Math.max(margin, Math.min(x, viewportWidth - width - margin)),
+    y: Math.max(margin, Math.min(y, viewportHeight - height - margin))
+  };
 }
 
 export function hideTooltip(): void { if (tooltipEl) tooltipEl.style.display = "none"; }
@@ -196,7 +221,7 @@ export function drawBarChart(
     }
     ctx.strokeRect(pad.left, pad.top, pw, ph);
     ctx.fillStyle = labelMuted;
-    ctx.font = "10px Inter, sans-serif";
+    ctx.font = "11px Inter, sans-serif";
     ctx.textAlign = "right";
     ctx.textBaseline = "middle";
     for (let i = 0; i <= 4; i++) {
@@ -208,15 +233,21 @@ export function drawBarChart(
     const x = pad.left + i * (pw / bins.length) + (minimal ? 2 : 3);
     drawChartBar(ctx, x, pad.top + ph - h, barW, h, bins[i].color || color);
     ctx.fillStyle = minimal ? text : labelMuted;
-    ctx.font = "9px Inter, sans-serif";
+    ctx.font = "10px Inter, sans-serif";
     ctx.textAlign = "center";
     ctx.textBaseline = "top";
     ctx.fillText(bins[i].label, x + barW / 2, H - pad.bottom + (minimal ? 8 : 14));
     if (bins[i].val > 0) {
-      ctx.fillStyle = text;
-      ctx.font = minimal ? "9px Inter,sans-serif" : "bold 10px Inter, sans-serif";
-      ctx.textBaseline = minimal ? "top" : "bottom";
-      ctx.fillText(String(bins[i].val), x + barW / 2, minimal ? pad.top + ph - h - 4 : Math.max(18, pad.top + ph - h - 4));
+      // Value label above the bar; skip it when the bar fills the plot (the
+      // label would collide with the title/subtitle zone — the old clamp to
+      // y=18 parked short-bar labels right on top of the subtitle).
+      const ly = pad.top + ph - h - 4;
+      if (ly >= pad.top + 12) {
+        ctx.fillStyle = text;
+        ctx.font = minimal ? "10px Inter,sans-serif" : "bold 11px Inter, sans-serif";
+        ctx.textBaseline = minimal ? "top" : "bottom";
+        ctx.fillText(String(bins[i].val), x + barW / 2, ly);
+      }
     }
   }
 }

--- a/src/web/js/graphs/helpers.ts
+++ b/src/web/js/graphs/helpers.ts
@@ -133,6 +133,9 @@ export function canvas(id: string): ChartContext | null {
 export function showTooltip(evt: MouseEvent, tipText: string): void {
   if (!tooltipEl) { tooltipEl = document.createElement("div"); tooltipEl.className = "chart-tooltip"; document.body.appendChild(tooltipEl); }
   tooltipEl.textContent = tipText;
+  // Show first, then measure: offsetWidth/offsetHeight of a display:none
+  // element are 0 and the clamp would compute against an empty box.
+  tooltipEl.style.display = "block";
   const pos = clampTooltipPosition(
     evt.clientX + 14,
     evt.clientY - 32,
@@ -143,7 +146,6 @@ export function showTooltip(evt: MouseEvent, tipText: string): void {
   );
   tooltipEl.style.left = pos.x + "px";
   tooltipEl.style.top = pos.y + "px";
-  tooltipEl.style.display = "block";
 }
 
 // Keeps the tooltip inside the viewport (8 px margin) — near the right/bottom


### PR DESCRIPTION
Readability fixes from the full Graphs audit (user: napisy/opisy nie w pełni widoczne):

- **Fonts** 9→10 / 10→11 px (axis, bin, value labels)
- **Label overlap** — value label above a full-height bar was clamped into the subtitle zone; now skipped when it would collide
- **Tooltip** clamped to the viewport (was rendering off-screen near edges); pure clampTooltipPosition + 4 tests
- **Narrow windows** — canvas min-width 280→240 (was clipping in the 1fr grid)
- **pl binIntervalLabels** shortened ("0 dni"→"0 d.") — 7 bins no longer collide at 9-10px

Full suite 628/628, tsc clean. Part of the Graphs audit wave (correctness PRs follow).