### PR TITLE
fix(graphs): day-of-week chart counts real review activity

### DIFF
--- a/frontend-tests/shared/graphs-weekday.test.js
+++ b/frontend-tests/shared/graphs-weekday.test.js
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { readFile } from "node:fs/promises";
+import vm from "node:vm";
+
+// countReviewsByWeekday: review activity per weekday must come from
+// lastReviewedAt only — cards never reviewed were counted by their
+// addedAt day (583/640 in the user's data), faking "review activity".
+
+async function loadHelpers() {
+  const globals = {
+    console,
+    Date,
+    Math,
+    JSON,
+    setTimeout,
+    clearTimeout,
+    requestAnimationFrame: () => 0,
+    cancelAnimationFrame: () => {},
+    document: {
+      getElementById: () => null,
+      querySelectorAll: () => []
+    },
+    window: {}
+  };
+  const context = vm.createContext(globals);
+  const modules = new Map();
+  const createMock = (specifier, values) =>
+    new vm.SyntheticModule(
+      Object.keys(values),
+      function initialize() {
+        for (const [name, value] of Object.entries(values)) this.setExport(name, value);
+      },
+      { context, identifier: `mock:${specifier}` }
+    );
+  const imports = {
+    "../state.js": { state: { vocab: {} } },
+    "../i18n.js": { t: (key) => key },
+    "../loading.js": { setElementBusy: () => {} },
+    "../views/heatmap.js": { renderContributionHeatmap: () => {} },
+    "../sm2.js": { todayISO: () => "2026-08-12" }
+  };
+  for (const [specifier, values] of Object.entries(imports)) {
+    modules.set(specifier, createMock(specifier, values));
+  }
+  const getModule = (specifier) => {
+    const dependency = modules.get(specifier);
+    assert.ok(dependency, `unexpected import ${specifier}`);
+    return dependency;
+  };
+  const module = new vm.SourceTextModule(await readFile("dist/web/js/graphs/helpers.js", "utf8"), {
+    context,
+    identifier: "helpers.js"
+  });
+  await module.link(getModule);
+  await module.evaluate();
+  return module.namespace;
+}
+
+describe("countReviewsByWeekday (graphs/helpers)", () => {
+  it("counts a review on its local weekday", async () => {
+    const { countReviewsByWeekday } = await loadHelpers();
+    const r = countReviewsByWeekday([
+      { status: "learning", lastReviewedAt: "2026-08-10T09:00:00.000Z" } // Monday (2026-08-10)
+    ]);
+    assert.equal(r.total, 1);
+    assert.equal(r.counts[1], 1); // Monday = index 1
+  });
+
+  it("excludes cards never reviewed (addedAt must not count)", async () => {
+    const { countReviewsByWeekday } = await loadHelpers();
+    const r = countReviewsByWeekday([
+      { status: "new", addedAt: "2026-08-12T09:00:00.000Z" },
+      { status: "learning", addedAt: "2026-08-12T09:00:00.000Z", lastReviewedAt: "2026-08-12T10:00:00.000Z" }
+    ]);
+    assert.equal(r.total, 1);
+  });
+
+  it("excludes ignored cards", async () => {
+    const { countReviewsByWeekday } = await loadHelpers();
+    const r = countReviewsByWeekday([
+      { status: "ignored", lastReviewedAt: "2026-08-10T09:00:00.000Z" },
+      { status: "learning", lastReviewedAt: "2026-08-11T09:00:00.000Z" }
+    ]);
+    assert.equal(r.total, 1);
+    assert.equal(r.counts[2], 1); // Tuesday
+  });
+});

--- a/src/web/js/graphs/charts.ts
+++ b/src/web/js/graphs/charts.ts
@@ -8,7 +8,7 @@ import { effectiveLearningLanguage } from "../translator-preferences.js";
 import {
   C, text, muted, blue, green, red, amber, panelBg, grid, labelMuted,
   DAYS, canvas, daysBetween, showTooltip, hideTooltip, drawBarChart, drawChartBar, colorWithAlpha,
-  buildEaseFactorBins
+  buildEaseFactorBins, countReviewsByWeekday
 } from "./helpers.js";
 import { countMatureYoung } from "./helpers.js";
 import type { ChartBin, ChartOptions, VocabEntry } from "./helpers.js";
@@ -456,13 +456,7 @@ export function renderDayOfWeek(_chartEntries?: readonly VocabEntry[], _options?
   const DAY_KEYS = ["sunday", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday"];
   const W = ctx.w, H = ctx.h;
   const dayNames = DAY_KEYS.map((key) => t(`graphs.${key}`));
-  const counts = new Array(7).fill(0);
-  let total = 0;
-  for (const e of _chartEntries || stateVocabEntries()) {
-    if (e.status === "ignored" || !e.addedAt && !e.lastReviewedAt) continue;
-    const d = new Date(e.lastReviewedAt || e.addedAt);
-    counts[d.getDay()]++; total++;
-  }
+  const { counts, total } = countReviewsByWeekday(_chartEntries || stateVocabEntries());
   const maxVal = Math.max(1, ...counts);
   const pad = { top: 48, right: 28, bottom: 54, left: 50 };
   const pw = W - pad.left - pad.right;

--- a/src/web/js/graphs/helpers.ts
+++ b/src/web/js/graphs/helpers.ts
@@ -84,6 +84,20 @@ export function countMatureYoung(entries: readonly VocabEntry[]): { young: numbe
   return { young, mature };
 }
 
+// Review activity per weekday — counts cards by their lastReviewedAt LOCAL
+// weekday only. Cards never reviewed must not count (they used to fall back
+// to addedAt, faking "review activity" — 583/640 entries in the user's data).
+export function countReviewsByWeekday(entries: readonly VocabEntry[]): { counts: number[]; total: number } {
+  const counts = new Array(7).fill(0);
+  let total = 0;
+  for (const e of entries) {
+    if (e.status === "ignored" || !e.lastReviewedAt) continue;
+    counts[new Date(e.lastReviewedAt).getDay()]++;
+    total++;
+  }
+  return { counts, total };
+}
+
 const t = rawT as (key: string, vars?: TranslationVars) => string;
 
 // Theme colors (initialized by updateColors)


### PR DESCRIPTION
The weekday chart fell back to `addedAt` for never-reviewed cards (583/640 in the user's data) — 'review activity' was mostly 'add activity'. Now counts only `lastReviewedAt` (local weekday, ignored excluded) via a tested helper `countReviewsByWeekday`. Suite 627/627, tsc clean.