### PR TITLE
fix: never re-schedule the shared pending-save slot when appending AI notes

### DIFF
--- a/frontend-tests/shared/review-ai-note.test.js
+++ b/frontend-tests/shared/review-ai-note.test.js
@@ -171,7 +171,10 @@ describe("flashcards AI explanation → word note", () => {
     await runReviewCardAiExplain(button, "run");
 
     assert.match(state.vocab.run.note, /^Live edit\.\n\nWyjaśnienie AI:\nTo czasownik\.$/);
-    assert.ok(flushed.some((entry) => Array.isArray(entry) && entry[0] === "schedule"));
+    // Only a flush: the single global pending slot must never be re-scheduled
+    // here, or an unrelated pending field save would be silently dropped.
+    assert.ok(flushed.includes("flush"));
+    assert.ok(!flushed.some((entry) => Array.isArray(entry) && entry[0] === "schedule"));
   });
 
   it("appends the finished explanation to state.vocab[word].note", async () => {

--- a/src/web/js/ai-note-append.ts
+++ b/src/web/js/ai-note-append.ts
@@ -47,23 +47,14 @@ export function appendAiExplanationToNote(word: string, explanation: string): st
   if (new RegExp(`(?:^|\n)[^\n]+:\n${trimmedEscaped}`).test(current)) return current;
   const marker = `${t("reader.aiNoteMarker")}:\n${trimmed}`;
   const next = current ? `${current}\n\n${marker}` : marker;
-  // Flush pending debounced saves before overwriting. The global debouncer
-  // keeps a SINGLE slot, so when we are about to write a note we re-schedule
-  // this word's note slot from the live value and flush immediately — the
-  // pending write can neither clobber the canonical write below nor be
-  // clobbered by it.
+  // Flush pending debounced saves FIRST. The global debouncer keeps a SINGLE
+  // slot — re-scheduling it here would silently drop an unrelated pending
+  // field save. A plain flush applies any pending edit, then the canonical
+  // write below wins for this note.
   const pendingApi = window as Window & {
     flushWordFieldSave?: () => void;
-    scheduleWordFieldSave?: (word: string, field: string, value: string) => void;
   };
-  if (pendingApi.scheduleWordFieldSave && field) {
-    // Re-write the pending note slot from the live textarea (current + marker
-    // is what we are about to persist), then flush — one canonical write.
-    pendingApi.scheduleWordFieldSave(word, "note", next);
-    pendingApi.flushWordFieldSave?.();
-  } else {
-    pendingApi.flushWordFieldSave?.();
-  }
+  pendingApi.flushWordFieldSave?.();
   if (field) field.value = next;
   updateWordField(word, "note", next);
   return next;


### PR DESCRIPTION
## Problem (audyt rc.4, P2 domena)
appendAiExplanationToNote re-schedule'ował (word, note, next) na jedynym globalnym slocie debounce'a przed flushem — pendująca edycja innego pola/słowa (wpisana <300 ms wcześniej) była cicho gubiona. Komentarz bezpieczeństwa twierdził co innego niż robiła single-slot implementacja.

## Fix
Tylko flush: pendujący zapis (jeśli jest) zostaje zastosowany, a kanoniczny write poniżej wygrywa dla tej notatki. Ścieżka readera nadal czyta żywą wartość textarea (bez zmiany semantyki).

## Tests
- Zaostrzony test w review-ai-note.test.js: reader path wykonuje flush i NIE wywołuje schedule.
- Pełne suity 658/658, tsc, diff-check zielone.