### PR TITLE
fix(settings): reveal the AI API-key row (id mismatch)

### DIFF
--- a/frontend-tests/shared/dialog-ports.test.js
+++ b/frontend-tests/shared/dialog-ports.test.js
@@ -891,6 +891,16 @@ describe("settings view renderer (events/settings.ts)", () => {
     assert.equal(document.mainPanel.children.length, 1);
   });
 
+  it("toggles the AI API-key row by the id the settings markup actually uses", () => {
+    // Regression (2026-08-13): the row is #pref-ai-key-row in the markup,
+    // but preferences.ts toggled the stale #pref-ai-api-key-row, so the API
+    // key field stayed hidden forever and AI explanations could never be
+    // configured. Pin both sides of the contract.
+    const prefs = readFileSync(new URL("../../dist/web/js/preferences.js", import.meta.url), "utf8");
+    assert.match(prefs, /"pref-ai-key-row"/, "preferences.js must target #pref-ai-key-row");
+    assert.doesNotMatch(prefs, /"pref-ai-api-key-row"/, "stale #pref-ai-api-key-row reference");
+  });
+
   it("keeps the settings view out of static HTML and renders it before cacheElements", () => {
     const html = read("dist/web/index.html");
     const app = read("dist/web/app.js");

--- a/src/web/js/preferences.ts
+++ b/src/web/js/preferences.ts
@@ -323,7 +323,7 @@ export function syncSettingsControls() {
   if (byId<HTMLInputElement>("pref-ai-auto-trigger")) byId<HTMLInputElement>("pref-ai-auto-trigger").checked = prefs.aiExplanationAutoTrigger === true;
   if (byId<HTMLInputElement>("pref-ai-endpoint-row")) byId<HTMLInputElement>("pref-ai-endpoint-row").hidden = !aiEnabled;
   if (byId<HTMLInputElement>("pref-ai-model-row")) byId<HTMLInputElement>("pref-ai-model-row").hidden = !aiEnabled;
-  if (byId<HTMLInputElement>("pref-ai-api-key-row")) byId<HTMLInputElement>("pref-ai-api-key-row").hidden = !aiEnabled;
+  if (byId<HTMLInputElement>("pref-ai-key-row")) byId<HTMLInputElement>("pref-ai-key-row").hidden = !aiEnabled;
   if (byId<HTMLSelectElement>("pref-ai-effort-row")) byId<HTMLSelectElement>("pref-ai-effort-row").hidden = !aiEnabled;
   if (byId<HTMLInputElement>("pref-ai-auto-trigger-row")) byId<HTMLInputElement>("pref-ai-auto-trigger-row").hidden = !aiEnabled;
   if (els.prefAutoTranslate) els.prefAutoTranslate.checked = prefs.autoTranslateWords === true;


### PR DESCRIPTION
preferences.ts toggled the stale #pref-ai-api-key-row; the markup row is #pref-ai-key-row — the API key field stayed hidden on every platform, so AI explanations could never be configured. One-line fix + contract test. 648/648.