### PR TITLE
fix(server): stop the listener socket timeout from killing the Android backend

### DIFF
--- a/src-tauri/src/server.rs
+++ b/src-tauri/src/server.rs
@@ -4,7 +4,6 @@ use std::net::TcpListener;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;
-use std::time::Duration;
 use tauri::AppHandle;
 use tiny_http::Server;
 
@@ -13,7 +12,6 @@ use crate::store::Store;
 const MAX_REGULAR_REQUEST_WORKERS: usize = 10;
 const MAX_STORE_REQUEST_WORKERS: usize = 4;
 const MAX_CONTROL_REQUEST_WORKERS: usize = 2;
-const REQUEST_READ_TIMEOUT: Duration = Duration::from_secs(60);
 
 struct RequestPermit {
     active: Arc<AtomicUsize>,
@@ -153,19 +151,6 @@ pub fn start_server_on_port(
     start_server_from_listener(listener, store, token, app_handle)
 }
 
-fn apply_socket_timeouts(listener: &TcpListener) -> Result<(), String> {
-    use socket2::SockRef;
-
-    let socket = SockRef::from(listener);
-    socket
-        .set_read_timeout(Some(REQUEST_READ_TIMEOUT))
-        .map_err(|e| e.to_string())?;
-    socket
-        .set_write_timeout(Some(REQUEST_READ_TIMEOUT))
-        .map_err(|e| e.to_string())?;
-    Ok(())
-}
-
 fn start_server_from_listener(
     listener: TcpListener,
     store: Arc<Store>,
@@ -173,9 +158,14 @@ fn start_server_from_listener(
     app_handle: AppHandle,
 ) -> Result<u16, String> {
     let port = listener.local_addr().map_err(|e| e.to_string())?.port();
-    // Enforce a read timeout on every accepted connection so a stalled client
-    // (slow-loris) cannot pin a worker thread forever with an incomplete body.
-    apply_socket_timeouts(&listener)?;
+    // Slow-loris protection lives in the vendored tiny_http accept path
+    // (connection.rs sets a 60 s read/write deadline per accepted socket).
+    // A timeout must NOT be set on the listening socket itself: on Android
+    // the kernel honors SO_RCVTIMEO on listen sockets, so accept() fails
+    // after 60 s of idle traffic, tiny_http's incoming_requests() ends, and
+    // the whole server thread drops the listener — the app then loses its
+    // HTTP backend mid-session (observed 2026-08-13: "No text source
+    // found" on every book open after ~a minute of reading).
     let server = Server::from_listener(listener, None).map_err(|e| e.to_string())?;
     let state = Arc::new(ServerState {
         base_url: format!("http://{}:{}", crate::HOST, port),

--- a/src-tauri/src/tests/http_boundary/tests.rs
+++ b/src-tauri/src/tests/http_boundary/tests.rs
@@ -544,3 +544,28 @@ fn store_save_without_conflicts_returns_204() {
     assert_eq!(response.status, 204);
     assert!(response.body.is_empty());
 }
+
+#[test]
+fn listener_carries_no_socket_timeout() {
+    // Regression (2026-08-13, Android): setting SO_RCVTIMEO on the LISTENING
+    // socket made accept() fail after 60 s of idle traffic on Android; the
+    // vendored tiny_http then ended incoming_requests() and the server thread
+    // dropped the listener — the app lost its whole HTTP backend mid-session
+    // ("No text source found" on every book open). The slow-loris deadline
+    // must live in the vendored accept path (connection.rs), not on the
+    // listener. Pin both sides of the contract at the source level.
+    let server_source = include_str!("../../server.rs");
+    assert!(
+        !server_source.contains("set_read_timeout"),
+        "server.rs must not set a read timeout on the listening socket"
+    );
+    assert!(
+        server_source.contains("connection.rs sets a 60 s read/write deadline"),
+        "slow-loris protection must be delegated to the vendored accept path"
+    );
+    let connection_source = include_str!("../../../vendor/tiny_http/src/connection.rs");
+    assert!(
+        connection_source.contains("set_read_timeout(Some(Duration::from_secs(60)))"),
+        "the vendored accept path must keep the per-connection deadline"
+    );
+}


### PR DESCRIPTION
## Root cause (Android, on-device evidence)

The app-level `apply_socket_timeouts` set `SO_RCVTIMEO=60s` on the **listening** socket. Android kernels honor that timeout on listen sockets: after 60s of idle traffic `accept()` fails, the vendored tiny_http ends `incoming_requests()`, and the server thread drops the listener — the whole HTTP backend dies mid-session. Reproduced on a Pixel 9 Pro XL: after ~a minute of reading, every book open showed `No text source found` and AI explanations failed (the listener vanished from `/proc/net/tcp` while the process stayed alive).

## Fix

- Remove the listener-level timeout entirely. Slow-loris protection already lives in the vendored accept path (`vendor/tiny_http/src/connection.rs` sets a 60s read/write deadline **per accepted socket** — WordHunter vendor patch), which works on every platform.
- Regression test `listener_carries_no_socket_timeout` pins the contract at the source level: `server.rs` must not set a read timeout on the listener, and the vendored per-connection deadline must remain.

## Verification

- `cargo test --lib`: **290 passed** (289 + the new regression test)
- `scripts/validate.sh`: `Validation complete.`
- `cargo fmt --check` clean