### PR TITLE
fix: keep word taps alive right after a reader page swipe

### DIFF
--- a/frontend-tests/shared/flashcard-gestures.test.js
+++ b/frontend-tests/shared/flashcard-gestures.test.js
@@ -114,13 +114,14 @@ describe("flashcard gestures", () => {
     assert.equal(surfaceEvent.propagationStopped, true);
   });
 
-  it("keeps word-panel control taps alive after a reader word-card swipe", () => {
-    // The reader word panel has the same post-swipe click suppression; both
-    // the capture and bubble handlers must exempt interactive controls or
-    // the reader 'add image' path stays dead on Android.
+  it("keeps control and word taps alive after a reader swipe", () => {
+    // The reader has three post-swipe click suppressions: word-panel capture
+    // + bubble handlers AND the reader-text surface handler. All three must
+    // exempt interactive targets, or word selection / 'add image' stays dead
+    // right after a swipe on Android.
     const reader = readFileSync(new URL("../../dist/web/js/views/reader.js", import.meta.url), "utf8");
     assert.match(reader, /\[role=/);
-    assert.equal((reader.match(/closest\(INTERACTIVE_CLICK_SELECTOR\)/g) || []).length, 2);
+    assert.equal((reader.match(/closest\(INTERACTIVE_CLICK_SELECTOR\)/g) || []).length, 3);
   });
 
   it("reveals on a tap and navigates the deck on horizontal pointer gestures", () => {

--- a/src/web/js/views/reader.ts
+++ b/src/web/js/views/reader.ts
@@ -296,9 +296,15 @@ export function bindReaderEvents(): void {
     });
     readerText.addEventListener("click", async (event) => {
       if (Date.now() < suppressSwipeClickUntil) {
-        event.preventDefault();
-        event.stopPropagation();
-        return;
+        // The window kills the stray synthetic click a swipe leaves on the
+        // text surface. Word tokens and controls are interactive — a quick
+        // tap on a word right after swiping must still select it.
+        const target = event.target instanceof Element ? event.target : null;
+        if (!target?.closest(INTERACTIVE_CLICK_SELECTOR)) {
+          event.preventDefault();
+          event.stopPropagation();
+          return;
+        }
       }
       if (!(event.target instanceof Element)) return;
       const zoomBtn = event.target.closest("[data-pdf-zoom]");


### PR DESCRIPTION
## Problem (audyt rc.4, P2 UI)
\#reader-text miało to samo 400 ms tłumienie klików po swipe co word panel, ale bez wyjątku dla elementów interaktywnych — tokeny słów to <button class=word-token>, więc szybki tap na słowo tuż po przewinięciu był zjadany (selekcja 'działała losowo' na Pocket).

## Fix
Wyjątek interaktywny (INTERACTIVE_CLICK_SELECTOR) w handlerze click readerText — słowa i kontrolki przechodzą od razu; stray click na lukach tekstu nadal tłumiony.

## Tests
- Guard statyczny w flashcard-gestures.test.js: wszystkie 3 handleriki readera (word-panel capture+bubble, reader-text) używają closest(INTERACTIVE_CLICK_SELECTOR).
- Pełne suity 658/658, tsc, diff-check zielone.