### PR TITLE
fix: protect Android stores during slow startup

### DIFF
--- a/docs/releases/1.0.13.md
+++ b/docs/releases/1.0.13.md
@@ -18,6 +18,9 @@ Stable release of the 1.0.13 line.
 - **Android and backend reliability** — fixes app-data resolution at startup,
   native source-link opening, reader control layout, API-key settings, idle
   listener shutdowns, and transient accept errors.
+- **Safe startup for large Android libraries** — gives durable stores enough
+  time to load, defers pending teardown replay until the snapshot succeeds,
+  and validates deltas before writing recovery journals.
 
 ## Privacy and configuration
 
@@ -33,3 +36,5 @@ not store the API key.
   explicit refresh, accessibility, and Android IME input.
 - Pixel 9 Pro XL / Android 16: in-place install with preserved app data; image
   selection, image persistence, and Pocket control sizing tested.
+- Pixel 9 Pro XL / Android 16: recovered-library cold start with 684 visible
+  vocabulary entries, eight custom texts, and a 260-page OCR PDF preserved.

--- a/fastlane/metadata/android/en-US/changelogs/101001399.txt
+++ b/fastlane/metadata/android/en-US/changelogs/101001399.txt
@@ -2,4 +2,4 @@ Word Hunter 1.0.13
 
 Searchable AI model discovery, reliable Android image selection and flashcard
 refresh, saved AI explanations, shuffled reviews, compressed image uploads,
-and stronger backend reliability.
+stronger backend reliability, and safe startup for large Android libraries.

--- a/flatpak/com.wordhunter.app.metainfo.xml
+++ b/flatpak/com.wordhunter.app.metainfo.xml
@@ -37,12 +37,13 @@
     </screenshot>
   </screenshots>
   <releases>
-    <release version="1.0.13" date="2026-08-17">
+    <release version="1.0.13" date="2026-08-18">
       <description>
         <ul>
           <li>Adds searchable model discovery for OpenAI-compatible AI services while preserving manual model entry.</li>
           <li>Fixes Android image selection and immediate flashcard refresh, with compressed uploads and refined Pocket controls.</li>
           <li>Improves flashcard AI-note persistence, shuffled review sessions, Android navigation, and backend resilience.</li>
+          <li>Prevents slow large-library startup and stale pending saves from replacing durable Android data.</li>
         </ul>
       </description>
     </release>

--- a/frontend-tests/shared/persistence-lifecycle.test.js
+++ b/frontend-tests/shared/persistence-lifecycle.test.js
@@ -67,11 +67,13 @@ function cssDeclarations(source, selectorPattern) {
 
 async function loadAppHarness({
   applyPreferences = () => {},
+  bridgeFetch = async () => ({ ok: true, json: async () => ({}) }),
   hydrateActiveLibraryTexts = async () => {},
   hydrateCurrentReaderText = async () => true,
   loadBooksCatalog = async () => {},
   loadLocale = async () => {},
   pendingDelta = null,
+  qtBridge = false,
   hasPending = false,
   deltaEnvelope = { payload: "{}", session: "harness", sequence: 0 }
 } = {}) {
@@ -92,7 +94,7 @@ async function loadAppHarness({
     }
   };
   const window = fakeEventTarget({
-    __qtBridge: false,
+    __qtBridge: qtBridge,
     flushPendingSave() { calls.push("flush-save"); },
     hasPendingChanges() { return hasPending; },
     buildPendingDeltaEnvelope() { calls.push("build-envelope"); return deltaEnvelope; },
@@ -152,7 +154,7 @@ async function loadAppHarness({
     "./js/events/word-editor.js": { renderAddWordDialog: noOp },
 "./js/events/settings.js": { renderArgosDownloadDialog: noOp, renderSettingsView: noOp },
     "./js/events/book-import.js": { renderImportPanel: noOp },    "./js/book-actions/edit-modal.js": { renderEditBookDialog: noOp },
-    "./js/request.js": { fetchWithTimeout: async () => ({ ok: true, json: async () => ({}) }) },
+    "./js/request.js": { fetchWithTimeout: bridgeFetch },
     "./js/platform.js": {
       applyPlatformUi: noOp,
       detectPlatform: noOp,
@@ -320,6 +322,7 @@ describe("persistence lifecycle", () => {
       deltaEnvelope: { payload: '{"delta":true,"fullKeys":[]}', session: "s1", sequence: 3 }
     });
     harness.setAndroid(true);
+    harness.window.__bridgeState = {};
 
     harness.window.emit("pagehide");
 
@@ -332,6 +335,42 @@ describe("persistence lifecycle", () => {
       !harness.calls.includes("keepalive-save"),
       "the multi-MB payload must not go through a keepalive fetch"
     );
+  });
+
+  it("does not freeze an Android teardown delta before the bridge snapshot is applied", async () => {
+    const harness = await loadAppHarness({
+      hasPending: true,
+      deltaEnvelope: { payload: '{"delta":true,"fullKeys":[]}', session: "s1", sequence: 3 }
+    });
+    harness.setAndroid(true);
+    delete harness.window.__bridgeState;
+
+    harness.window.emit("pagehide");
+
+    assert.deepEqual(harness.calls, ["flush-buffers"]);
+  });
+
+  it("refuses to build a destructive pending delta before the bridge snapshot is applied", async () => {
+    const { createAutosave } = await evaluateWithMocks("../../dist/web/js/state/autosave.js", {
+      "../api.js": {
+        buildSavePayload: (state) => state,
+        buildDeltaSavePayload: () => ({ delta: true, fullKeys: [], records: {} }),
+        saveToLocalStorage() {},
+        saveWithRetry: async () => ({}),
+        saveSyncXhr() {},
+        readPendingDelta() { return null; },
+        clearPendingDelta() {}
+      }
+    }, {
+      window: { __qtBridge: true, __bridgeStatePromise: Promise.resolve({}), dispatchEvent() {} },
+      CustomEvent,
+      setTimeout,
+      clearTimeout,
+      console
+    });
+    const autosave = createAutosave(() => ({ preferences: {}, profiles: { de: { vocab: {} } } }));
+
+    assert.equal(autosave.buildPendingDeltaEnvelope(), null);
   });
 
   it("replays a pending Android teardown flush through the normal save path at boot", async () => {
@@ -347,6 +386,34 @@ describe("persistence lifecycle", () => {
       "the pending delta is replayed through the normal save path"
     );
     assert.ok(harness.calls.includes("clear-pending"), "the pending flush is cleared on success");
+  });
+
+  it("allows large Android stores up to 120 seconds to load", async () => {
+    let timeoutMs = null;
+    const harness = await loadAppHarness({
+      qtBridge: true,
+      bridgeFetch: async (_url, _options, timeout) => {
+        timeoutMs = timeout;
+        return { ok: true, json: async () => ({}) };
+      }
+    });
+
+    await Promise.all(harness.document.emit("DOMContentLoaded"));
+
+    assert.equal(timeoutMs, 120_000);
+  });
+
+  it("keeps a pending delta untouched when the durable store load fails", async () => {
+    const harness = await loadAppHarness({
+      pendingDelta: { payload: '{"delta":true,"fullKeys":[]}', session: "prev", sequence: 2 }
+    });
+    harness.window.__bridgeStatePromise = Promise.reject(new Error("store load timeout"));
+
+    await Promise.all(harness.document.emit("DOMContentLoaded"));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    assert.equal(harness.calls.some((call) => call.startsWith("replay:")), false);
+    assert.equal(harness.calls.includes("clear-pending"), false);
   });
 
   it("clears a pending delta only when a same-session save built after the freeze supersedes it", async () => {

--- a/frontend-tests/shared/persistence-lifecycle.test.js
+++ b/frontend-tests/shared/persistence-lifecycle.test.js
@@ -388,6 +388,22 @@ describe("persistence lifecycle", () => {
     assert.ok(harness.calls.includes("clear-pending"), "the pending flush is cleared on success");
   });
 
+  it("replays a pending Android teardown flush after the durable store load succeeds", async () => {
+    const harness = await loadAppHarness({
+      pendingDelta: { payload: '{"delta":true,"fullKeys":[]}', session: "prev", sequence: 2 }
+    });
+    harness.window.__bridgeStatePromise = Promise.resolve({ preferences: {}, profiles: {} });
+
+    await Promise.all(harness.document.emit("DOMContentLoaded"));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    assert.ok(
+      harness.calls.includes('replay:{"delta":true,"fullKeys":[]}'),
+      "the pending delta is replayed only after the durable snapshot resolves"
+    );
+    assert.ok(harness.calls.includes("clear-pending"), "the pending flush is cleared on success");
+  });
+
   it("allows large Android stores up to 120 seconds to load", async () => {
     let timeoutMs = null;
     const harness = await loadAppHarness({
@@ -1346,7 +1362,7 @@ describe("persistence lifecycle", () => {
     assert.doesNotMatch(styles, /content: "Word Hunter"/);
     assert.ok(app.includes('fetchWithTimeout("/__store/load"'));
     assert.match(handlers, /bootstrap_script\([\s\S]*(Some|None)/);
-    assert.match(bootstrapTemplate, /storeLoadController[\s\S]*12000/);
+    assert.match(bootstrapTemplate, /storeLoadController[\s\S]*120000/);
     assert.match(boot, /wordHunterBootTimeout = window\.setTimeout/);
     assert.match(boot, /Startup timed out before the application became ready/);
     assert.match(app, /clearTimeout\(window\.wordHunterBootTimeout\)/);

--- a/packaging/linux/com.wordhunter.app.metainfo.xml
+++ b/packaging/linux/com.wordhunter.app.metainfo.xml
@@ -37,12 +37,13 @@
     </screenshot>
   </screenshots>
   <releases>
-    <release version="1.0.13" date="2026-08-17">
+    <release version="1.0.13" date="2026-08-18">
       <description>
         <ul>
           <li>Adds searchable model discovery for OpenAI-compatible AI services while preserving manual model entry.</li>
           <li>Fixes Android image selection and immediate flashcard refresh, with compressed uploads and refined Pocket controls.</li>
           <li>Improves flashcard AI-note persistence, shuffled review sessions, Android navigation, and backend resilience.</li>
+          <li>Prevents slow large-library startup and stale pending saves from replacing durable Android data.</li>
         </ul>
       </description>
     </release>

--- a/src-tauri/src/store/snapshot.rs
+++ b/src-tauri/src/store/snapshot.rs
@@ -202,8 +202,19 @@ impl Store {
             .unwrap_or_else(|e| e.into_inner())
             .clone();
         let saved_at = record_files::now_millis();
-        let mut incoming = record_files::payload_to_records(&payload, self.device_id(), saved_at);
+        // Validate the effective records and fullKeys before persisting the
+        // recovery journal. A malformed delta must not leave a journal that
+        // every later startup/save will try (and fail) to replay.
+        let effective = if payload.get("delta").and_then(Value::as_bool) == Some(true) {
+            payload
+                .get("records")
+                .ok_or_else(|| "delta payload is missing records".to_string())?
+        } else {
+            &payload
+        };
+        let mut incoming = record_files::payload_to_records(effective, self.device_id(), saved_at);
         self.hydrate_text_records(&mut incoming)?;
+        full_keys_from_payload(&payload, &incoming)?;
         let journal = self.save_journal_path();
         durable::write_json_atomic(
             &journal,
@@ -805,6 +816,7 @@ mod tests {
         // Nothing was applied.
         let records = record_files::load_records(dir.path()).unwrap();
         assert_eq!(records["vocab:de:wort"].data["status"], "learning");
+        assert!(!store.save_journal_path().exists());
     }
 
     #[test]

--- a/src-tauri/src/store/snapshot.rs
+++ b/src-tauri/src/store/snapshot.rs
@@ -820,6 +820,23 @@ mod tests {
     }
 
     #[test]
+    fn delta_save_rejects_missing_records_without_leaving_a_journal() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store_at(&dir);
+        store.bulk_save(payload("Wort")).unwrap();
+        let result = store.bulk_save(json!({
+            "schemaVersion": SNAPSHOT_SCHEMA_VERSION,
+            "delta": true,
+            "fullKeys": FULL_KEYS_TWO
+        }));
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), "delta payload is missing records");
+        let records = record_files::load_records(dir.path()).unwrap();
+        assert_eq!(records["vocab:de:wort"].data["status"], "learning");
+        assert!(!store.save_journal_path().exists());
+    }
+
+    #[test]
     fn delta_save_journal_recovery_replays() {
         let dir = tempfile::tempdir().unwrap();
         let store = store_at(&dir);

--- a/src-tauri/src/tests/http_boundary/tests.rs
+++ b/src-tauri/src/tests/http_boundary/tests.rs
@@ -344,6 +344,8 @@ fn bootstrap_starts_snapshot_loading_when_state_is_not_inlined() {
     let script = handlers::bootstrap_script("token", None, false);
 
     assert!(script.contains("window.__bridgeStatePromise = origFetch('/__store/load'"));
+    assert!(script.contains("storeLoadController.abort(); }, 120000)"));
+    assert!(script.contains("Store load timed out after 120 seconds"));
     assert!(!script.contains("window.__bridgeState = null"));
 }
 

--- a/src-tauri/templates/bootstrap.js
+++ b/src-tauri/templates/bootstrap.js
@@ -9,7 +9,7 @@
     window.__bridgeState = bridgeSnapshot;
   } else {
     const storeLoadController = new AbortController();
-    const storeLoadTimeout = setTimeout(function() { storeLoadController.abort(); }, 12000);
+    const storeLoadTimeout = setTimeout(function() { storeLoadController.abort(); }, 120000);
     window.__bridgeStatePromise = origFetch('/__store/load', {
       cache: 'no-store',
       headers: {
@@ -20,7 +20,7 @@
       if (!response.ok) throw new Error('Store load failed: HTTP ' + response.status);
       return response.json();
     }).catch(function(error) {
-      if (storeLoadController.signal.aborted) throw new Error('Store load timed out after 12 seconds');
+      if (storeLoadController.signal.aborted) throw new Error('Store load timed out after 120 seconds');
       throw error;
     }).finally(function() { clearTimeout(storeLoadTimeout); });
   }

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -78,8 +78,11 @@ function flushPendingStateBeforeExit() {
     // never reach the backend (issue #137). Persist the save delta to
     // localStorage synchronously instead; the next boot replays it through
     // the normal save path (recoverPendingFlush).
-    if (typeof window.hasPendingChanges === "function" && window.hasPendingChanges()) {
-      flushPendingDeltaToLocalStorage(window.buildPendingDeltaEnvelope());
+    if (window.__bridgeState != null
+      && typeof window.hasPendingChanges === "function"
+      && window.hasPendingChanges()) {
+      const envelope = window.buildPendingDeltaEnvelope();
+      if (envelope) flushPendingDeltaToLocalStorage(envelope);
     }
     return;
   }
@@ -87,8 +90,9 @@ function flushPendingStateBeforeExit() {
 }
 
 // Replay a pending Android teardown flush into the backend once the boot
-// snapshot has been applied (or after the load failed — the delta in
-// localStorage may then be the only copy of the last mutations).
+// snapshot has been applied. If the durable load fails, keep the delta in
+// localStorage for a later boot; replaying fullKeys against an unknown store
+// can tombstone records that the temporary frontend state never loaded.
 function recoverPendingFlush(): void {
   const pending = readPendingDelta();
   if (pending === null) return;
@@ -98,7 +102,9 @@ function recoverPendingFlush(): void {
       .catch((error) => console.error("pending-flush replay failed; will retry next boot", error));
   };
   if (window.__bridgeStatePromise) {
-    void window.__bridgeStatePromise.then(replay, replay);
+    void window.__bridgeStatePromise.then(replay).catch((error) => {
+      console.error("pending-flush replay deferred until store load succeeds", error);
+    });
   } else {
     replay();
   }
@@ -181,7 +187,7 @@ function startBridgeStateLoad(): void {
   if (!window.__qtBridge || window.__bridgeState || bridgeStateLoadStarted) return;
   bridgeStateLoadStarted = true;
   const promise = window.__bridgeStatePromise
-    ?? fetchWithTimeout("/__store/load", { cache: "no-store", headers: { "X-WH-Token": window.WH_TOKEN || "" } }, 12_000)
+    ?? fetchWithTimeout("/__store/load", { cache: "no-store", headers: { "X-WH-Token": window.WH_TOKEN || "" } }, 120_000)
       .then(async (response) => {
         if (!response.ok) throw new Error(`Store load failed: HTTP ${response.status}`);
         return response.json();

--- a/src/web/js/state/autosave.ts
+++ b/src/web/js/state/autosave.ts
@@ -67,6 +67,12 @@ export function createAutosave(getState: () => WhAppState) {
   type DirtyContext = { kind: "vocab" | "word" | "profile" | "books" | "texts" | "text"; lang?: string };
   const dirtyContexts = new WeakMap<object, DirtyContext>();
 
+  function isBridgeSnapshotPending(): boolean {
+    return Boolean(window.__qtBridge)
+      && (window.__bridgeState === null
+        || (window.__bridgeState === undefined && window.__bridgeStatePromise !== undefined));
+  }
+
   function hasPendingChanges(): boolean {
     return lastMutationAt > lastSaveSucceededAt
       || saveInFlight
@@ -132,14 +138,14 @@ export function createAutosave(getState: () => WhAppState) {
         return Promise.reject(error);
       }
     }
-    if (window.__bridgeState === null) {
+    if (isBridgeSnapshotPending()) {
       // The backend snapshot has not been applied yet: on Android it is
       // fetched asynchronously after boot. Sending a delta/full payload now
       // would tombstone the store with an effectively empty state. Buffer
       // locally; once the snapshot lands, markDurableStateReplaced flags
       // everything dirty and the next save pushes the full state through.
-      // (In tests __bridgeState is undefined, which deliberately bypasses
-      // this guard; at runtime the bootstrap always sets it to null first.)
+      // The bootstrap leaves __bridgeState undefined until the async snapshot
+      // lands, so both null and undefined must stay behind this guard.
       try {
         saveToLocalStorage(current);
         lastSaveSucceededAt = Date.now();
@@ -442,14 +448,19 @@ export function createAutosave(getState: () => WhAppState) {
       if (!hasPendingChanges()) return;
       const current = rawState();
       syncProfilePreferences();
-      if (window.__qtBridge && window.__bridgeState === null) saveToLocalStorage(current);
+      if (isBridgeSnapshotPending()) saveToLocalStorage(current);
       else if (window.__qtBridge) saveSyncXhr(JSON.stringify(buildSavePayload(current)));
       else saveToLocalStorage(current);
     },
     // Synchronous serialization of the save delta for the Android teardown
     // flush (see flushPendingDeltaToLocalStorage): reuses the same dirty
     // tracking as doSave so the replayed payload merges cleanly on next boot.
-    buildPendingDeltaEnvelope(): PendingDelta {
+    buildPendingDeltaEnvelope(): PendingDelta | null {
+      // Android can hide/tear down the WebView while the durable bridge
+      // snapshot is still loading. The temporary frontend state is incomplete
+      // at that point; freezing its fullKeys would make the next boot replay
+      // tombstone every durable record that has not arrived yet.
+      if (isBridgeSnapshotPending()) return null;
       const current = rawState();
       return {
         payload: JSON.stringify(

--- a/types/wordhunter-browser.d.ts
+++ b/types/wordhunter-browser.d.ts
@@ -453,7 +453,7 @@ interface WhDomCache {
     __bridgeStatePromise?: Promise<WhBridgeSnapshot>;
     WordHunterAndroid?: WhAndroidBridge;
     flushPendingSave?: () => void;
-    buildPendingDeltaEnvelope?: () => { payload: string; session: string; sequence: number };
+    buildPendingDeltaEnvelope?: () => { payload: string; session: string; sequence: number } | null;
     hasPendingChanges?: () => boolean;
     flushAllPendingFrontendState?: () => Promise<void>;
     requestWordHunterClose?: () => void;


### PR DESCRIPTION
## Summary

- give Android durable-store bootstrap loads a 120-second budget for large OCR libraries
- block autosave/teardown deltas until the asynchronous bridge snapshot is actually applied, including the real `undefined + Promise` bootstrap state
- keep pending teardown deltas for a later boot when store loading fails instead of replaying `fullKeys` against an unknown store
- validate delta records and `fullKeys` before creating a recovery journal
- document the stable 1.0.13 data-safety fix

## Root cause

A 14 MB Android store containing a 260-page OCR book exceeded the bootstrap's 12-second load deadline. The frontend continued with its temporary empty state. A pending teardown delta was then replayed after the failed load and its incomplete `fullKeys` tombstoned the durable vocabulary and text records.

## Verification

- `npm run build:frontend`
- `npm run check:frontend`
- full frontend matrix: 675/675
- `cargo test --lib`: 297/297
- three independent reviews: no blockers; added the requested resolved-promise replay test, missing-records journal test, and exact `120000` assertion
- `cargo fmt --check`
- `TMPDIR="C:/Users/Oleg/AppData/Local/Temp" ./scripts/validate.sh`: `Validation complete.` (fresh final rerun)
- both AppStream files: `appstreamcli validate --no-net` PASS
- Pixel 9 Pro XL / Android 16, in-place `adb install -r`:
  - recovered store: 13 profiles, 760 German vocab records / 684 visible, 8 custom texts
  - 7 full German text bodies, 260-page PDF OCR metadata and media, 1 Russian OCR page
  - full `force-stop` cold start preserved the store with no load, replay, or recovery errors
  - post-recovery app-data TAR verified: 13 active profiles, 8 active texts, 761 active vocab records

## Known unrelated warning

`cargo clippy --all-targets -- -D warnings` still stops on the pre-existing `src/pdf_ocr/runner.rs:114` `match_result_ok` warning. The canonical `scripts/validate.sh` clippy invocation completes with that warning and the final validation passes.
