### PR TITLE
fix(graphs): FSRS scatter spans the real stability range

### DIFF
--- a/frontend-tests/shared/graphs-fsrs-scatter.test.js
+++ b/frontend-tests/shared/graphs-fsrs-scatter.test.js
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { readFile } from "node:fs/promises";
+import vm from "node:vm";
+
+// collectFsrsPoints: fsrs cards with positive stability form the scatter,
+// KNOWN cards included (they carry the top stability values — the axis must
+// span them).
+
+async function loadHelpers() {
+  const globals = {
+    console, Date, Math, JSON, setTimeout, clearTimeout,
+    requestAnimationFrame: () => 0,
+    cancelAnimationFrame: () => {},
+    document: { getElementById: () => null, querySelectorAll: () => [] },
+    window: {}
+  };
+  const context = vm.createContext(globals);
+  const modules = new Map();
+  const createMock = (specifier, values) =>
+    new vm.SyntheticModule(
+      Object.keys(values),
+      function initialize() {
+        for (const [name, value] of Object.entries(values)) this.setExport(name, value);
+      },
+      { context, identifier: `mock:${specifier}` }
+    );
+  const imports = {
+    "../state.js": { state: { vocab: {} } },
+    "../i18n.js": { t: (key) => key },
+    "../loading.js": { setElementBusy: () => {} },
+    "../views/heatmap.js": { renderContributionHeatmap: () => {} },
+    "../sm2.js": { todayISO: () => "2026-08-12", simulateNextReview: () => ({ interval: 1, nextDate: "2026-08-13" }) }
+  };
+  for (const [specifier, values] of Object.entries(imports)) {
+    modules.set(specifier, createMock(specifier, values));
+  }
+  const getModule = (specifier) => {
+    const dependency = modules.get(specifier);
+    assert.ok(dependency, `unexpected import ${specifier}`);
+    return dependency;
+  };
+  const module = new vm.SourceTextModule(await readFile("dist/web/js/graphs/helpers.js", "utf8"), {
+    context,
+    identifier: "helpers.js"
+  });
+  await module.link(getModule);
+  await module.evaluate();
+  return module.namespace;
+}
+
+describe("collectFsrsPoints (graphs/helpers)", () => {
+  it("includes a KNOWN fsrs card and spans the axis to its stability", async () => {
+    const { collectFsrsPoints } = await loadHelpers();
+    const r = collectFsrsPoints([
+      { status: "known", srsAlgorithm: "fsrs", stability: 33.14, difficulty: 5 }
+    ]);
+    assert.equal(r.points.length, 1);
+    assert.equal(r.maxS, 33.14);
+  });
+
+  it("excludes sm2 cards", async () => {
+    const { collectFsrsPoints } = await loadHelpers();
+    const r = collectFsrsPoints([
+      { status: "learning", srsAlgorithm: "sm2", stability: 4, difficulty: 5 }
+    ]);
+    assert.equal(r.points.length, 0);
+    assert.equal(r.maxS, 0);
+  });
+
+  it("excludes ignored and stability-0 cards", async () => {
+    const { collectFsrsPoints } = await loadHelpers();
+    const r = collectFsrsPoints([
+      { status: "ignored", srsAlgorithm: "fsrs", stability: 9, difficulty: 5 },
+      { status: "learning", srsAlgorithm: "fsrs", stability: 0, difficulty: 5 },
+      { status: "learning", srsAlgorithm: "fsrs", stability: 2.5, difficulty: 6 }
+    ]);
+    assert.equal(r.points.length, 1);
+    assert.equal(r.maxS, 2.5);
+  });
+});

--- a/src/web/js/graphs/charts.ts
+++ b/src/web/js/graphs/charts.ts
@@ -8,7 +8,7 @@ import { effectiveLearningLanguage } from "../translator-preferences.js";
 import {
   C, text, muted, blue, green, red, amber, panelBg, grid, labelMuted,
   DAYS, canvas, daysBetween, showTooltip, hideTooltip, drawBarChart, drawChartBar, colorWithAlpha,
-  buildEaseFactorBins, countReviewsByWeekday, projectDueBuckets
+  buildEaseFactorBins, countReviewsByWeekday, projectDueBuckets, collectFsrsPoints
 } from "./helpers.js";
 import { countMatureYoung } from "./helpers.js";
 import type { ChartBin, ChartOptions, VocabEntry } from "./helpers.js";
@@ -488,19 +488,14 @@ export function renderFsrsScatter(_chartEntries?: readonly VocabEntry[], _option
   const W = ctx.w, H = ctx.h;
   const pad = { top: 34, right: 20, bottom: 54, left: 52 };
   const pw = W - pad.left - pad.right, ph = H - pad.top - pad.bottom;
-  const points: Array<{ s: number; d: number }> = [];
-  let maxS = 0, maxD = 10;
-  for (const e of _chartEntries || stateVocabEntries()) {
-    if (e.status === "ignored" || e.status === "known" || e.srsAlgorithm !== "fsrs") continue;
-    const s = e.stability || 0, d = e.difficulty || 5;
-    if (s > 0) { points.push({ s, d }); if (s > maxS) maxS = s; }
-  }
+  const { points, maxS } = collectFsrsPoints(_chartEntries || stateVocabEntries());
+  const maxD = 10;
   if (!points.length) {
     ctx.fillStyle = text; ctx.font = "13px Inter, sans-serif"; ctx.textAlign = "center";
     ctx.fillText(t("graphs.noFsrsData"), W / 2, H / 2);
     return;
   }
-  maxS = Math.max(maxS, 1);
+  const maxSPlot = Math.max(maxS, 1);
   ctx.fillStyle = panelBg; ctx.fillRect(0, 0, W, H);
   ctx.strokeStyle = grid; ctx.lineWidth = 0.5;
   for (let i = 0; i <= 4; i++) {
@@ -509,9 +504,9 @@ export function renderFsrsScatter(_chartEntries?: readonly VocabEntry[], _option
     const x = pad.left + (i / 4) * pw;
     ctx.beginPath(); ctx.moveTo(x, pad.top); ctx.lineTo(x, pad.top + ph); ctx.stroke();
   }
-  const fmt = (v: number) => maxS < 10 ? v.toFixed(1) : Math.round(v).toString();
+  const fmt = (v: number) => maxSPlot < 10 ? v.toFixed(1) : Math.round(v).toString();
   ctx.fillStyle = labelMuted; ctx.font = "11px Inter, sans-serif"; ctx.textAlign = "right"; ctx.textBaseline = "middle";
-  for (let i = 0; i <= 4; i++) { ctx.fillText(fmt((i / 4) * maxS), pad.left - 6, pad.top + ph - (i / 4) * ph); }
+  for (let i = 0; i <= 4; i++) { ctx.fillText(fmt((i / 4) * maxSPlot), pad.left - 6, pad.top + ph - (i / 4) * ph); }
   ctx.textAlign = "center"; ctx.textBaseline = "top";
   for (let i = 0; i <= 4; i++) ctx.fillText(Math.round((i / 4) * maxD).toString(), pad.left + (i / 4) * pw, H - pad.bottom + 16);
   ctx.textAlign = "center"; ctx.textBaseline = "top";
@@ -523,7 +518,7 @@ export function renderFsrsScatter(_chartEntries?: readonly VocabEntry[], _option
   ctx.restore();
   for (const p of points) {
     const x = pad.left + (p.d / maxD) * pw;
-    const y = pad.top + ph - (p.s / maxS) * ph;
+    const y = pad.top + ph - (p.s / maxSPlot) * ph;
     ctx.fillStyle = blue; ctx.beginPath(); ctx.arc(x, y, 4, 0, Math.PI * 2); ctx.fill();
     ctx.fillStyle = panelBg; ctx.beginPath(); ctx.arc(x, y, 3, 0, Math.PI * 2); ctx.fill();
   }

--- a/src/web/js/graphs/helpers.ts
+++ b/src/web/js/graphs/helpers.ts
@@ -100,6 +100,26 @@ export function countReviewsByWeekday(entries: readonly VocabEntry[]): { counts:
   return { counts, total };
 }
 
+// FSRS scatter points: every fsrs card with a positive stability, INCLUDING
+// known cards — the known cohort carries the highest stability values (e.g.
+// 33+) and the axis must span them, or the chart compresses the whole range.
+export function collectFsrsPoints(
+  entries: readonly VocabEntry[]
+): { points: Array<{ s: number; d: number }>; maxS: number } {
+  const points: Array<{ s: number; d: number }> = [];
+  let maxS = 0;
+  for (const e of entries) {
+    if (e.status === "ignored" || e.srsAlgorithm !== "fsrs") continue;
+    const s = e.stability || 0;
+    const d = e.difficulty || 5;
+    if (s > 0) {
+      points.push({ s, d });
+      if (s > maxS) maxS = s;
+    }
+  }
+  return { points, maxS };
+}
+
 const t = rawT as (key: string, vars?: TranslationVars) => string;
 
 // Theme colors (initialized by updateColors)


### PR DESCRIPTION
The scatter excluded `known` cards, so the stability axis capped at ~7 while the real maximum (a known card) is 33.14 — the whole cohort was compressed into the bottom of the chart. Now known fsrs cards are included (ignored and stability-0 excluded as before) via a tested `collectFsrsPoints` helper. Suite 627/627, tsc clean.