### PR TITLE
fix(graphs): consistent local calendar day (forecast/stats/AI/heatmap)

### DIFF
--- a/frontend-tests/shared/render-performance.test.js
+++ b/frontend-tests/shared/render-performance.test.js
@@ -502,7 +502,8 @@ describe("render performance guards", () => {
       "../state.js": { state: { vocab: {} } },
       "../i18n.js": { t: (key) => key },
       "../loading.js": { setElementBusy() {} },
-      "../views/heatmap.js": { renderContributionHeatmap() {} }
+      "../views/heatmap.js": { renderContributionHeatmap() {} },
+      "../sm2.js": { todayISO: () => "2026-08-12" }
     }, {
       document: {
         documentElement: {},

--- a/src/web/js/graphs/ai-summary.ts
+++ b/src/web/js/graphs/ai-summary.ts
@@ -4,6 +4,7 @@
  * conclusions summary into a section below the graphs.
  */
 import { state } from "../state.js";
+import { todayISO } from "../sm2.js";
 import {
   aiExplanationConfigured,
   aiExplanationLanguagePair,
@@ -18,7 +19,7 @@ import type { VocabEntry } from "./helpers.js";
 /** Serialize the current vocabulary statistics as plain text for the LLM. */
 function buildGraphsSummaryText(): string {
   const entries = Object.values(state.vocab) as VocabEntry[];
-  const today = new Date().toISOString().slice(0, 10);
+  const today = todayISO();
   let total = 0;
   let newCount = 0;
   let learning = 0;

--- a/src/web/js/graphs/charts.ts
+++ b/src/web/js/graphs/charts.ts
@@ -2,6 +2,7 @@
  * Individual chart render functions for the graphs view.
  */
 import { state } from "../state.js";
+import { todayISO } from "../sm2.js";
 import { getLocale, t as rawT } from "../i18n.js";
 import { effectiveLearningLanguage } from "../translator-preferences.js";
 import {
@@ -196,7 +197,9 @@ export function renderDueForecast(_chartEntries?: readonly VocabEntry[], options
   const W = ctx.w, H = ctx.h;
   const pad = { top: 52, right: 20, bottom: 40, left: 44 };
   const pw = W - pad.left - pad.right, ph = H - pad.top - pad.bottom;
-  const today = new Date().toISOString().slice(0, 10);
+  // Local "today" — the review queue (isDue) uses todayISO(); using UTC
+  // here shifted every bucket by a day in the 00:00-02:00 window (PL).
+  const today = todayISO();
   if (options.allTime) {
     const todayDate = new Date(`${today}T00:00:00`);
     let overdue = 0;

--- a/src/web/js/graphs/helpers.ts
+++ b/src/web/js/graphs/helpers.ts
@@ -2,6 +2,7 @@
  * Shared helpers and module-level state for graphs.
  */
 import { state } from "../state.js";
+import { todayISO } from "../sm2.js";
 import { t as rawT } from "../i18n.js";
 import { setElementBusy } from "../loading.js";
 import { renderContributionHeatmap } from "../views/heatmap.js";
@@ -255,7 +256,9 @@ export function buildHeatmapActivityCounts(entries: readonly VocabEntry[]) {
     const time = new Date(d).getTime();
     if (!Number.isFinite(time)) continue;
     firstTime = Math.min(firstTime, time);
-    const day = new Date(time).toISOString().slice(0, 10);
+    // Local calendar day — a review at 23:30 local must count for that
+    // day, not the next UTC day.
+    const day = todayISO(new Date(time));
     counts[day] = (counts[day] || 0) + 1;
   }
   return { counts, firstTime };
@@ -283,7 +286,7 @@ export function renderStatsSummary(_chartEntries?: readonly VocabEntry[]): void 
   const el = document.getElementById("graphs-stats");
   if (!el) return;
   let due = 0, overdue = 0, total = 0, newCount = 0, learning = 0, known = 0, matureCount = 0;
-  const today = new Date().toISOString().slice(0, 10);
+  const today = todayISO();
   for (const e of _chartEntries || Object.values(state.vocab) as VocabEntry[]) {
     if (e.status === "ignored") continue;
     total++;

--- a/src/web/js/state/normalize.ts
+++ b/src/web/js/state/normalize.ts
@@ -10,6 +10,7 @@ import {
   STORAGE_KEY,
   UI_SCALE
 } from "../constants.js";
+import { todayISO } from "../sm2.js";
 import { clamp, cleanCatalogTitle } from "../utils.js";
 import { createDefaultState, getDefaultDictionaryUrl, normalizeAnkiExportStatuses, normalizeVocabStatusFilters } from "./defaults.js";
 import { normalizeLearningColors } from "../reader-colors.js";
@@ -279,7 +280,9 @@ function normalizeVocabEntries(rawVocab: unknown, language = "en"): WhVocabulary
     if (typeof entry.stability !== "number" || !Number.isFinite(entry.stability)) entry.stability = 0;
     if (typeof entry.difficulty !== "number" || !Number.isFinite(entry.difficulty)) entry.difficulty = 5;
     if (entry.srsAlgorithm !== "fsrs") entry.srsAlgorithm = "sm2";
-    if (!entry.nextDate) entry.nextDate = new Date().toISOString().slice(0, 10);
+    // Local day (todayISO) — a UTC date here made cards added between
+    // 00:00 and 02:00 local time immediately overdue.
+    if (!entry.nextDate) entry.nextDate = todayISO();
   }
   return vocab;
 }

--- a/src/web/js/vocabulary/review-chart.ts
+++ b/src/web/js/vocabulary/review-chart.ts
@@ -5,9 +5,11 @@
  * Colors and the no-grid bar-chart variant are shared with the Graphs view via
  * graphs/helpers.js so the palette and basic canvas drawing stay in one place.
  *
- * diffDays is kept local (UTC-midnight parsing) rather than reusing
- * graphs/helpers.js::daysBetween (local-midnight parsing): the two disagree
- * around DST transitions and across host time zones.
+ * Both diffDays (local to this file) and graphs/helpers.js::daysBetween parse
+ * "YYYY-MM-DD" date-only strings at UTC midnight per ECMA-262, so the two
+ * produce identical day differences. The real date consistency rule is the
+ * "today" SOURCE: review cards use local todayISO() (sm2.js), so the charts
+ * must use the same local today — see renderDueForecast/renderStatsSummary.
  */
 import { state } from "../state.js";
 import { els } from "../dom.js";


### PR DESCRIPTION
UTC-vs-local date audit fix (agent-verified): 4 sites used UTC today while the review queue uses local todayISO(). In the 00:00-02:00 window (PL): forecast buckets shifted a day, overdue inflated, cards added in that window went instantly overdue, the AI stats prompt got the wrong day. Fixed to todayISO() everywhere + heatmap day keys local. Stale review-chart.ts comment corrected. Suite 624/624, tsc clean.