### PR TITLE
fix: keep the backend alive on transient accept errors (tiny_http)

### DIFF
--- a/src-tauri/vendor/tiny_http/src/lib.rs
+++ b/src-tauri/vendor/tiny_http/src/lib.rs
@@ -340,8 +340,16 @@ impl Server {
 
                     Err(e) => {
                         log::error!("Error accepting new client: {}", e);
-                        inside_messages.push(e.into());
-                        break;
+                        // A transient accept error (EMFILE, ECONNABORTED,
+                        // interrupted syscall) must not kill the whole
+                        // backend: keep the listener alive and rely on the
+                        // close flag to end this loop. Do NOT forward the
+                        // error to the main loop — a Message::Error makes
+                        // recv() return Err and shuts the server down
+                        // mid-session (same failure class as the listener
+                        // read-timeout bug: 'No text source found').
+                        thread::sleep(Duration::from_millis(100));
+                        continue;
                     }
                 }
             }


### PR DESCRIPTION
## Problem (audyt rc.4, P2 platforma)
Vendored tiny_http: Err(e) w pętli accept robił push Message::Error + break. Błąd przejściowy (EMFILE, ECONNABORTED, przerwany syscall) zabijał cały backend HTTP mid-session — ta sama klasa awarii co naprawiony #259 (listener read timeout, 'No text source found').

## Fix
Na błędzie accept: log + sleep 100 ms + continue. Flaga close nadal kończy wątek accept; błąd nie jest już wstrzykiwany do głównej pętli (Message::Error powodował Err z recv i zamknięcie serwera).

## Gates
cargo fmt --check ✓, cargo test --lib 290/290 ✓ (clippy lokalny: przedistniejący warning pdf_ocr/runner.rs:114, bez nowych).