### PR TITLE
fix: shuffle the upcoming review list with the session order

### DIFF
--- a/frontend-tests/shared/review-shuffle.test.js
+++ b/frontend-tests/shared/review-shuffle.test.js
@@ -1,0 +1,116 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+globalThis.window = { addEventListener: () => {}, removeEventListener: () => {}, dispatchEvent: () => {}, __qtBridge: false };
+globalThis.localStorage = { getItem: () => null, setItem: () => {} };
+globalThis.document = { addEventListener: () => {}, getElementById: () => null };
+
+const { renderReview } = await import("../../dist/web/js/vocabulary/review-card.js");
+const { state } = await import("../../dist/web/js/state.js");
+const { els } = await import("../../dist/web/js/dom.js");
+
+/** Deterministic PRNG so the shuffled session order is reproducible. */
+function mulberry32(seed) {
+  let a = seed >>> 0;
+  return function random() {
+    a |= 0; a = (a + 0x6D2B79F5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function dueEntry(word) {
+  return { word, status: "learning", nextDate: "2000-01-01", repetition: 1, interval: 2 };
+}
+
+/** Renders the deck and waits for the deferred upcoming-list summary render. */
+async function renderAndCollect() {
+  renderReview();
+  await sleep(25);
+  const upcoming = [...els.reviewUpcoming.innerHTML.matchAll(/<strong>([^<]+)<\/strong>/g)].map((m) => m[1]);
+  return { upcoming };
+}
+
+function cardOrder(count) {
+  const order = [];
+  for (let index = 0; index < count; index += 1) {
+    state.reviewIndex = index;
+    renderReview();
+    order.push(els.reviewCard.innerHTML.match(/data-dict-word="([^"]+)"/)?.[1]);
+  }
+  return order;
+}
+
+describe("review upcoming list order", () => {
+  it("orders due rows by the shuffled session instead of the alphabetical insertion order", async () => {
+    const previousCard = els.reviewCard;
+    const previousUpcoming = els.reviewUpcoming;
+    const previousVocab = state.vocab;
+    const previousIndex = state.reviewIndex;
+    const previousRandom = Math.random;
+    const words = ["alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf", "hotel"];
+    try {
+      Math.random = mulberry32(1234);
+      els.reviewCard = { innerHTML: "" };
+      els.reviewUpcoming = { innerHTML: "" };
+      state.preferences.autoAddLearningOnly = true;
+      state.vocab = Object.fromEntries(words.map((word) => [word, dueEntry(word)]));
+      state.reviewIndex = 0;
+
+      const { upcoming } = await renderAndCollect();
+
+      assert.deepEqual(new Set(upcoming), new Set(words));
+      // The due rows must follow the shuffled flashcard session order, not
+      // the alphabetical order the words were inserted in.
+      assert.deepEqual(upcoming, cardOrder(words.length));
+      assert.notDeepEqual(upcoming, words);
+    } finally {
+      Math.random = previousRandom;
+      els.reviewCard = previousCard;
+      els.reviewUpcoming = previousUpcoming;
+      state.vocab = previousVocab;
+      state.reviewIndex = previousIndex;
+    }
+  });
+
+  it("keeps future rows date-sorted after the shuffled due block", async () => {
+    const previousCard = els.reviewCard;
+    const previousUpcoming = els.reviewUpcoming;
+    const previousVocab = state.vocab;
+    const previousIndex = state.reviewIndex;
+    const previousRandom = Math.random;
+    const dueWords = ["able", "baker", "charlie"];
+    const futureWords = [
+      ["later", "2100-01-03"],
+      ["sooner", "2100-01-01"],
+      ["middle", "2100-01-02"]
+    ];
+    try {
+      Math.random = mulberry32(777);
+      els.reviewCard = { innerHTML: "" };
+      els.reviewUpcoming = { innerHTML: "" };
+      state.preferences.autoAddLearningOnly = true;
+      state.vocab = Object.fromEntries([
+        ...dueWords.map((word) => [word, dueEntry(word)]),
+        ...futureWords.map(([word, nextDate]) => [word, { word, status: "learning", nextDate, repetition: 1, interval: 2 }])
+      ]);
+      state.reviewIndex = 0;
+
+      const { upcoming } = await renderAndCollect();
+
+      // Future block stays date-sorted and sits after the due block.
+      assert.deepEqual(upcoming.slice(dueWords.length), ["sooner", "middle", "later"]);
+      // The due block is the shuffled session order.
+      assert.deepEqual(upcoming.slice(0, dueWords.length), cardOrder(dueWords.length));
+    } finally {
+      Math.random = previousRandom;
+      els.reviewCard = previousCard;
+      els.reviewUpcoming = previousUpcoming;
+      state.vocab = previousVocab;
+      state.reviewIndex = previousIndex;
+    }
+  });
+});

--- a/src/web/js/vocabulary/review-card.ts
+++ b/src/web/js/vocabulary/review-card.ts
@@ -61,6 +61,15 @@ function shuffle<T>(values: readonly T[]): T[] {
   return shuffled;
 }
 
+/**
+ * Stable shuffled key order of the current review session (due cards only).
+ * The upcoming list reuses it so the visible queue can't leak the
+ * alphabetical insertion order of the deck.
+ */
+export function reviewSessionKeyOrder(): readonly string[] {
+  return reviewSession ? [...reviewSession.keys] : [];
+}
+
 function buildReviewQueue(entries: readonly ReviewQueueEntry[], today: string): ReviewQueueEntry[] {
   const profile = effectiveLearningLanguage(state.preferences);
   const byKey = new Map(entries.filter((entry) => isDue(entry.nextDate, today)).map((entry) => [entry.key, entry]));

--- a/src/web/js/vocabulary/review-chart.ts
+++ b/src/web/js/vocabulary/review-chart.ts
@@ -18,7 +18,7 @@ import { t as rawT } from "../i18n.js";
 import { renderContributionHeatmap } from "../views/heatmap.js";
 import { buildEaseFactorBins, buildHeatmapActivityCounts, drawBarChart, drawChartBar, updateColors, text as ink, muted, blue, green, red, panelBg, projectDueBuckets } from "../graphs/helpers.js";
 import type { ChartContext, VocabEntry } from "../graphs/helpers.js";
-import { formatSrsMeta } from "./review-card.js";
+import { formatSrsMeta, reviewSessionKeyOrder } from "./review-card.js";
 
 type TranslationVars = Record<string, string | number | boolean | null | undefined>;
 
@@ -142,7 +142,24 @@ export function renderReviewUpcoming(srsEntries: readonly ReviewEntry[], today: 
     reviewEls.reviewUpcoming.innerHTML = `<p class="empty-row">${escapeHtml(t("vocab.upcomingEmpty"))}</p>`;
     return;
   }
-  const rows = srsEntries.slice(0, 30).map((entry) => {
+  // Due rows (overdue + today) follow the current flashcard session order so
+  // the visible queue can't leak the deck's alphabetical insertion order;
+  // future rows stay date-sorted. Entries without a session slot (no session
+  // yet, or words due later) keep their original position at the end of the
+  // due group.
+  const sessionIndex = new Map(reviewSessionKeyOrder().map((key, index) => [key, index]));
+  const keyOf = (entry: ReviewEntry): string => (entry as ReviewEntry & { key?: string }).key ?? entry.word;
+  const due = srsEntries.filter((entry) => diffDays(entry.nextDate, today) <= 0);
+  const future = srsEntries.filter((entry) => diffDays(entry.nextDate, today) > 0);
+  const ordered = [
+    ...due.slice().sort((a, b) => {
+      const indexA = sessionIndex.get(keyOf(a)) ?? Number.MAX_SAFE_INTEGER;
+      const indexB = sessionIndex.get(keyOf(b)) ?? Number.MAX_SAFE_INTEGER;
+      return indexA - indexB;
+    }),
+    ...future
+  ];
+  const rows = ordered.slice(0, 30).map((entry) => {
     const delta = diffDays(entry.nextDate, today);
     let when;
     if (delta < 0) when = t("vocab.upcomingOverdue", { days: -delta });


### PR DESCRIPTION
## Problem
Fiszki dnia losują się poprawnie, ale lista 'nadchodzące' (Queue) pokazuje karty w kolejności alfabetycznej — widać, jaka litera będzie następna.

## Root cause
`renderReviewUpcoming` renderował `srsEntries.slice(0,30)` w kolejności nextDate/wstawienia — dla słów z tym samym dniem to kolejność alfabetyczna. Kolejność sesji (Fisher-Yates, stabilna per dzień/profil) istniała, ale lista jej nie używała.

## Fix
Wiersze due (zaległe + dziś) sortowane wg kolejności sesji (`reviewSessionKeyOrder()`); przyszłe daty pozostają po dacie. Brak slotu w sesji → dotychczasowa pozycja. Bez nowych opcji w settings (tasowanie już działało — nie dodawać przełącznika).

## Tests
- Nowy `review-shuffle.test.js` (seeded PRNG): due rows = kolejność sesji (nie alfabetyczna), przyszłe rows date-sorted po bloku due.
- Pełne suity zielone (650/650 na tej gałęzi).