### PR TITLE
chore: update 1.0.13 package hashes

### DIFF
--- a/packaging/scoop/wordhunter.json
+++ b/packaging/scoop/wordhunter.json
@@ -1,12 +1,12 @@
 {
-    "version": "1.0.11",
+    "version": "1.0.13",
     "description": "Local-first reader, vocabulary trainer, and language-learning workspace",
     "homepage": "https://ironship.github.io/WordHunter-site/",
     "license": "AGPL-3.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Ironship/WordHunter/releases/download/WordHunter1.0.11/Word.Hunter.portable.zip",
-            "hash": "681574154a8d76f6914ae04707c7f41ba129e9645f98b1835905793e542afcc8"
+            "url": "https://github.com/Ironship/WordHunter/releases/download/WordHunter1.0.13/Word.Hunter.portable.zip",
+            "hash": "858ec26e2f5ff93932e4618a169aea9c2b642ea60caa0ccaf64451397cb31a99"
         }
     },
     "shortcuts": [

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -59,7 +59,7 @@ parts:
     plugin: dump
     source: https://github.com/Ironship/WordHunter/releases/download/WordHunter1.0.13/word-hunter_1.0.13_amd64.deb
     source-type: deb
-    source-checksum: sha256/9cef8fe726a8fb3b0aa9ae52293d8d1c1510c457ae72f4dd698c8ef3e2065d29
+    source-checksum: sha256/d95617843fb96fd9e645e55b822cc222227a6746491adb1bf906c1c74d00a421
     stage-packages:
       - dbus-daemon
       - dbus-session-bus-common


### PR DESCRIPTION
## Summary
- update the Snap DEB checksum to the published WordHunter 1.0.13 asset
- update Scoop to 1.0.13 and the published portable ZIP checksum

## Verification
- downloaded both assets from the public release URLs
- SHA-256 matched the manifests
- `node --experimental-vm-modules --test frontend-tests/shared/repo-validation.test.js` (21/21)
- `git diff --check`

Release: https://github.com/Ironship/WordHunter/releases/tag/WordHunter1.0.13