### PR TITLE
fix(android): bridge-first source links + 44 px TTS touch targets

### DIFF
--- a/frontend-tests/android/uri-bridge-contracts.test.js
+++ b/frontend-tests/android/uri-bridge-contracts.test.js
@@ -1,0 +1,68 @@
+// Contract tests for the 2026-08-13 Android audit fixes (P1/P2):
+// - the Gutenberg card link in the library and the reader source link must
+//   route through the native bridge (window.WordHunterAndroid.openUrl)
+//   BEFORE the /__open_external fallback — the Android webview cannot open
+//   new windows, and a skipped bridge means a dead link or a false
+//   "openExternalFailed" toast;
+// - the review-card TTS buttons must be 44 px touch targets on Pocket
+//   (round-icon-btn-28/24 are 24-28 px wide in the shared stylesheet).
+// Pattern: frontend-tests/shared/youglish-android-bridge.test.js.
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+function assertSourceOrder(source, before, after, message) {
+  const beforeIndex = source.indexOf(before);
+  const afterIndex = source.indexOf(after);
+  assert.notEqual(beforeIndex, -1, `Missing source marker: ${before}`);
+  assert.notEqual(afterIndex, -1, `Missing source marker: ${after}`);
+  assert.ok(beforeIndex < afterIndex, message || `Expected ${before} before ${after}`);
+}
+
+describe("Android URI bridge contracts", () => {
+  it("routes the Gutenberg card link through the native bridge before the server fallback", () => {
+    const library = readFileSync(
+      new URL("../../dist/web/js/views/library.js", import.meta.url),
+      "utf8"
+    );
+    // The link is picked up by the card delegation handler.
+    assert.ok(
+      library.includes('data-action="open-source"'),
+      "library card link must carry data-action=open-source"
+    );
+    // The handler tries the bridge first, then /__open_external.
+    assertSourceOrder(
+      library,
+      "openAndroidUrl(url))",
+      'fetch(`/__open_external?url=',
+      "bridge must run before the /__open_external fallback"
+    );
+  });
+
+  it("routes the reader source link through the native bridge before the server fallback", () => {
+    const renderer = readFileSync(
+      new URL("../../dist/web/js/reader/renderer.js", import.meta.url),
+      "utf8"
+    );
+    assertSourceOrder(
+      renderer,
+      "openAndroidUrl(url))",
+      'fetch(`/__open_external?url=',
+      "bridge must run before the /__open_external fallback"
+    );
+  });
+
+  it("sizes the review-card TTS buttons to 44 px touch targets on Pocket", () => {
+    const css = readFileSync(
+      new URL("../../dist/web/platforms/android-pocket.css", import.meta.url),
+      "utf8"
+    );
+    const start = css.indexOf(".pocket-mode .round-icon-btn-28");
+    assert.notEqual(start, -1, "pocket rule for round-icon-btn must exist");
+    const rule = css.slice(start, css.indexOf("}", start) + 1);
+    for (const expected of ["width: 44px", "min-width: 44px", "height: 44px"]) {
+      assert.ok(rule.includes(expected), `rule must set ${expected}: ${rule}`);
+    }
+    assert.ok(rule.includes(".pocket-mode .round-icon-btn-24"), "rule must cover the 24 px variant too");
+  });
+});

--- a/frontend-tests/shared/dialog-ports.test.js
+++ b/frontend-tests/shared/dialog-ports.test.js
@@ -272,6 +272,8 @@ describe("delete-book dialog renderer (views/library.ts)", () => {
       },
       "../i18n.js": { t: (key) => key, getLocale: () => "en" },
       "../panel-resizer.js": { bindSidebarResizer: () => {} },
+      "../platform.js": { openAndroidUrl: () => false },
+      "../toast.js": { showToast: () => {} },
       "../translator-preferences.js": { effectiveLearningLanguage: () => "en" }
     }, { document, HTMLDialogElement: HTMLDialogElementInstance });
 
@@ -592,6 +594,8 @@ describe("library filter bar renderer (views/library.ts)", () => {
       },
       "../i18n.js": { t: (key) => key, getLocale: () => "en" },
       "../panel-resizer.js": { bindSidebarResizer: () => {} },
+      "../platform.js": { openAndroidUrl: () => false },
+      "../toast.js": { showToast: () => {} },
       "../translator-preferences.js": { effectiveLearningLanguage: () => "en" }
     }, { document, HTMLDialogElement: HTMLDialogElementInstance });
 

--- a/frontend-tests/shared/focused-regressions.test.js
+++ b/frontend-tests/shared/focused-regressions.test.js
@@ -160,6 +160,8 @@ describe("lazy library statistics", () => {
       },
       "../i18n.js": { t: (key) => key, getLocale: () => "en" },
       "../panel-resizer.js": { bindSidebarResizer() {} },
+      "../platform.js": { openAndroidUrl: () => false },
+      "../toast.js": { showToast: () => {} },
       "../translator-preferences.js": { effectiveLearningLanguage: () => "en" }
     }, {
       window: {},

--- a/src/web/js/reader/renderer.ts
+++ b/src/web/js/reader/renderer.ts
@@ -10,6 +10,7 @@ import { escapeHtml, escapeAttribute, calcStatsPcts } from "../utils.js";
 import { t } from "../i18n.js";
 import { showToast } from "../toast.js";
 import { findBookById, getAllBooks, bookTexts } from "../books.js";
+import { openAndroidUrl } from "../platform.js";
 import { renderPlainText } from "./text-renderer.js";
 import { isPdfOcrText, renderPdfOcrReader } from "./pdf-ocr-renderer.js";
 import {
@@ -124,6 +125,10 @@ function renderReaderSource(current: WhText): void {
     const sourceLink = els.readerSource.querySelector("a.reader-source-link");
     sourceLink?.addEventListener("click", (event: Event) => {
       event.preventDefault();
+      // Android first: the bridge opens the system browser; without it the
+      // webview cannot open the link and the toast below would lie about a
+      // failure while the browser actually opened (audit 2026-08-13).
+      if (openAndroidUrl(url)) return;
       fetch(`/__open_external?url=${encodeURIComponent(url)}`)
         .then((res) => {
           if (!res.ok) {

--- a/src/web/js/views/library.ts
+++ b/src/web/js/views/library.ts
@@ -8,6 +8,8 @@ import { getCachedBookTextStats, getCachedTextStats, prepareTextStats } from "..
 import { t as translate, getLocale } from "../i18n.js";
 import { bindSidebarResizer } from "../panel-resizer.js";
 import { effectiveLearningLanguage } from "../translator-preferences.js";
+import { openAndroidUrl } from "../platform.js";
+import { showToast } from "../toast.js";
 
 interface LibraryBook {
   id: string;
@@ -326,7 +328,7 @@ export function renderLibrary(): void {
     const metaLine = metaParts.length ? `<p class="book-card-meta-line">${escapeHtml(metaParts.join(" · "))}</p>` : "";
     const blurbLine = book.blurb ? `<p class="book-card-blurb">${escapeHtml(book.blurb)}</p>` : "";
     const gutenbergLink = book.pageUrl && !book.isCustom
-      ? `<a class="icon-button" href="${escapeHtml(book.pageUrl)}" target="_blank" rel="noreferrer" title="${escapeHtml(t("reader.sourceGutenberg"))}">${icon("external", 16)}</a>`
+      ? `<a class="icon-button" data-action="open-source" data-id="${escapeAttribute(book.id)}" href="${escapeHtml(book.pageUrl)}" target="_blank" rel="noreferrer" title="${escapeHtml(t("reader.sourceGutenberg"))}">${icon("external", 16)}</a>`
       : "";
     return `
       <article class="book-card ${cover ? "has-cover" : ""} ${isArchived ? "archived" : ""}" data-book-id="${escapeAttribute(book.id)}" data-level="${escapeHtml(book.level)}">
@@ -476,6 +478,28 @@ export function bindLibraryEvents(): void {
     const control = event.target.closest<HTMLElement>("[data-action]");
     if (!control) return;
     const id = control.dataset.id;
+
+    if (control.dataset.action === "open-source") {
+      const url = control.getAttribute("href");
+      if (url) {
+        // On Android the webview cannot open new windows, so the native
+        // bridge goes first; /__open_external covers the desktop webview.
+        if (openAndroidUrl(url)) return;
+        fetch(`/__open_external?url=${encodeURIComponent(url)}`)
+          .then((res) => {
+            if (!res.ok) {
+              console.warn("Failed to open source link", `HTTP ${res.status}`);
+              showToast(translate("toast.openExternalFailed"), "error");
+            }
+          })
+          .catch((error) => {
+            console.warn("Failed to open source link", error);
+            showToast(translate("toast.openExternalFailed"), "error");
+          });
+      }
+      return;
+    }
+
     const actions = await import("../book-actions.js");
 
     const customText = (state.customTexts || []).find((t) => t.id === id);

--- a/src/web/platforms/android-pocket.css
+++ b/src/web/platforms/android-pocket.css
@@ -95,6 +95,16 @@ html.pocket-mode {
   min-height: 44px;
 }
 
+/* The small round TTS buttons on the review card (round-icon-btn-28/24)
+   stay at 24-28 px wide on Pocket otherwise — below the 44 px touch
+   target. Same bump as the icon buttons above. */
+.pocket-mode .round-icon-btn-28,
+.pocket-mode .round-icon-btn-24 {
+  width: 44px;
+  min-width: 44px;
+  height: 44px;
+}
+
 .pocket-mode input.color-picker-lg {
   width: var(--color-picker-size);
   min-width: var(--color-picker-size);


### PR DESCRIPTION
Follow-ups from the full Android audit (3 subagents). P1: dead Gutenberg link on the library card (target=_blank is a no-op in the Android webview). P2: false openExternalFailed toast on the reader source link; 24-28 px TTS buttons on the review card. Contract tests + harness mocks. 646/646.