### PR TITLE
fix: stop the flashcard swipe suppression from eating control taps

### DIFF
--- a/frontend-tests/shared/flashcard-gestures.test.js
+++ b/frontend-tests/shared/flashcard-gestures.test.js
@@ -3,10 +3,13 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
 class FakeElement {
-  constructor(interactive = false) { this.interactive = interactive; }
+  constructor(...selectors) {
+    // Selectors this element matches (empty = plain card surface).
+    this.selectors = new Set(selectors);
+  }
   closest(selector) {
-    if (selector === "[data-review-card-surface]") return this;
-    return this.interactive ? this : null;
+    const parts = String(selector).split(",").map((part) => part.trim());
+    return parts.some((part) => this.selectors.has(part)) ? this : null;
   }
 }
 class FakeHTMLElement extends FakeElement {}
@@ -71,7 +74,7 @@ describe("flashcard gestures", () => {
 
   it("keeps clicks on interactive controls alive inside the post-swipe suppression window", () => {
     const host = new FakeHost();
-    const surface = new FakeElement();
+    const surface = new FakeElement("[data-review-card-surface]");
     els.reviewCard = host;
     bindFlashcardEvents();
     // Arm the 400 ms suppression window with a real swipe.
@@ -81,8 +84,8 @@ describe("flashcard gestures", () => {
     });
     host.emit("pointerup", { pointerId: 2, clientX: 50, clientY: 25, preventDefault() {} });
 
-    const clickEvent = (interactive) => ({
-      target: new FakeElement(interactive),
+    const clickEvent = (selector = null) => ({
+      target: selector ? new FakeElement(selector) : new FakeElement(),
       defaultPrevented: false,
       propagationStopped: false,
       preventDefault() { this.defaultPrevented = true; },
@@ -91,22 +94,38 @@ describe("flashcard gestures", () => {
 
     // A tap on an image-suggestion tile / any control must survive so the
     // document-level handler (setWordImage) can still run.
-    const tileEvent = clickEvent(true);
+    const tileEvent = clickEvent("button");
     host.emit("click", tileEvent);
     assert.equal(tileEvent.defaultPrevented, false);
     assert.equal(tileEvent.propagationStopped, false);
 
+    // The upload tile is a div[role="button"], not a <button> — it must
+    // survive as well.
+    const uploadEvent = clickEvent('[role="button"]');
+    host.emit("click", uploadEvent);
+    assert.equal(uploadEvent.defaultPrevented, false);
+    assert.equal(uploadEvent.propagationStopped, false);
+
     // The stray synthetic click a swipe leaves on the plain card surface
     // must still be swallowed.
-    const surfaceEvent = clickEvent(false);
+    const surfaceEvent = clickEvent();
     host.emit("click", surfaceEvent);
     assert.equal(surfaceEvent.defaultPrevented, true);
     assert.equal(surfaceEvent.propagationStopped, true);
   });
 
+  it("keeps word-panel control taps alive after a reader word-card swipe", () => {
+    // The reader word panel has the same post-swipe click suppression; both
+    // the capture and bubble handlers must exempt interactive controls or
+    // the reader 'add image' path stays dead on Android.
+    const reader = readFileSync(new URL("../../dist/web/js/views/reader.js", import.meta.url), "utf8");
+    assert.match(reader, /\[role=/);
+    assert.equal((reader.match(/closest\(INTERACTIVE_CLICK_SELECTOR\)/g) || []).length, 2);
+  });
+
   it("reveals on a tap and navigates the deck on horizontal pointer gestures", () => {
     const host = new FakeHost();
-    const surface = new FakeElement();
+    const surface = new FakeElement("[data-review-card-surface]");
     els.reviewCard = host;
     bindFlashcardEvents();
     const start = (x, y, target = surface) => host.emit("pointerdown", {
@@ -120,7 +139,7 @@ describe("flashcard gestures", () => {
     start(50, 20); finish(160, 25);
     start(50, 20); finish(54, 24);
     start(50, 20); finish(54, 90);
-    start(50, 20, new FakeElement(true)); finish(54, 24);
+    start(50, 20, new FakeElement("button")); finish(54, 24);
 
     assert.deepEqual(host.clicks, { next: 1, prev: 1, toggle: 1 });
   });

--- a/frontend-tests/shared/flashcard-gestures.test.js
+++ b/frontend-tests/shared/flashcard-gestures.test.js
@@ -69,6 +69,41 @@ describe("flashcard gestures", () => {
     assert.ok(html.indexOf('id="review-chart-fullwidth"') < html.indexOf('id="review-upcoming"'));
   });
 
+  it("keeps clicks on interactive controls alive inside the post-swipe suppression window", () => {
+    const host = new FakeHost();
+    const surface = new FakeElement();
+    els.reviewCard = host;
+    bindFlashcardEvents();
+    // Arm the 400 ms suppression window with a real swipe.
+    host.emit("pointerdown", {
+      isPrimary: true, pointerType: "touch", button: 0, pointerId: 2,
+      clientX: 160, clientY: 20, target: surface
+    });
+    host.emit("pointerup", { pointerId: 2, clientX: 50, clientY: 25, preventDefault() {} });
+
+    const clickEvent = (interactive) => ({
+      target: new FakeElement(interactive),
+      defaultPrevented: false,
+      propagationStopped: false,
+      preventDefault() { this.defaultPrevented = true; },
+      stopPropagation() { this.propagationStopped = true; }
+    });
+
+    // A tap on an image-suggestion tile / any control must survive so the
+    // document-level handler (setWordImage) can still run.
+    const tileEvent = clickEvent(true);
+    host.emit("click", tileEvent);
+    assert.equal(tileEvent.defaultPrevented, false);
+    assert.equal(tileEvent.propagationStopped, false);
+
+    // The stray synthetic click a swipe leaves on the plain card surface
+    // must still be swallowed.
+    const surfaceEvent = clickEvent(false);
+    host.emit("click", surfaceEvent);
+    assert.equal(surfaceEvent.defaultPrevented, true);
+    assert.equal(surfaceEvent.propagationStopped, true);
+  });
+
   it("reveals on a tap and navigates the deck on horizontal pointer gestures", () => {
     const host = new FakeHost();
     const surface = new FakeElement();

--- a/src/web/js/events/flashcards.ts
+++ b/src/web/js/events/flashcards.ts
@@ -71,6 +71,13 @@ export function bindFlashcardEvents(): void {
 
   host.addEventListener("click", (event) => {
     if (Date.now() >= suppressClickUntil) return;
+    // The window only exists to kill the stray synthetic click a swipe leaves
+    // on the card surface. Never swallow clicks on interactive controls —
+    // on touch devices this window is hot right after every deck swipe, so a
+    // legitimate tap on an image tile / button must still reach the
+    // document-level action handler.
+    const target = event.target instanceof Element ? event.target : null;
+    if (target?.closest(INTERACTIVE_SELECTOR)) return;
     event.preventDefault();
     event.stopPropagation();
   }, { capture: true });

--- a/src/web/js/events/flashcards.ts
+++ b/src/web/js/events/flashcards.ts
@@ -7,7 +7,7 @@ interface FlashcardGesture {
   canReveal: boolean;
 }
 
-const INTERACTIVE_SELECTOR = "button, a, input, textarea, select, [contenteditable]";
+const INTERACTIVE_SELECTOR = "button, a, input, textarea, select, [contenteditable], [role=\"button\"]";
 const CARD_SWIPE_MIN_DISTANCE = 56;
 const CARD_SWIPE_AXIS_RATIO = 1.2;
 

--- a/src/web/js/views/reader.ts
+++ b/src/web/js/views/reader.ts
@@ -132,6 +132,7 @@ export function bindReaderEvents(): void {
     let swipeStart: SwipePoint | null = null;
     let suppressSwipeClickUntil = 0;
     let wordCardResetTimer = 0;
+    const INTERACTIVE_CLICK_SELECTOR = "button, a, input, textarea, select, [contenteditable], [role=\"button\"]";
     const isWordPanelOpen = (): boolean => {
       const root = document.documentElement;
       if (!state.selectedWord) return false;
@@ -489,15 +490,23 @@ export function bindReaderEvents(): void {
     wordPanel.addEventListener("focusin", rememberWordPanelInteraction);
     wordPanel.addEventListener("click", (event) => {
       if (Date.now() >= suppressSwipeClickUntil) return;
+      // The window only exists to kill the stray synthetic click a word-card
+      // swipe leaves on the panel surface. Taps on interactive controls
+      // (image tiles, upload tile, buttons) must still reach their handlers.
+      const target = event.target instanceof Element ? event.target : null;
+      if (target?.closest(INTERACTIVE_CLICK_SELECTOR)) return;
       event.preventDefault();
       event.stopPropagation();
     }, { capture: true });
     wordPanel.addEventListener("click", async (event) => {
       rememberWordPanelInteraction();
       if (Date.now() < suppressSwipeClickUntil) {
-        event.preventDefault();
-        event.stopPropagation();
-        return;
+        const target = event.target instanceof Element ? event.target : null;
+        if (!target?.closest(INTERACTIVE_CLICK_SELECTOR)) {
+          event.preventDefault();
+          event.stopPropagation();
+          return;
+        }
       }
       if (!(event.target instanceof Element)) return;
       const articleBtn = event.target.closest("[data-suggest-article]");


### PR DESCRIPTION
## Problem
Na Androidzie dodawanie obrazu do słowa 'nie działało': klik w proponowaną miniaturę (save-image) nie wywoływał zapisu.

## Root cause
Warstwa gestów fiszek (`flashcards.ts`) w fazie capture tłumiła KAŻDY klik w oknie 400 ms po swipie talią — także kliknięcia na kontrolkach (przyciski, kafelki obrazów). Na urządzeniach dotykowych okno jest 'gorące' po każdym przejściu między kartami, więc tap w miniaturę ginął, zanim dotarł do dokumentowego handlera `setWordImage`. Na PC problem występuje niszowo (klawiaturowy shortcut Ctrl+1..4 w oknie po swipie).

## Fix
Kontrolki interaktywne (`button, a, input, textarea, select, [contenteditable]`) są wyłączone z tłumienia — stray click na powierzchni karty po swipie nadal jest zjadany.

## Tests
- Nowy test w `flashcard-gestures.test.js`: klik na kontrolkę w oknie po swipie przechodzi, klik na powierzchnię karty — tłumiony.
- Pełne suity zielone (649/649 na tej gałęzi).