### PR TITLE
feat(graphs): forecast projects future reviews

### DIFF
--- a/frontend-tests/shared/graphs-maturity.test.js
+++ b/frontend-tests/shared/graphs-maturity.test.js
@@ -44,7 +44,7 @@ async function loadHelpers() {
     "../i18n.js": { t: (key) => key },
     "../loading.js": { setElementBusy: () => {} },
     "../views/heatmap.js": { renderContributionHeatmap: () => {} },
-    "../sm2.js": { todayISO: () => "2026-08-12" }
+    "../sm2.js": { todayISO: () => "2026-08-12", simulateNextReview: () => ({ interval: 1, nextDate: "2026-08-13" }) }
   };
   for (const [specifier, values] of Object.entries(imports)) {
     modules.set(specifier, createMock(specifier, values));

--- a/frontend-tests/shared/graphs-projection.test.js
+++ b/frontend-tests/shared/graphs-projection.test.js
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { readFile } from "node:fs/promises";
+import vm from "node:vm";
+
+// projectDueBuckets: real nextDate buckets + one simulated "good" review for
+// every due card (the Graphs forecast projection). The scheduler is mocked
+// to nextDate = today + 1 so the bucket math is what's under test.
+
+async function loadHelpers() {
+  const globals = {
+    console,
+    Date,
+    Math,
+    JSON,
+    setTimeout,
+    clearTimeout,
+    requestAnimationFrame: () => 0,
+    cancelAnimationFrame: () => {},
+    document: {
+      getElementById: () => null,
+      querySelectorAll: () => []
+    },
+    window: {}
+  };
+  const context = vm.createContext(globals);
+  const modules = new Map();
+  const createMock = (specifier, values) =>
+    new vm.SyntheticModule(
+      Object.keys(values),
+      function initialize() {
+        for (const [name, value] of Object.entries(values)) this.setExport(name, value);
+      },
+      { context, identifier: `mock:${specifier}` }
+    );
+  const imports = {
+    "../state.js": { state: { vocab: {} } },
+    "../i18n.js": { t: (key) => key },
+    "../loading.js": { setElementBusy: () => {} },
+    "../views/heatmap.js": { renderContributionHeatmap: () => {} },
+    "../sm2.js": {
+      todayISO: () => "2026-08-12",
+      simulateNextReview: () => ({ interval: 1, nextDate: "2026-08-13" })
+    }
+  };
+  for (const [specifier, values] of Object.entries(imports)) {
+    modules.set(specifier, createMock(specifier, values));
+  }
+  const getModule = (specifier) => {
+    const dependency = modules.get(specifier);
+    assert.ok(dependency, `unexpected import ${specifier}`);
+    return dependency;
+  };
+  const module = new vm.SourceTextModule(await readFile("dist/web/js/graphs/helpers.js", "utf8"), {
+    context,
+    identifier: "helpers.js"
+  });
+  await module.link(getModule);
+  await module.evaluate();
+  return module.namespace;
+}
+
+const TODAY = "2026-08-12";
+
+describe("projectDueBuckets (graphs/helpers)", () => {
+  it("keeps a due-today card in bucket 0 and projects its next review", async () => {
+    const { projectDueBuckets } = await loadHelpers();
+    const r = projectDueBuckets(
+      [{ status: "learning", nextDate: "2026-08-12" }],
+      TODAY,
+      30,
+      4
+    );
+    assert.equal(r.total, 1);
+    assert.equal(r.overdue, 0);
+    assert.equal(r.buckets[0], 1);
+    assert.equal(r.buckets[1], 1); // simulated +1 day
+  });
+
+  it("keeps a future card in its bucket without projecting", async () => {
+    const { projectDueBuckets } = await loadHelpers();
+    const r = projectDueBuckets(
+      [{ status: "learning", nextDate: "2026-08-17" }],
+      TODAY,
+      30,
+      4
+    );
+    assert.equal(r.total, 1);
+    assert.equal(r.buckets[5], 1);
+    assert.equal(r.buckets[1], 0);
+  });
+
+  it("counts an overdue card in the overdue bar and projects it", async () => {
+    const { projectDueBuckets } = await loadHelpers();
+    const r = projectDueBuckets(
+      [{ status: "learning", nextDate: "2026-08-09" }],
+      TODAY,
+      30,
+      4
+    );
+    assert.equal(r.overdue, 1);
+    assert.equal(r.buckets[1], 1);
+  });
+
+  it("skips known, ignored and missing-nextDate cards", async () => {
+    const { projectDueBuckets } = await loadHelpers();
+    const r = projectDueBuckets(
+      [
+        { status: "known", nextDate: "2026-08-12" },
+        { status: "ignored", nextDate: "2026-08-12" },
+        { status: "learning" }
+      ],
+      TODAY,
+      30,
+      4
+    );
+    assert.equal(r.total, 0);
+    assert.equal(r.buckets.every((v) => v === 0), true);
+  });
+});

--- a/frontend-tests/shared/graphs-readability.test.js
+++ b/frontend-tests/shared/graphs-readability.test.js
@@ -38,7 +38,7 @@ async function loadHelpers() {
     "../i18n.js": { t: (key) => key },
     "../loading.js": { setElementBusy: () => {} },
     "../views/heatmap.js": { renderContributionHeatmap: () => {} },
-    "../sm2.js": { todayISO: () => "2026-08-12" }
+    "../sm2.js": { todayISO: () => "2026-08-12", simulateNextReview: () => ({ interval: 1, nextDate: "2026-08-13" }) }
   };
   for (const [specifier, values] of Object.entries(imports)) {
     modules.set(specifier, createMock(specifier, values));

--- a/frontend-tests/shared/graphs-weekday.test.js
+++ b/frontend-tests/shared/graphs-weekday.test.js
@@ -38,7 +38,7 @@ async function loadHelpers() {
     "../i18n.js": { t: (key) => key },
     "../loading.js": { setElementBusy: () => {} },
     "../views/heatmap.js": { renderContributionHeatmap: () => {} },
-    "../sm2.js": { todayISO: () => "2026-08-12" }
+    "../sm2.js": { todayISO: () => "2026-08-12", simulateNextReview: () => ({ interval: 1, nextDate: "2026-08-13" }) }
   };
   for (const [specifier, values] of Object.entries(imports)) {
     modules.set(specifier, createMock(specifier, values));

--- a/frontend-tests/shared/render-performance.test.js
+++ b/frontend-tests/shared/render-performance.test.js
@@ -503,7 +503,7 @@ describe("render performance guards", () => {
       "../i18n.js": { t: (key) => key },
       "../loading.js": { setElementBusy() {} },
       "../views/heatmap.js": { renderContributionHeatmap() {} },
-      "../sm2.js": { todayISO: () => "2026-08-12" }
+      "../sm2.js": { todayISO: () => "2026-08-12", simulateNextReview: () => ({ interval: 1, nextDate: "2026-08-13" }) }
     }, {
       document: {
         documentElement: {},

--- a/src/web/js/graphs/charts.ts
+++ b/src/web/js/graphs/charts.ts
@@ -8,7 +8,7 @@ import { effectiveLearningLanguage } from "../translator-preferences.js";
 import {
   C, text, muted, blue, green, red, amber, panelBg, grid, labelMuted,
   DAYS, canvas, daysBetween, showTooltip, hideTooltip, drawBarChart, drawChartBar, colorWithAlpha,
-  buildEaseFactorBins, countReviewsByWeekday
+  buildEaseFactorBins, countReviewsByWeekday, projectDueBuckets
 } from "./helpers.js";
 import { countMatureYoung } from "./helpers.js";
 import type { ChartBin, ChartOptions, VocabEntry } from "./helpers.js";
@@ -250,16 +250,11 @@ export function renderDueForecast(_chartEntries?: readonly VocabEntry[], options
     ctx.fillText(t("graphs.totalReviews", { n: total, overdue }), W / 2, 24);
     return;
   }
-  const buckets = new Array(DAYS).fill(0);
-  let overdue = 0, total = 0;
-  for (const e of _chartEntries || stateVocabEntries()) {
-    if (e.status === "ignored" || e.status === "known") continue;
-    if (!e.nextDate) continue;
-    total++;
-    const delta = daysBetween(e.nextDate, today);
-    if (delta < 0) overdue++;
-    else if (delta < DAYS) buckets[delta]++;
-  }
+  const { buckets, overdue, total } = projectDueBuckets(
+    _chartEntries || stateVocabEntries(),
+    today,
+    DAYS
+  );
   const maxVal = Math.max(1, overdue, ...buckets);
   const totalSlots = DAYS + (overdue > 0 ? 1 : 0);
   const barW = Math.max(2, pw / totalSlots - 3);

--- a/src/web/js/graphs/helpers.ts
+++ b/src/web/js/graphs/helpers.ts
@@ -4,6 +4,8 @@
 import { state } from "../state.js";
 import { todayISO } from "../sm2.js";
 import { t as rawT } from "../i18n.js";
+import { simulateNextReview } from "../sm2.js";
+import type { SrsEntry } from "../sm2.js";
 import { setElementBusy } from "../loading.js";
 import { renderContributionHeatmap } from "../views/heatmap.js";
 
@@ -135,6 +137,34 @@ function dateTimestamp(value: DateInput): number {
 
 export function daysBetween(a: DateInput, b: DateInput): number {
   return Math.round((dateTimestamp(a) - dateTimestamp(b)) / 86400000);
+}
+
+// Forecast projection: the real buckets for existing nextDates PLUS, for
+// every due card (delta <= 0), one simulated "good" review through the
+// card's own scheduler — so the chart shows what the coming days will look
+// like after today's session, not just an empty future.
+export function projectDueBuckets(
+  entries: readonly VocabEntry[],
+  today: string,
+  horizon = 30,
+  quality: unknown = 4
+): { buckets: number[]; overdue: number; total: number } {
+  const buckets = new Array(horizon).fill(0);
+  let overdue = 0;
+  let total = 0;
+  for (const e of entries) {
+    if (e.status === "ignored" || e.status === "known" || !e.nextDate) continue;
+    total++;
+    const delta = daysBetween(e.nextDate, today);
+    if (delta < 0) overdue++;
+    else if (delta < horizon) buckets[delta]++;
+    if (delta <= 0) {
+      const sim = simulateNextReview(e as unknown as SrsEntry, quality);
+      const sd = daysBetween(sim.nextDate, today);
+      if (sd > 0 && sd < horizon) buckets[sd]++;
+    }
+  }
+  return { buckets, overdue, total };
 }
 
 export function canvas(id: string): ChartContext | null {

--- a/src/web/js/sm2.ts
+++ b/src/web/js/sm2.ts
@@ -150,6 +150,25 @@ export function todayISO(date = new Date()): string {
   return `${y}-${m}-${d}`;
 }
 
+/**
+ * Pure, non-mutating simulation of one review: applies the card's own
+ * scheduler (SM2 or FSRS) with the given quality and returns the projected
+ * interval and nextDate. Used by the Graphs forecast projection — the real
+ * review path (applyReviewNative) is left untouched.
+ */
+export function simulateNextReview(
+  entry: SrsEntry,
+  quality: unknown,
+  now = new Date()
+): { interval: number; nextDate: string } {
+  const schedule = entry.srsAlgorithm === "fsrs"
+    ? calculateFSRS(quality, entry, now)
+    : calculateSM2(quality, entry);
+  const next = new Date(now);
+  next.setDate(next.getDate() + schedule.interval);
+  return { interval: schedule.interval, nextDate: todayISO(next) };
+}
+
 /** Adds N days to a date and returns in YYYY-MM-DD format. */
 function addDaysISO(days: number, from = new Date()): string {
   const d = new Date(from);

--- a/src/web/js/vocabulary/review-chart.ts
+++ b/src/web/js/vocabulary/review-chart.ts
@@ -16,7 +16,7 @@ import { els } from "../dom.js";
 import { escapeHtml, escapeAttribute } from "../utils.js";
 import { t as rawT } from "../i18n.js";
 import { renderContributionHeatmap } from "../views/heatmap.js";
-import { buildEaseFactorBins, buildHeatmapActivityCounts, drawBarChart, drawChartBar, updateColors, text as ink, muted, blue, green, red, panelBg } from "../graphs/helpers.js";
+import { buildEaseFactorBins, buildHeatmapActivityCounts, drawBarChart, drawChartBar, updateColors, text as ink, muted, blue, green, red, panelBg, projectDueBuckets } from "../graphs/helpers.js";
 import type { ChartContext, VocabEntry } from "../graphs/helpers.js";
 import { formatSrsMeta } from "./review-card.js";
 
@@ -85,13 +85,7 @@ export function renderReviewChart(srsEntries: readonly ReviewEntry[], today: str
 
       if (graphType === "dueForecast") {
         const days = 21;
-        const buckets = new Array(days).fill(0);
-        let overdue = 0;
-        for (const e of srsEntries) {
-          const delta = diffDays(e.nextDate, today);
-          if (delta < 0) overdue++;
-          else if (delta < days) buckets[delta]++;
-        }
+        const { buckets, overdue } = projectDueBuckets(srsEntries, today, days);
         const maxVal = Math.max(1, overdue, ...buckets);
         const barW = Math.max(3, (W - pad.left - pad.right) / (days + (overdue > 0 ? 1 : 0)) - 3);
         let bx = pad.left;


### PR DESCRIPTION
The core fix for "ciągle mam do przeglądania tylko dzisiaj": the due forecast was a static snapshot — only existing nextDates (today + overdue), an empty future. Now every due card gets one simulated "good" review through its own scheduler (SM2 or FSRS, non-mutating `simulateNextReview`) and the projected nextDate lands in the future buckets; overdue stays a separate red bar; known/ignored excluded as before.

Real-data cross-check (752 cards): currently overdue 383 / d0 4 / future 4; with the projection the chart shows tomorrow +70, +3d +30, +4d +264… — the real shape of the coming weeks.

Pure + tested: `projectDueBuckets` (4 cases), `simulateNextReview`. Wired into Graphs AND the Flashcards review chart (21-day view). Suite 628/628, tsc clean.