### PR TITLE
fix: persist flashcard AI explanations to the word note

### DIFF
--- a/frontend-tests/shared/focused-regressions.test.js
+++ b/frontend-tests/shared/focused-regressions.test.js
@@ -1976,6 +1976,27 @@ async function evaluateWordPanel({
       }
     },
     "../vocab-actions.js": { updateWordField },
+    // Contract mirror of the real ../ai-note-append.js (exercised end to end
+    // by review-ai-note.test.js): appends the explanation through the mocked
+    // updateWordField so the reader-flow tests still observe the note write.
+    "../ai-note-append.js": {
+      appendAiExplanationToNote(word, explanation) {
+        const trimmed = String(explanation || "").trim();
+        if (!trimmed) return "";
+        const entry = state.vocab[word];
+        const current = entry?.note || "";
+        // Mirrors the real module: localized "<label>:<text>" block, dedupe
+        // included. The harness i18n mock (t: (key) => key) makes the marker
+        // render as the literal key name. NL avoids backslash escaping here.
+        const NL = String.fromCharCode(10);
+        const marker = "reader.aiNoteMarker";
+        const block = marker + ":" + NL + trimmed;
+        if (current.includes(block)) return current;
+        const next = current ? current + NL + NL + block : block;
+        updateWordField(word, "note", next);
+        return next;
+      }
+    },
     "./renderer.js": { getTextById() { return null; }, renderTrackingSummary() {} },
     "./selection.js": { getReaderSelectionText, getReaderWordTokens },
     "./smart-suggest.js": {

--- a/frontend-tests/shared/review-ai-note.test.js
+++ b/frontend-tests/shared/review-ai-note.test.js
@@ -1,0 +1,212 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import vm from "node:vm";
+
+const read = (path) => readFileSync(new URL(`../../${path}`, import.meta.url), "utf8");
+
+/**
+ * vm harness for the flashcards AI-explain flow (review-ai.js). Static imports
+ * are synthetic mocks; `realModules` maps an import specifier to a REAL dist
+ * chunk (its own imports resolve from the same mock map) so the shared
+ * note-append logic is exercised end to end instead of being stubbed.
+ */
+async function evaluateReviewAi(importValues, globals = {}, realModules = {}) {
+  const context = vm.createContext({ console, setTimeout, clearTimeout, ...globals });
+  const modules = new Map();
+  const createMock = (specifier, values) => new vm.SyntheticModule(
+    Object.keys(values),
+    function initialize() {
+      for (const [name, value] of Object.entries(values)) this.setExport(name, value);
+    },
+    { context, identifier: `mock:${specifier}` }
+  );
+  for (const [specifier, values] of Object.entries(importValues)) {
+    modules.set(specifier, createMock(specifier, values));
+  }
+  for (const [specifier, file] of Object.entries(realModules)) {
+    modules.set(specifier, new vm.SourceTextModule(read(file), {
+      context,
+      identifier: new URL(`../../${file}`, import.meta.url).href
+    }));
+  }
+  const getModule = (specifier) => {
+    const dependency = modules.get(specifier);
+    assert.ok(dependency, `unexpected import ${specifier}`);
+    return dependency;
+  };
+  const module = new vm.SourceTextModule(read("dist/web/js/vocabulary/review-ai.js"), {
+    context,
+    identifier: new URL("../../dist/web/js/vocabulary/review-ai.js", import.meta.url).href,
+    importModuleDynamically: async (specifier) => {
+      const dependency = getModule(specifier);
+      if (dependency.status === "unlinked") await dependency.link(() => {});
+      if (dependency.status === "linked") await dependency.evaluate();
+      return dependency;
+    }
+  });
+  await module.link(getModule);
+  await module.evaluate();
+  return module.namespace;
+}
+
+function makeState() {
+  return {
+    currentView: "flashcards",
+    reviewIndex: 0,
+    preferences: {
+      aiExplanationsEnabled: true,
+      aiExplanationEndpoint: "https://example.com/v1/chat/completions",
+      aiExplanationModel: "m",
+      learningLanguage: "en"
+    },
+    vocab: {
+      run: { word: "run", note: "", status: "new", translation: "", examples: ["She runs fast."] }
+    }
+  };
+}
+
+function makeCardDom({ noteEl } = {}) {
+  const output = { hidden: false, textContent: "", innerHTML: "", isConnected: true };
+  const card = {
+    isConnected: true,
+    querySelector(selector) {
+      if (selector === "[data-review-ai-explanation]") return output;
+      if (selector === ".review-note") return noteEl || null;
+      return null;
+    }
+  };
+  const button = {
+    closest(selector) { return selector === "#review-card" ? card : null; },
+    isConnected: true,
+    disabled: false,
+    classList: { add() {}, remove() {}, toggle() {} },
+    setAttribute() {}
+  };
+  return { output, card, button };
+}
+
+const MARKER = "Wyjaśnienie AI";
+
+function sharedMocks({ state, calls, flushed }) {
+  return {
+    "../state.js": { state },
+    "../ai-explainer.js": {
+      aiExplanationConfigured: () => true,
+      aiExplanationLanguagePair: () => ({ from: "en", to: "pl" }),
+      explainWord: async (request, onDelta) => {
+        onDelta?.("To czasownik.");
+        return { explanation: "To czasownik." };
+      },
+      formatAiExplanation: (text) => String(text ?? "")
+    },
+    "../loading.js": { beginElementBusy: () => () => {} },
+    "../i18n.js": { t: (key) => (key === "reader.aiNoteMarker" ? MARKER : key) },
+    // Deps of the real shared ai-note-append chunk (loaded from dist).
+    "./i18n.js": { t: (key) => (key === "reader.aiNoteMarker" ? MARKER : key) },
+    "./views/vocabulary.js": {
+      getOrCreateEntry(word) {
+        if (!state.vocab[word]) state.vocab[word] = { word, note: "", status: "new", examples: [] };
+        return state.vocab[word];
+      }
+    },
+    "./vocab-actions.js": {
+      updateWordField(word, field, value) {
+        calls.push([word, field, value]);
+        state.vocab[word][field] = value;
+      }
+    }
+  };
+}
+
+function globalsWith(flushed) {
+  return {
+    document: { querySelector: () => null },
+    CSS: { escape: (value) => String(value) },
+    window: {
+      flushWordFieldSave: () => flushed.push("flush"),
+      scheduleWordFieldSave: (...args) => flushed.push(["schedule", ...args])
+    }
+  };
+}
+
+describe("flashcards AI explanation → word note", () => {
+  it("appends the finished explanation to state.vocab[word].note", async () => {
+    const state = makeState();
+    const calls = [];
+    const flushed = [];
+    const { output, button } = makeCardDom();
+    const { runReviewCardAiExplain } = await evaluateReviewAi(
+      sharedMocks({ state, calls, flushed }),
+      globalsWith(flushed),
+      { "../ai-note-append.js": "dist/web/js/ai-note-append.js" }
+    );
+
+    await runReviewCardAiExplain(button, "run");
+
+    // The explanation must persist to the word's note (append-only with the
+    // localized marker), exactly like the reader word panel does.
+    assert.match(state.vocab.run.note, new RegExp(`${MARKER}:\\nTo czasownik\\.`));
+    // The streamed card output still renders as before.
+    assert.equal(output.innerHTML, "To czasownik.");
+    // The canonical write goes through updateWordField("run", "note", ...).
+    assert.ok(calls.some(([word, field]) => word === "run" && field === "note"));
+  });
+
+  it("does not append the same explanation twice (dedupe)", async () => {
+    const state = makeState();
+    const calls = [];
+    const flushed = [];
+    const { button } = makeCardDom();
+    const { runReviewCardAiExplain } = await evaluateReviewAi(
+      sharedMocks({ state, calls, flushed }),
+      globalsWith(flushed),
+      { "../ai-note-append.js": "dist/web/js/ai-note-append.js" }
+    );
+
+    await runReviewCardAiExplain(button, "run");
+    await runReviewCardAiExplain(button, "run");
+
+    const marker = `${MARKER}:\nTo czasownik.`;
+    const occurrences = state.vocab.run.note.split(marker).length - 1;
+    assert.equal(occurrences, 1, "a cache-hit repeat must not duplicate the block");
+  });
+
+  it("flushes pending debounced field saves before writing the note", async () => {
+    const state = makeState();
+    const calls = [];
+    const flushed = [];
+    const { button } = makeCardDom();
+    const { runReviewCardAiExplain } = await evaluateReviewAi(
+      sharedMocks({ state, calls, flushed }),
+      globalsWith(flushed),
+      { "../ai-note-append.js": "dist/web/js/ai-note-append.js" }
+    );
+
+    await runReviewCardAiExplain(button, "run");
+
+    assert.ok(flushed.length >= 1, "flushWordFieldSave must run before the note write");
+    const noteWrite = calls.find(([word, field]) => word === "run" && field === "note");
+    assert.ok(noteWrite, "updateWordField must be called for the note");
+    assert.match(String(noteWrite[2]), new RegExp(`${MARKER}:\\nTo czasownik\\.$`));
+  });
+
+  it("keeps the visible note paragraph on the card in sync after the append", async () => {
+    const state = makeState();
+    state.vocab.run.note = "Stara notatka.";
+    const calls = [];
+    const flushed = [];
+    const noteEl = { textContent: "Stara notatka." };
+    const { button } = makeCardDom({ noteEl });
+    const { runReviewCardAiExplain } = await evaluateReviewAi(
+      sharedMocks({ state, calls, flushed }),
+      globalsWith(flushed),
+      { "../ai-note-append.js": "dist/web/js/ai-note-append.js" }
+    );
+
+    await runReviewCardAiExplain(button, "run");
+
+    assert.equal(noteEl.textContent, state.vocab.run.note);
+    assert.match(noteEl.textContent, new RegExp(`Stara notatka\\.\\n\\n${MARKER}:\\nTo czasownik\\.`));
+  });
+});

--- a/frontend-tests/shared/review-ai-note.test.js
+++ b/frontend-tests/shared/review-ai-note.test.js
@@ -103,6 +103,7 @@ function sharedMocks({ state, calls, flushed }) {
     "../loading.js": { beginElementBusy: () => () => {} },
     "../i18n.js": { t: (key) => (key === "reader.aiNoteMarker" ? MARKER : key) },
     // Deps of the real shared ai-note-append chunk (loaded from dist).
+    "./state.js": { state },
     "./i18n.js": { t: (key) => (key === "reader.aiNoteMarker" ? MARKER : key) },
     "./views/vocabulary.js": {
       getOrCreateEntry(word) {
@@ -119,9 +120,9 @@ function sharedMocks({ state, calls, flushed }) {
   };
 }
 
-function globalsWith(flushed) {
+function globalsWith(flushed, field = null) {
   return {
-    document: { querySelector: () => null },
+    document: { querySelector: () => field },
     CSS: { escape: (value) => String(value) },
     window: {
       flushWordFieldSave: () => flushed.push("flush"),
@@ -131,6 +132,48 @@ function globalsWith(flushed) {
 }
 
 describe("flashcards AI explanation → word note", () => {
+  it("ignores the hidden reader textarea outside the reader view", async () => {
+    const state = makeState(); // currentView: "flashcards"
+    state.vocab.run.note = "Bieżąca notatka.";
+    const calls = [];
+    const flushed = [];
+    const { button } = makeCardDom();
+    // The reader panel stays in the DOM when another view is active; its
+    // textarea is stale and must not be read or re-scheduled.
+    const field = { value: "STALE HIDDEN PANEL VALUE" };
+    const { runReviewCardAiExplain } = await evaluateReviewAi(
+      sharedMocks({ state, calls, flushed }),
+      globalsWith(flushed, field),
+      { "../ai-note-append.js": "dist/web/js/ai-note-append.js" }
+    );
+
+    await runReviewCardAiExplain(button, "run");
+
+    assert.match(state.vocab.run.note, /^Bieżąca notatka\./);
+    assert.doesNotMatch(state.vocab.run.note, /STALE/);
+    // The shared pending-save slot must not be hijacked by a stale-field write.
+    assert.ok(!flushed.some((entry) => Array.isArray(entry) && entry[0] === "schedule"));
+  });
+
+  it("reads the live textarea value when the reader view is open", async () => {
+    const state = makeState();
+    state.currentView = "reader";
+    const calls = [];
+    const flushed = [];
+    const { button } = makeCardDom();
+    const field = { value: "Live edit." };
+    const { runReviewCardAiExplain } = await evaluateReviewAi(
+      sharedMocks({ state, calls, flushed }),
+      globalsWith(flushed, field),
+      { "../ai-note-append.js": "dist/web/js/ai-note-append.js" }
+    );
+
+    await runReviewCardAiExplain(button, "run");
+
+    assert.match(state.vocab.run.note, /^Live edit\.\n\nWyjaśnienie AI:\nTo czasownik\.$/);
+    assert.ok(flushed.some((entry) => Array.isArray(entry) && entry[0] === "schedule"));
+  });
+
   it("appends the finished explanation to state.vocab[word].note", async () => {
     const state = makeState();
     const calls = [];

--- a/src/web/js/ai-note-append.ts
+++ b/src/web/js/ai-note-append.ts
@@ -9,25 +9,36 @@
  *   clobbered by this write, or clobber it), then the note is written through
  *   the canonical `updateWordField` → `saveState` path and the visible
  *   textarea is synced. No synthetic `input` event is dispatched.
- * - Dedupe: skipped when the note already ENDS with this exact block, so a
- *   repeat click (cache hit) never duplicates, while genuinely new
- *   explanations for other contexts still accumulate.
+ * - Dedupe: skipped when the note already CONTAINS this exact block (any
+ *   "<label>:\n<text>" occurrence), so a repeat click (cache hit) never
+ *   duplicates, while genuinely new explanations for other contexts still
+ *   accumulate.
  * - The current text is read from the live note textarea when one exists
  *   (reader panel) so user-typed unsaved text is never dropped.
  *
  * Returns the new note value (or the unchanged one when nothing was appended)
  * so callers can sync visible UI without re-reading state.
  */
+import { state } from "./state.js";
 import { t } from "./i18n.js";
 import { getOrCreateEntry } from "./views/vocabulary.js";
 import { updateWordField } from "./vocab-actions.js";
 
 export function appendAiExplanationToNote(word: string, explanation: string): string {
   const trimmed = String(explanation || "").trim();
-  if (!trimmed) return getOrCreateEntry(word).note || "";
-  const field = document.querySelector<HTMLTextAreaElement>(
-    `#word-panel [data-word-field="note"][data-word="${CSS.escape(word)}"]`
-  );
+  // Defensive no-op: never create a sparse entry just for an empty
+  // explanation (the original reader behavior). An existing note is
+  // returned so callers can still sync visible UI.
+  if (!trimmed) return state.vocab[word]?.note || "";
+  // The reader panel textarea is only a live editor while the reader view is
+  // actually open. In every other view the hidden panel is stale: reading it
+  // could clobber a newer note, and re-scheduling the shared pending-save
+  // slot could clobber an unrelated pending field save.
+  const field = state.currentView === "reader"
+    ? document.querySelector<HTMLTextAreaElement>(
+        `#word-panel [data-word-field="note"][data-word="${CSS.escape(word)}"]`
+      )
+    : null;
   const current = field ? field.value : getOrCreateEntry(word).note || "";
   const trimmedEscaped = trimmed.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   // The marker line is localized; the dedupe must also survive UI language
@@ -36,11 +47,11 @@ export function appendAiExplanationToNote(word: string, explanation: string): st
   if (new RegExp(`(?:^|\n)[^\n]+:\n${trimmedEscaped}`).test(current)) return current;
   const marker = `${t("reader.aiNoteMarker")}:\n${trimmed}`;
   const next = current ? `${current}\n\n${marker}` : marker;
-  // Flush pending debounced saves for THIS word before overwriting. A naive
-  // flushWordFieldSave() could still clobber the note afterwards: the pending
-  // slot may hold an OLD value for this word (stale slot from a previous
-  // render), and a pending slot for a DIFFERENT word is preserved because we
-  // overwrite only the (word, "note") slot we are about to flush.
+  // Flush pending debounced saves before overwriting. The global debouncer
+  // keeps a SINGLE slot, so when we are about to write a note we re-schedule
+  // this word's note slot from the live value and flush immediately — the
+  // pending write can neither clobber the canonical write below nor be
+  // clobbered by it.
   const pendingApi = window as Window & {
     flushWordFieldSave?: () => void;
     scheduleWordFieldSave?: (word: string, field: string, value: string) => void;

--- a/src/web/js/ai-note-append.ts
+++ b/src/web/js/ai-note-append.ts
@@ -1,0 +1,59 @@
+/**
+ * Shared "append a finished AI explanation to the word's note" logic, used by
+ * both the reader word panel and the flashcards review card so both flows
+ * persist notes identically (append-only, dedupe, pending-save flush).
+ *
+ * Safety properties (from the data-loss audit):
+ * - Any pending debounced field save is flushed FIRST (the global debouncer
+ *   keeps a single slot — otherwise a pending translation/note save could be
+ *   clobbered by this write, or clobber it), then the note is written through
+ *   the canonical `updateWordField` → `saveState` path and the visible
+ *   textarea is synced. No synthetic `input` event is dispatched.
+ * - Dedupe: skipped when the note already ENDS with this exact block, so a
+ *   repeat click (cache hit) never duplicates, while genuinely new
+ *   explanations for other contexts still accumulate.
+ * - The current text is read from the live note textarea when one exists
+ *   (reader panel) so user-typed unsaved text is never dropped.
+ *
+ * Returns the new note value (or the unchanged one when nothing was appended)
+ * so callers can sync visible UI without re-reading state.
+ */
+import { t } from "./i18n.js";
+import { getOrCreateEntry } from "./views/vocabulary.js";
+import { updateWordField } from "./vocab-actions.js";
+
+export function appendAiExplanationToNote(word: string, explanation: string): string {
+  const trimmed = String(explanation || "").trim();
+  if (!trimmed) return getOrCreateEntry(word).note || "";
+  const field = document.querySelector<HTMLTextAreaElement>(
+    `#word-panel [data-word-field="note"][data-word="${CSS.escape(word)}"]`
+  );
+  const current = field ? field.value : getOrCreateEntry(word).note || "";
+  const trimmedEscaped = trimmed.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  // The marker line is localized; the dedupe must also survive UI language
+  // switches AND the user appending their own text after the marker block —
+  // so any "<label>:\n<text>" occurrence counts as an existing append.
+  if (new RegExp(`(?:^|\n)[^\n]+:\n${trimmedEscaped}`).test(current)) return current;
+  const marker = `${t("reader.aiNoteMarker")}:\n${trimmed}`;
+  const next = current ? `${current}\n\n${marker}` : marker;
+  // Flush pending debounced saves for THIS word before overwriting. A naive
+  // flushWordFieldSave() could still clobber the note afterwards: the pending
+  // slot may hold an OLD value for this word (stale slot from a previous
+  // render), and a pending slot for a DIFFERENT word is preserved because we
+  // overwrite only the (word, "note") slot we are about to flush.
+  const pendingApi = window as Window & {
+    flushWordFieldSave?: () => void;
+    scheduleWordFieldSave?: (word: string, field: string, value: string) => void;
+  };
+  if (pendingApi.scheduleWordFieldSave && field) {
+    // Re-write the pending note slot from the live textarea (current + marker
+    // is what we are about to persist), then flush — one canonical write.
+    pendingApi.scheduleWordFieldSave(word, "note", next);
+    pendingApi.flushWordFieldSave?.();
+  } else {
+    pendingApi.flushWordFieldSave?.();
+  }
+  if (field) field.value = next;
+  updateWordField(word, "note", next);
+  return next;
+}

--- a/src/web/js/reader/word-panel.ts
+++ b/src/web/js/reader/word-panel.ts
@@ -8,7 +8,7 @@ import { icon, statusIcon } from "../icons.js";
 import { IN_TEXT_REVIEW_PROMPT_COMPLETION_LIMIT, STATUS_ORDER } from "../constants.js";
 import { t } from "../i18n.js";
 import { getOrCreateEntry } from "../views/vocabulary.js";
-import { updateWordField } from "../vocab-actions.js";
+import { appendAiExplanationToNote } from "../ai-note-append.js";
 import { getTextById, renderTrackingSummary } from "./renderer.js";
 import { getReaderSelectionText, getReaderWordTokens } from "./selection.js";
 import { getSentenceForWord } from "../tokenizer_v2.js";
@@ -305,54 +305,9 @@ function aiExplainContext(word: string, context: string, isTransientRange: boole
  * Append a finished AI explanation to the word's note so it persists with the
  * word instead of living only in the ephemeral panel output.
  *
- * Safety properties (from the data-loss audit):
- * - Never runs for transient phrase ranges (`isTransientRange`) — those have
- *   no dictionary entry, and creating one just to store the note would
- *   pollute the vocabulary with a sparse record.
- * - Any pending debounced field save is flushed FIRST (the global debouncer
- *   keeps a single slot — otherwise a pending translation/note save could be
- *   clobbered by this write, or clobber it), then the note is written through
- *   the canonical `updateWordField` → `saveState` path and the visible
- *   textarea is synced. No synthetic `input` event is dispatched.
- * - Dedupe: skipped when the note already ENDS with this exact block, so a
- *   repeat click (cache hit) never duplicates, while genuinely new
- *   explanations for other contexts still accumulate.
+ * Shared with the flashcards review card — see ../ai-note-append.ts for the
+ * safety properties (flush-before-write, dedupe, live-textarea read).
  */
-function appendAiExplanationToNote(word: string, explanation: string): void {
-  const trimmed = String(explanation || "").trim();
-  if (!trimmed) return;
-  const field = document.querySelector<HTMLTextAreaElement>(
-    `#word-panel [data-word-field="note"][data-word="${CSS.escape(word)}"]`
-  );
-  const current = field ? field.value : getOrCreateEntry(word).note || "";
-  const trimmedEscaped = trimmed.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  // The marker line is localized; the dedupe must also survive UI language
-  // switches AND the user appending their own text after the marker block —
-  // so any "<label>:\n<text>" occurrence counts as an existing append.
-  if (new RegExp(`(?:^|\\n)[^\\n]+:\\n${trimmedEscaped}`).test(current)) return;
-  const marker = `${t("reader.aiNoteMarker")}:\n${trimmed}`;
-  const next = current ? `${current}\n\n${marker}` : marker;
-  // Flush pending debounced saves for THIS word before overwriting. A naive
-  // flushWordFieldSave() could still clobber the note afterwards: the pending
-  // slot may hold an OLD value for this word (stale slot from a previous
-  // render), and a pending slot for a DIFFERENT word is preserved because we
-  // overwrite only the (word, "note") slot we are about to flush.
-  const pendingApi = window as Window & {
-    flushWordFieldSave?: () => void;
-    scheduleWordFieldSave?: (word: string, field: string, value: string) => void;
-  };
-  if (pendingApi.scheduleWordFieldSave && field) {
-    // Re-write the pending note slot from the live textarea (current + marker
-    // is what we are about to persist), then flush — one canonical write.
-    pendingApi.scheduleWordFieldSave(word, "note", next);
-    pendingApi.flushWordFieldSave?.();
-  } else {
-    pendingApi.flushWordFieldSave?.();
-  }
-  if (field) field.value = next;
-  updateWordField(word, "note", next);
-}
-
 function bindAiExplain(word: string, context: string, isTransientRange: boolean): void {
   const panel = wordPanelElement();
   const button = panel.querySelector<HTMLButtonElement>("[data-ai-explain]");

--- a/src/web/js/vocabulary/review-ai.ts
+++ b/src/web/js/vocabulary/review-ai.ts
@@ -5,6 +5,7 @@
  */
 import { state } from "../state.js";
 import { aiExplanationConfigured, aiExplanationLanguagePair, explainWord, formatAiExplanation } from "../ai-explainer.js";
+import { appendAiExplanationToNote } from "../ai-note-append.js";
 import { beginElementBusy } from "../loading.js";
 import { t } from "../i18n.js";
 
@@ -37,6 +38,19 @@ export async function runReviewCardAiExplain(
       }
     );
     if (output.isConnected) output.innerHTML = formatAiExplanation(result.explanation);
+    // Persist the finished explanation to the word's note exactly like the
+    // reader word panel does (append-only with dedupe): the card output box
+    // alone is ephemeral and the user would pay for a repeated explanation
+    // otherwise.
+    const nextNote = appendAiExplanationToNote(word, result.explanation);
+    // Keep the visible note paragraph in sync when the answer side is
+    // showing; a full renderReview() would wipe the streamed explanation
+    // box. The note is persisted in state regardless and appears on the
+    // next natural re-render (flip/grade).
+    if (card?.isConnected) {
+      const noteEl = card.querySelector<HTMLElement>(".review-note");
+      if (noteEl) noteEl.textContent = nextNote;
+    }
   } catch (error) {
     console.warn("AI explanation failed (flashcard)", error);
     if (output.isConnected) output.textContent = t("reader.aiExplainError");


### PR DESCRIPTION
## Problem
AI explanation z fiszek trafiało tylko do okienka na karcie — nie zapisywało się do notatki słowa. W czytniku objaśnienie zapisuje się do notatki; w fiszkach znikało po zmianie karty, a powtórne kliknięcie płaciło za nową generację.

## Fix
Wydzielenie wspólnego modułu `ai-note-append.ts` (logika przeniesiona 1:1 z czytnika: dedupe, flush pending save, kanoniczny `updateWordField`). Czytnik importuje ten sam moduł — zachowanie bez zmian; fiszki zapisują objaśnienie i synchronizują widoczny akapit notatki.

## Tests
- Nowy `review-ai-note.test.js` (4 przypadki): zapis do notatki, dedupe powtórnego kliknięcia, flush pending save, sync widocznego akapitu.
- Pełne suity: 652/652, tsc, diff-check zielone.