### PR TITLE
fix(android): honor APPDATA in data-dir resolution (app crashed at launch)

### DIFF
--- a/src-tauri/src/paths.rs
+++ b/src-tauri/src/paths.rs
@@ -10,16 +10,19 @@ fn env_path(name: &str) -> Option<PathBuf> {
     })
 }
 
-// APPDATA is a Windows concept; on Linux it is at best a Wine/Proton
+// APPDATA is a Windows concept; on Linux/macOS it is at best a Wine/Proton
 // artifact and must never win over the XDG base directories (issue #135,
-// bullet 1). config_dir() and default_data_dir() both route their APPDATA
-// lookup through this single gate, so no per-call-site cfg is needed.
-#[cfg(windows)]
+// bullet 1). Android is the one exception: platform/android.rs sets APPDATA
+// from tauri's app_data_dir during setup (Android has neither XDG nor HOME
+// for app processes), so the mobile build must honor it here.
+// config_dir() and default_data_dir() both route their APPDATA lookup
+// through this single gate, so no per-call-site cfg is needed.
+#[cfg(any(windows, target_os = "android"))]
 fn appdata_dir() -> Option<PathBuf> {
     env_path("APPDATA")
 }
 
-#[cfg(not(windows))]
+#[cfg(not(any(windows, target_os = "android")))]
 fn appdata_dir() -> Option<PathBuf> {
     None
 }
@@ -75,14 +78,25 @@ fn write_config_file(app_name: &str, suffix: &str, bytes: &[u8]) -> Result<(), S
     crate::store::durable::write_file_atomic(&path, bytes, true)
 }
 
-fn default_data_dir(app_name: &str) -> Result<PathBuf, String> {
-    if let Some(appdata) = appdata_dir() {
+// Pure, platform-agnostic resolution core: appdata (Windows native, or the
+// APPDATA contract set by platform/android.rs) wins; otherwise the XDG data
+// base (which already includes the HOME/.local/share fallback). Testable on
+// every host so the Linux/macOS and Android shapes are both pinned.
+pub(crate) fn resolve_default_data_dir(
+    appdata: Option<PathBuf>,
+    xdg_data: Option<PathBuf>,
+    app_name: &str,
+) -> Result<PathBuf, String> {
+    if let Some(appdata) = appdata {
         return Ok(appdata.join(app_name));
     }
-
-    xdg_data_dir()
+    xdg_data
         .map(|base| base.join(app_name))
         .ok_or_else(|| "could not locate user data directory".to_string())
+}
+
+fn default_data_dir(app_name: &str) -> Result<PathBuf, String> {
+    resolve_default_data_dir(appdata_dir(), xdg_data_dir(), app_name)
 }
 
 /// How to treat a stored data-dir pointer whose metadata could not be

--- a/src-tauri/src/tests/paths/tests.rs
+++ b/src-tauri/src/tests/paths/tests.rs
@@ -1,6 +1,8 @@
 #[cfg(unix)]
 use super::config_dir;
-use super::{data_dir, device_id, read_config_file, sanitize_id, write_config_file};
+use super::{
+    data_dir, device_id, read_config_file, resolve_default_data_dir, sanitize_id, write_config_file,
+};
 use std::ffi::OsString;
 use std::path::Path;
 
@@ -44,6 +46,40 @@ fn sanitizes_ids_to_file_names() {
     assert!(sanitize_id("folder\\book-1").is_err());
     assert!(sanitize_id("book:alternate-stream").is_err());
     assert!(sanitize_id("..").is_err());
+}
+
+#[test]
+fn resolve_default_data_dir_platform_shapes() {
+    // Android shape (the 2026-08-13 crash): APPDATA is set by
+    // platform/android.rs from tauri's app_data_dir — it must win even
+    // with no XDG/HOME at all.
+    let appdata = tempfile::tempdir().unwrap();
+    let dir =
+        resolve_default_data_dir(Some(appdata.path().to_path_buf()), None, "WordHunter").unwrap();
+    assert_eq!(dir, appdata.path().join("WordHunter"));
+
+    // Linux/macOS shape: no APPDATA, explicit XDG_DATA_HOME wins.
+    let xdg = tempfile::tempdir().unwrap();
+    let dir = resolve_default_data_dir(None, Some(xdg.path().to_path_buf()), "WordHunter").unwrap();
+    assert_eq!(dir, xdg.path().join("WordHunter"));
+
+    // Linux/macOS shape: no APPDATA, no XDG — the resolved base already
+    // includes the HOME/.local/share fallback (xdg_data_dir does that).
+    let home = tempfile::tempdir().unwrap();
+    let dir = resolve_default_data_dir(
+        None,
+        Some(home.path().join(".local").join("share")),
+        "WordHunter",
+    )
+    .unwrap();
+    assert_eq!(
+        dir,
+        home.path().join(".local").join("share").join("WordHunter")
+    );
+
+    // The exact crash shape: nothing resolvable at all.
+    let error = resolve_default_data_dir(None, None, "WordHunter").unwrap_err();
+    assert_eq!(error, "could not locate user data directory");
 }
 
 #[test]


### PR DESCRIPTION
**The real root cause of the Android launch crash** (replaces #253, which was based on a wrong premise — the frontend is embedded in the binary, not served from APK assets).

Captured on the user's phone (Pixel 9 Pro XL, Android 16, adb logcat):

```
thread '<unnamed>' panicked at tauri-2.11.5/src/app.rs:1425:11:
Failed to setup app: error encountered during setup hook:
could not locate user data directory
```

`paths.rs` appdata_dir() was `cfg(windows)`-only → on Android it ignored the APPDATA that `platform/android.rs` sets from tauri's `app_data_dir`; the XDG/HOME fallback has nothing to work with on Android → error → panic → SIGABRT.

- cfg now `any(windows, target_os = "android")` — Linux/macOS unchanged (XDG-first preserved, pinned by existing tests)
- pure `resolve_default_data_dir` + 4 platform shapes in tests
- cargo test --lib 289/289

Next: after merge → 1.0.13-rc.1 → install on the phone via adb → boot verification.