### PR TITLE
fix: downscale and compress oversized word-image uploads

### DIFF
--- a/frontend-tests/shared/ui-events.test.js
+++ b/frontend-tests/shared/ui-events.test.js
@@ -77,6 +77,53 @@ describe("shared UI event behavior", () => {
     assert.equal(input.value, "");
   });
 
+  it("compresses oversized image uploads through a canvas before saving", async () => {
+    const bigDataUrl = "data:image/png;base64," + "A".repeat(500 * 1024);
+    globalThis.FileReader = class {
+      readAsDataURL() { this.onload({ target: { result: bigDataUrl } }); }
+    };
+    const drawn = [];
+    const canvas = {
+      width: 0,
+      height: 0,
+      getContext() { return { drawImage(image, x, y, w, h) { drawn.push([image, x, y, w, h]); } }; },
+      toDataURL() { return "data:image/jpeg;base64,COMPRESSED"; }
+    };
+    const originalCreateElement = globalThis.document.createElement;
+    globalThis.document.createElement = (tag) => (tag === "canvas" ? canvas : originalCreateElement(tag));
+    const OriginalImage = globalThis.Image;
+    globalThis.Image = class {
+      constructor() { this.naturalWidth = 4000; this.naturalHeight = 3000; this.width = 4000; this.height = 3000; }
+      set src(value) { assert.equal(value, bigDataUrl); queueMicrotask(() => this.onload()); }
+    };
+
+    try {
+      const { state } = await import("../../dist/web/js/state.js");
+      const { handleGlobalChange } = await import("../../dist/web/js/events/global-actions.js");
+      state.currentView = "library";
+      delete state.vocab.example;
+      const input = {
+        files: [{ name: "big-photo.jpg" }],
+        dataset: { uploadImage: "example" },
+        value: "selected",
+        closest(selector) { return selector === "[data-upload-image]" ? this : null; },
+      };
+
+      handleGlobalChange({ target: input });
+      await new Promise((resolve) => setTimeout(resolve, 5));
+
+      assert.equal(state.vocab.example.imageUrl, "data:image/jpeg;base64,COMPRESSED");
+      // Downscaled to the 1024 px budget (4000 × 0.256) and drawn as JPEG.
+      assert.equal(canvas.width, 1024);
+      assert.equal(canvas.height, 768);
+      assert.equal(drawn.length, 1);
+      assert.equal(input.value, "");
+    } finally {
+      globalThis.document.createElement = originalCreateElement;
+      globalThis.Image = OriginalImage;
+    }
+  });
+
   it("requests Pocket vocabulary exports through the local backend", async () => {
     const originalFetch = globalThis.fetch;
     let request;

--- a/src/web/js/events/global-actions.ts
+++ b/src/web/js/events/global-actions.ts
@@ -109,12 +109,55 @@ function handleReviewButton(reviewButton: HTMLElement): void {
   }
 }
 
+const UPLOAD_IMAGE_MAX_DIMENSION = 1024;
+const UPLOAD_IMAGE_JPEG_QUALITY = 0.85;
+// Keep uploads at-or-below ~300 KB binary (~400 KB base64) untouched so small
+// PNGs keep transparency; anything bigger is downscaled + re-encoded as JPEG.
+const UPLOAD_IMAGE_PASSTHROUGH_DATAURL_CHARS = 400 * 1024;
+
+function compressImageDataUrl(dataUrl: string): Promise<string> {
+  return new Promise((resolve) => {
+    const image = new Image();
+    image.onload = () => {
+      try {
+        const sourceWidth = image.naturalWidth || image.width || 1;
+        const sourceHeight = image.naturalHeight || image.height || 1;
+        const scale = Math.min(1, UPLOAD_IMAGE_MAX_DIMENSION / Math.max(sourceWidth, sourceHeight));
+        const width = Math.max(1, Math.round(sourceWidth * scale));
+        const height = Math.max(1, Math.round(sourceHeight * scale));
+        const canvas = document.createElement("canvas");
+        canvas.width = width;
+        canvas.height = height;
+        const context = canvas.getContext("2d");
+        if (!context) {
+          resolve(dataUrl);
+          return;
+        }
+        context.drawImage(image, 0, 0, width, height);
+        resolve(canvas.toDataURL("image/jpeg", UPLOAD_IMAGE_JPEG_QUALITY));
+      } catch {
+        resolve(dataUrl);
+      }
+    };
+    image.onerror = () => resolve(dataUrl);
+    image.src = dataUrl;
+  });
+}
+
 function handleUploadImageInput(uploadFileInput: HTMLInputElement): void {
   if (!uploadFileInput.files?.[0]) return;
   const word = uploadFileInput.dataset.uploadImage;
   const file = uploadFileInput.files[0];
   const reader = new FileReader();
-  reader.onload = (event: ProgressEvent<FileReader>) => { setWordImage(word, event.target?.result); };
+  reader.onload = (event: ProgressEvent<FileReader>) => {
+    const raw = event.target?.result;
+    if (typeof raw !== "string") return;
+    if (raw.length <= UPLOAD_IMAGE_PASSTHROUGH_DATAURL_CHARS) {
+      setWordImage(word, raw);
+      return;
+    }
+    void compressImageDataUrl(raw).then((compressed) => setWordImage(word, compressed));
+  };
   reader.readAsDataURL(file);
   uploadFileInput.value = "";
 }


### PR DESCRIPTION
## Problem (audyt rc.4)
Upload zdjęcia jako obrazu słowa: FileReader → dataURL bez limitu. Zdjęcie 5-10 MB = ~7-13 MB base64 wysyłane przy KAŻDYM zapisie delty profilu (nie tylko przy zmianie obrazu): ryzyko przekroczenia 60 s read deadline połączenia, blisko limitu 128 MB JSON body, presja pamięci WebView.

## Fix
- Powyżej ~300 KB binarnych: canvas downscale do 1024 px + re-kodowanie JPEG (q0.85).
- Mniejsze pliki przechodzą bez zmian (małe PNG zachowują przezroczystość).
- Awaria canvas/ładowania obrazu → fallback do oryginalnego dataURL (dotychczasowe zachowanie).

## Tests
- Nowy test w ui-events.test.js: duży upload idzie przez canvas (wymiary 1024x768 z 4000x3000, JPEG), mały przechodzi nietknięty (istniejący test).
- Pełne suity 659/659, tsc, diff-check zielone.