### PR TITLE
scoop: Word Hunter 1.0.12 (real sha256)

### DIFF
--- a/packaging/scoop/wordhunter.json
+++ b/packaging/scoop/wordhunter.json
@@ -5,8 +5,8 @@
     "license": "AGPL-3.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Ironship/WordHunter/releases/download/WordHunter1.0.11/Word.Hunter.portable.zip",
-            "hash": "681574154a8d76f6914ae04707c7f41ba129e9645f98b1835905793e542afcc8"
+            "url": "https://github.com/Ironship/WordHunter/releases/download/WordHunter1.0.12/Word.Hunter.portable.zip",
+            "hash": "181302768425d4670479b70aef02868fc6ff7d8c1679cbb3e845f4fbb11bc350"
         }
     },
     "shortcuts": [


### PR DESCRIPTION
Post-publish scoop update: version 1.0.12, portable URL + real sha256 from the published release.