### PR TITLE
scoop: revert to 1.0.11 while 1.0.12 is pulled

### DIFF
--- a/packaging/scoop/wordhunter.json
+++ b/packaging/scoop/wordhunter.json
@@ -1,12 +1,12 @@
 {
-    "version": "1.0.12",
+    "version": "1.0.11",
     "description": "Local-first reader, vocabulary trainer, and language-learning workspace",
     "homepage": "https://ironship.github.io/WordHunter-site/",
     "license": "AGPL-3.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Ironship/WordHunter/releases/download/WordHunter1.0.12/Word.Hunter.portable.zip",
-            "hash": "181302768425d4670479b70aef02868fc6ff7d8c1679cbb3e845f4fbb11bc350"
+            "url": "https://github.com/Ironship/WordHunter/releases/download/WordHunter1.0.11/Word.Hunter.portable.zip",
+            "hash": "681574154a8d76f6914ae04707c7f41ba129e9645f98b1835905793e542afcc8"
         }
     },
     "shortcuts": [


### PR DESCRIPTION
1.0.12 was pulled (Android fails to launch); restore the last known-good scoop manifest.