### PR TITLE
fix(android): bundle the frontend into the app assets

### DIFF
--- a/frontend-tests/android/pocket-packaging.test.js
+++ b/frontend-tests/android/pocket-packaging.test.js
@@ -104,6 +104,7 @@ function androidFixture(abi = "arm64-v8a") {
     "base/manifest/AndroidManifest.xml": "binary manifest",
     "base/dex/classes.dex": "dex",
     [`base/lib/${abi}/libword_hunter.so`]: createArm64Elf(),
+    "base/assets/index.html": "<!doctype html>",
     "base/root/LICENSE": "license",
     "base/root/THIRD-PARTY-NOTICES.md": "notices",
     "base/root/THIRD-PARTY-LICENSES.html": "licenses",
@@ -227,6 +228,14 @@ describe("Android Pocket packaging", () => {
       const invalid = join(directory, "Word.Hunter.Pocket.release.aab");
       writeStoredZip(invalid, androidFixture("x86_64"));
       assert.throws(() => inspectAndroidZipList(invalid, "arm64-v8a"), /expected only arm64-v8a/);
+
+      // Regression gate (2026-08-13): an artifact without a bundled
+      // frontend ships an empty WebView.
+      const empty = join(directory, "Word.Hunter.Pocket.release.aab");
+      const emptyFixture = androidFixture();
+      delete emptyFixture["base/assets/index.html"];
+      writeStoredZip(empty, emptyFixture);
+      assert.throws(() => inspectAndroidZipList(empty, "arm64-v8a"), /no bundled frontend/);
     } finally {
       rmSync(directory, { recursive: true, force: true });
     }

--- a/frontend-tests/shared/android-artifact-inspection.test.js
+++ b/frontend-tests/shared/android-artifact-inspection.test.js
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import {
   androidVersionCodeFor,
+  hasFrontendEntry,
   isBadgingDebuggable,
   parseAxmlManifest,
   parseBadgingPackage,
@@ -58,6 +59,14 @@ const debugXmlTree = releaseXmlTree.replace(
 );
 
 describe("Android release artifact assertions", () => {
+  it("requires the bundled frontend entry (APK: assets/index.html, AAB: base/assets/index.html)", () => {
+    assert.equal(hasFrontendEntry(["assets/index.html", "assets/web/app.js"], false), true);
+    assert.equal(hasFrontendEntry(["base/assets/index.html", "base/manifest/AndroidManifest.xml"], true), true);
+    // The 1.0.11/1.0.12 regression: the release recipe never copied dist/web
+    // into the app assets, so every Android build opened an empty WebView.
+    assert.equal(hasFrontendEntry(["assets/tauri.conf.json", "assets/LICENSE"], false), false);
+    assert.equal(hasFrontendEntry(["base/assets/tauri.conf.json"], true), false);
+  });
   it("derives the Android versionCode the way tauri-cli 2.11.4 does", () => {
     assert.equal(androidVersionCodeFor("1.0.10"), 101001099);
     assert.equal(androidVersionCodeFor("1.0.9"), 101000999);

--- a/scripts/build.bat
+++ b/scripts/build.bat
@@ -541,6 +541,26 @@ function Get-AndroidVersionInfo {
     }
 }
 
+function Sync-AndroidFrontendAssets {
+    # The WebView loads tauri://localhost from the app assets root, but the
+    # tauri CLI only injects tauri.conf.json + bundle.resources there — it
+    # never copies frontendDist. Without this step every Android build ships
+    # with an empty frontend (root-caused 2026-08-13: every release since
+    # the Android recipe existed opened a blank screen). The inspector gate
+    # (assets/index.html) turns a regression here into a red pipeline.
+    $assetsDir = Join-Path $Root "src-tauri\gen\android\app\src\main\assets"
+    $distDir = Join-Path $Root "dist\web"
+    if (-not (Test-Path -LiteralPath (Join-Path $distDir "index.html"))) {
+        Fail "compiled frontend is missing: dist\web\index.html (run npm run build:frontend first)"
+    }
+    Ensure-Directory $assetsDir
+    Copy-Item -LiteralPath (Join-Path $distDir "*") -Destination $assetsDir -Recurse -Force
+    if (-not (Test-Path -LiteralPath (Join-Path $assetsDir "index.html"))) {
+        Fail "frontend asset sync failed: index.html missing in $assetsDir"
+    }
+    Write-Note "Frontend assets synced into the Android app assets"
+}
+
 function Prepare-AndroidProject {
     Write-Step "Preparing Android project"
 
@@ -616,6 +636,7 @@ function Prepare-AndroidProject {
     Invoke-External "node.exe" @("scripts\android-version.mjs")
     Invoke-External "node.exe" @("scripts\android-version.mjs", "--check")
 
+    Sync-AndroidFrontendAssets
     Sync-AndroidLauncherIcons
 }
 

--- a/scripts/inspect-artifact.mjs
+++ b/scripts/inspect-artifact.mjs
@@ -244,6 +244,15 @@ function requireSuffix(names, suffix) {
   return found;
 }
 
+// The Android WebView loads tauri://localhost, which serves the assets
+// root: a release APK/AAB without a bundled index.html opens an empty
+// white screen (root-caused 2026-08-13 — the release recipe never copied
+// dist/web into the app assets, affecting every Android release).
+export function hasFrontendEntry(names, isAab) {
+  const expected = isAab ? "base/assets/index.html" : "assets/index.html";
+  return names.some((name) => name === expected);
+}
+
 function assertPeX64(bytes, description) {
   if (bytes.length < 64 || bytes[0] !== 0x4d || bytes[1] !== 0x5a) {
     fail(`${description} is not a PE executable`);
@@ -693,6 +702,9 @@ export function inspectAndroidZipList(path, abi) {
     fail(`${path} unexpectedly contains the desktop OCR runtime`);
   }
   for (const legalFile of legalFiles) requireSuffix(names, legalFile);
+  if (!hasFrontendEntry(names, isAab)) {
+    fail(`${path} has no bundled frontend (${isAab ? "base/assets/index.html" : "assets/index.html"} missing): the WebView would open empty`);
+  }
 
 
   console.log(`Validated ${isAab ? "AAB" : "APK"}: ${path} (${abi}, ${names.length} entries)`);


### PR DESCRIPTION
**'Wersja na Android w ogóle nie włącza się po instalacji' — root cause + fix.**

Every Android artifact since the recipe existed ships WITHOUT the frontend: the APK/AAB contain only icons, licenses and tauri.conf.json (verified by walking the 1.0.11 and 1.0.12 artifacts). The tauri CLI injects only tauri.conf.json + bundle.resources; nothing ever copied dist/web into the app assets — the WebView loads tauri://localhost and finds nothing.

- **build.bat** — new Sync-AndroidFrontendAssets step (index.html at the assets root + hard post-copy assert)
- **inspect-artifact.mjs** — release gate: an artifact without the bundled frontend now FAILS the pipeline inspection (this regression was invisible — the old pipeline was green while shipping a brick)
- tests 644/644, tsc clean

Release 1.0.12 was pulled; the fix will ship as 1.0.13.