### PR TITLE
fix: keep stable AppStream releases ordered

### DIFF
--- a/flatpak/com.wordhunter.app.metainfo.xml
+++ b/flatpak/com.wordhunter.app.metainfo.xml
@@ -46,7 +46,7 @@
         </ul>
       </description>
     </release>
-    <release version="1.0.13-rc.5" date="2026-08-13" type="development">
+    <release version="1.0.13~rc.5" date="2026-08-13" type="development">
       <description>
         <ul>
           <li>Fixes the Android launch crash: the app now resolves its data folder correctly and starts on the phone.</li>

--- a/frontend-tests/shared/repo-validation.test.js
+++ b/frontend-tests/shared/repo-validation.test.js
@@ -611,6 +611,10 @@ describe("repository validation wiring", () => {
     // full release history the desktop contract pins (1.0.5~rc entries).
     assert.equal(flatpak, template);
     assert.match(flatpak, /<release version="1\.0\.10"/);
+    // AppStream sorts `1.0.13-rc.5` after stable `1.0.13`, which makes the
+    // release list invalid. Tilde keeps historical candidates below stable.
+    assert.doesNotMatch(flatpak, /<release version="1\.0\.13-rc\./);
+    assert.match(flatpak, /<release version="1\.0\.13~rc\.5"[^>]*type="development">/);
     assert.match(flatpak, /<release version="1\.0\.5~rc\.5"[^>]*type="development">/);
     assert.match(flatpak, /<release version="1\.0\.5~rc\.4"[^>]*type="development">/);
   });

--- a/packaging/linux/com.wordhunter.app.metainfo.xml
+++ b/packaging/linux/com.wordhunter.app.metainfo.xml
@@ -46,7 +46,7 @@
         </ul>
       </description>
     </release>
-    <release version="1.0.13-rc.5" date="2026-08-13" type="development">
+    <release version="1.0.13~rc.5" date="2026-08-13" type="development">
       <description>
         <ul>
           <li>Fixes the Android launch crash: the app now resolves its data folder correctly and starts on the phone.</li>

--- a/scripts-dev/bump-1013stable.py
+++ b/scripts-dev/bump-1013stable.py
@@ -75,6 +75,10 @@ byte_replace("snap/snapcraft.yaml", [(OLD, NEW)])
 
 metainfo = ROOT / "packaging/linux/com.wordhunter.app.metainfo.xml"
 metainfo_data = metainfo.read_text(encoding="utf-8")
+rc_hyphen = f'<release version="{OLD}"'
+rc_appstream = f'<release version="{NEW}~rc.5"'
+if rc_hyphen in metainfo_data:
+    metainfo_data = metainfo_data.replace(rc_hyphen, rc_appstream, 1)
 release_anchor = "  <releases>\n"
 stable_entry = f"""  <releases>
     <release version=\"{NEW}\" date=\"{RELEASE_DATE}\">


### PR DESCRIPTION
## Root cause

The stable AppStream entry `1.0.13` was followed by historical `1.0.13-rc.5`. AppStream compares that hyphenated candidate as newer than stable and rejected the release list with:

`releases-not-in-order 1.0.13 << 1.0.13-rc.5`

## Fix

- normalize the historical candidate to AppStream's established `1.0.13~rc.5` form in both canonical metainfo copies
- update the stable bump generator so it cannot recreate the bad ordering
- add a regression assertion to the existing repository-validation contract

## Verification

- RED: WSL `appstreamcli validate --no-net` exited 3 with `releases-not-in-order`
- GREEN: both metainfo copies pass `appstreamcli validate --no-net`
- GREEN: focused AppStream repository test passes 1/1
- GREEN: full `scripts/validate.sh` completed with `Validation complete.`

No application code, Android artifacts, signing workflow, or version identity changes.
