### PR TITLE
fix(android): single-row reader controls (find floats top-right)

### DIFF
--- a/frontend-tests/android/pocket-layout.test.js
+++ b/frontend-tests/android/pocket-layout.test.js
@@ -126,6 +126,27 @@ describe("Android Pocket layout", () => {
     assertDeclarations(css, ".pocket-mode .pocket-drawer-close", { display: "inline-flex" });
   });
 
+  it("keeps the Pocket reader control bar to a single row (find floats top-right)", () => {
+    const css = readFileSync(new URL("../../dist/web/platforms/android-pocket.css", import.meta.url), "utf8");
+
+    // The find (lupa) toggle leaves the six-column bottom grid and floats at
+    // the top-right of the reader, so exactly six controls remain in the
+    // grid: nav-toggle, highlight, TTS, prev, next, bookmarks — one row.
+    assertDeclarations(css, '.pocket-mode[data-view="reader"] #reader-find-toggle', {
+      position: "fixed",
+      top: "calc(var(--pocket-statusbar-safe-top) + 0.5rem)",
+      right: "max(0.75rem, env(safe-area-inset-right, 0px))",
+      width: "44px",
+      height: "44px",
+    });
+    assertDeclarations(css, ".pocket-mode #reader-view .toolbar-buttons", {
+      "grid-template-columns": "repeat(6, minmax(0, 1fr))",
+    });
+    // The font controls stay hidden, so the six columns hold exactly six items.
+    assertDeclarations(css, ".pocket-mode #reader-view .toolbar-buttons [data-font]", { display: "none" });
+    assertDeclarations(css, ".pocket-mode #reader-view .reader-zoom-slider", { display: "none" });
+  });
+
   it("marks library filters for the Pocket collapse control", () => {
     const html = readFileSync(new URL("../../dist/web/index.html", import.meta.url), "utf8");
     const css = readFileSync(new URL("../../dist/web/platforms/android-pocket.css", import.meta.url), "utf8");

--- a/frontend-tests/shared/css-verifiability.test.js
+++ b/frontend-tests/shared/css-verifiability.test.js
@@ -59,7 +59,7 @@ const DUP_GROUP_PIN = 48;
    "pocket-reader.css" (6371 B) is theme.css — no such file exists on main. */
 const CSS_SIZE_PIN = new Map([
   ["src/web/styles.css", 109300],
-  ["src/web/platforms/android-pocket.css", 32200],
+  ["src/web/platforms/android-pocket.css", 33000],
   ["src/web/theme.css", 6500]
 ]);
 

--- a/src/web/platforms/android-pocket.css
+++ b/src/web/platforms/android-pocket.css
@@ -671,6 +671,23 @@ html.pocket-mode {
   box-shadow: none;
 }
 
+/* The find (lupa) toggle leaves the six-column bottom grid and floats at the
+   top-right of the reader, so the control bar stays a single row: nav-toggle,
+   highlight, TTS, prev, next, bookmarks = exactly six grid items. */
+.pocket-mode[data-view="reader"] #reader-find-toggle {
+  position: fixed;
+  z-index: var(--z-pocket-toolbar);
+  top: calc(var(--pocket-statusbar-safe-top) + 0.5rem);
+  right: max(0.75rem, env(safe-area-inset-right, 0px));
+  width: 44px;
+  min-width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: var(--sidebar-bg);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.24);
+}
+
 .pocket-mode #reader-view .pocket-word-navigation {
   display: inline-flex;
   width: 100%;


### PR DESCRIPTION
Reader bottom bar wrapped to two rows on Pocket (7 controls in a 6-column grid). The find toggle now floats at the top-right of the reader; six controls fill the grid in one row. Contract test + size-budget pin update. 647/647.